### PR TITLE
Taylor/ope-64-metric-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wheels/
 .ipynb_checkpoints/
 .coverage*
 .mypy_cache
+.vscode/

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -32,22 +32,8 @@ class Metric:
         init_time_datetime: datetime.datetime,
     ):
         """Align the forecast and observation datasets."""
-        try:
-            forecast = forecast.sel(init_time=init_time_datetime)
-        # handles duplicate initialization times. please try to avoid this situation
-        except ValueError:
-            init_time_duplicate_length = len(
-                forecast.where(
-                    forecast.init_time == init_time_datetime, drop=True
-                ).init_time
-            )
-            if init_time_duplicate_length > 1:
-                logger.warning(
-                    "init time %s has more than %d forecast associated with it, taking first only",
-                    init_time_datetime,
-                    init_time_duplicate_length,
-                )
-            forecast = forecast.sel(init_time=init_time_datetime).isel(init_time=0)
+
+        forecast = forecast.sel(init_time=init_time_datetime)
         time = np.array(
             [
                 init_time_datetime + pd.Timedelta(hours=int(t))

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -48,7 +48,7 @@ class Metric:
 
 @dataclasses.dataclass
 class RegionalRMSE(Metric):
-    """Root mean squared error of a regional forecast evalauted against observations."""
+    """Root mean squared error of a regional forecast evaluated against observations."""
 
     def compute(self, forecast: xr.DataArray, observation: xr.DataArray):
         rmse_values = []

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import regionmask
 import ujson
+import rioxarray  # noqa: F401
 import xarray as xr
 from kerchunk.hdf import SingleHdf5ToZarr
 from shapely.geometry import box

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -2,7 +2,7 @@
 other specialized package.
 """
 
-from typing import Union
+from typing import Union, List, Optional
 from collections import namedtuple
 import fsspec
 import geopandas as gpd
@@ -269,5 +269,36 @@ def expand_lead_times_to_6_hourly(
         final_times.append(hour)
     dataarray = xr.DataArray(
         data=final_data, dims=["lead_time"], coords={"lead_time": final_times}
-    )
+    ).astype(float)
     return dataarray
+
+
+def process_dataarray_for_output(da_list: List[Optional[xr.DataArray]]):
+    """Extract and format data from a list of DataArrays.
+
+    Args:
+        dataarray: A list of xarray DataArrays.
+        data:  An xarray DataArray (likely unused in current implementation).
+        dims: Dimensions of the DataArray (likely unused in current implementation).
+        coords: Coordinates of the DataArray (likely unused in current implementation).
+        dim: Dimension name (likely unused in current implementation).
+        lead_time: Lead time coordinate name (likely unused in current implementation).
+
+    Returns:
+        An xarray DataArray with lead_time coordinate, expanded to 6-hourly intervals.
+        Returns a DataArray with a single NaN value if the input dataarray is empty.
+    """
+
+    if len(da_list) == 0:
+        # create dummy nan dataarray in case no applicable forecast valid times exist
+        output_da = xr.DataArray(
+            data=[np.nan],
+            dims=["lead_time"],
+            coords={"lead_time": [0]},
+        )
+    else:
+        output_da = xr.concat(da_list, dim="lead_time")
+        # Reverse the lead time so that the minimum lead time is first
+        output_da = output_da.isel(lead_time=slice(None, None, -1))
+    output_da = expand_lead_times_to_6_hourly(output_da)
+    return output_da

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,14 +9,16 @@ from extremeweatherbench import config, events
 def mock_forecast_dataset():
     init_time = pd.date_range("2021-06-20", periods=5)
     lead_time = range(0, 241, 6)
-    data = np.random.rand(len(init_time), 180, 360, len(lead_time))
+    data = np.random.RandomState(21897820).standard_normal(
+        size=(len(init_time), 180, 360, len(lead_time)),
+    )
     latitudes = np.linspace(-90, 90, 180)
     longitudes = np.linspace(0, 359, 360)
     dataset = xr.Dataset(
         {
             "air_temperature": (
                 ["init_time", "latitude", "longitude", "lead_time"],
-                data,
+                20 + 5 * data,
             ),
             "eastward_wind": (
                 ["init_time", "latitude", "longitude", "lead_time"],
@@ -55,12 +57,31 @@ def mock_config():
 @pytest.fixture
 def mock_gridded_obs_dataset():
     time = pd.date_range("2021-06-20", freq="3h", periods=200)
-    data = np.random.rand(len(time), 180, 360)
+    data = np.random.RandomState(21897820).standard_normal(size=(len(time), 180, 360))
     latitudes = np.linspace(-90, 90, 180)
     longitudes = np.linspace(0, 359, 360)
     dataset = xr.Dataset(
         {
-            "2m_temperature": (["time", "latitude", "longitude"], data),
+            "2m_temperature": (["time", "latitude", "longitude"], 20 + 5 * data),
+            "tp": (["time", "latitude", "longitude"], data),
+            "10m_u_component_of_wind": (["time", "latitude", "longitude"], data),
+            "10m_v_component_of_wind": (["time", "latitude", "longitude"], data),
+        },
+        coords={"time": time, "latitude": latitudes, "longitude": longitudes},
+    )
+    return dataset
+
+
+@pytest.fixture
+def mock_gridded_obs_dataset_max_in_forecast():
+    time = pd.date_range("2021-06-20", freq="3h", periods=200)
+    data = np.random.RandomState(21897820).standard_normal(size=(len(time), 180, 360))
+    data[10, :, :] = 5
+    latitudes = np.linspace(-90, 90, 180)
+    longitudes = np.linspace(0, 359, 360)
+    dataset = xr.Dataset(
+        {
+            "2m_temperature": (["time", "latitude", "longitude"], 20 + 5 * data),
             "tp": (["time", "latitude", "longitude"], data),
             "10m_u_component_of_wind": (["time", "latitude", "longitude"], data),
             "10m_v_component_of_wind": (["time", "latitude", "longitude"], data),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,26 @@ def mock_gridded_obs_dataset_max_in_forecast():
         coords={"time": time, "latitude": latitudes, "longitude": longitudes},
     )
     return dataset
+
+
+@pytest.fixture
+def mock_forecast_dataarray(mock_forecast_dataset):
+    return dataset_to_dataarray(mock_forecast_dataset)
+
+
+@pytest.fixture
+def mock_gridded_obs_dataarray(mock_gridded_obs_dataset):
+    return dataset_to_dataarray(mock_gridded_obs_dataset)
+
+
+@pytest.fixture
+def mock_gridded_obs_dataarray_max_in_forecast(
+    mock_gridded_obs_dataset_max_in_forecast,
+):
+    return dataset_to_dataarray(mock_gridded_obs_dataset_max_in_forecast)
+
+
+def dataset_to_dataarray(dataset):
+    """Convert an xarray Dataset to a DataArray."""
+    mock_data_var = [data_var for data_var in dataset.data_vars][0]
+    return dataset[mock_data_var]

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,6 +1,5 @@
 import pytest
 import extremeweatherbench.case as case
-import rioxarray  # noqa: F401
 from extremeweatherbench.utils import Location
 import datetime
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,7 @@ from extremeweatherbench import metrics
 import xarray as xr
 import pytest
 import pandas as pd
+import numpy as np
 
 
 def dataset_to_dataarray(dataset):
@@ -11,18 +12,24 @@ def dataset_to_dataarray(dataset):
 
 
 class TestMetric:
+    """Tests the Metric base class."""
+
     def test_name_property(self):
+        """Test that the property decorator is applied properly."""
         metric = metrics.Metric()
         assert metric.name == "Metric"
 
     def test_compute_not_implemented(
         self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
+        """Test that the base Metric compute method returns a NotImplementedError."""
         metric = metrics.Metric()
         with pytest.raises(NotImplementedError):
             metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
 
     def test_align_datasets(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        """Test that the conversion from init time to valid time (named as time) produces an aligned
+        dataarray to ensure metrics are applied properly."""
         metric = metrics.Metric()
         init_time_datetime = pd.Timestamp(
             mock_forecast_dataarray.init_time[0].values
@@ -42,35 +49,101 @@ class TestMetric:
 
 
 class TestRegionalRMSE:
-    def test_regional_rmse_compute(
+    """Tests the RegionalRMSE Metric child class."""
+
+    def test_regional_rmse_compute_output_metadata_types(
         self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
+        """Test if compute returns the proper type and dimensions."""
         # Instantiate the RegionalRMSE metric
         metric = metrics.RegionalRMSE()
-        # Compute the RMSE
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
 
         # Check the result is an xarray DataArray
         assert isinstance(result, xr.DataArray)
         # Check the dimensions of the result
         assert "lead_time" in result.dims
+
+    def test_regional_rmse_values(
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray
+    ):
+        """Test if the numerical outputs of the metric are producing the correct results,
+        to a reasonable (1e-7) precision."""
+        output = np.array(
+            [
+                7.06819423,
+                7.07986864,
+                7.08808892,
+                7.06857515,
+                7.07467895,
+                7.07154156,
+                7.05989394,
+                7.06687087,
+                7.0665981,
+                7.05737303,
+                7.08282287,
+                7.06380817,
+                7.07936601,
+                7.07125565,
+                7.06621689,
+                7.0641209,
+                7.06740009,
+                7.07123912,
+                7.07697865,
+                7.05404263,
+                7.07595125,
+                7.07550436,
+                7.05839933,
+                7.06479538,
+                7.08006438,
+                7.06520873,
+                7.07479995,
+                7.06371806,
+                7.08151001,
+                7.08536655,
+                7.06980819,
+                7.07308411,
+                7.08840835,
+                7.06256349,
+                7.07074064,
+                7.08574952,
+                7.08438375,
+                7.07106463,
+                7.06908532,
+                7.08782645,
+                7.07161996,
+            ]
+        )
+
+        metric = metrics.RegionalRMSE()
+        result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+
+        assert all(
+            [
+                pytest.approx(individual_result, 1e-7) == individual_output
+                for individual_result, individual_output in zip(result.values, output)
+            ]
+        )
 
 
 class TestMaximumMAE:
+    """Tests the MaximumMAE Metric child class, which computes maximum temperature MAE during a case."""
+
     def test_base_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        """Test if compute returns the proper type and dimensions."""
         # Instantiate the MaximumMAE metric
         metric = metrics.MaximumMAE()
-        # Compute the RMSE
-
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
         # Check the result is an xarray DataArray
         assert isinstance(result, xr.DataArray)
         # Check the dimensions of the result
         assert "lead_time" in result.dims
 
-    def test_in_forecast_dataarray(
+    def test_maximum_mae_values(
         self, mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
     ):
+        """Test if the numerical outputs of the metric are producing the correct results,
+        to a reasonable (1e-7) precision."""
         # Instantiate the MaximumMAE metric
         metric = metrics.MaximumMAE()
         result = metric.compute(
@@ -87,12 +160,14 @@ class TestMaximumMAE:
 
 
 class TestMaxOfMinTempMAE:
+    """Tests the MaxOfMinTempMAE Metric child class, which computes highest minimum temperature MAE during a case."""
+
     def test_max_of_min_temp_mae_compute(
         self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
+        """Test if compute returns the proper type and dimensions."""
         # Instantiate the MaxOfMinTempMAE metric
         metric = metrics.MaxOfMinTempMAE()
-        # Compute the RMSE
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
         # Check the result is an xarray DataArray
         assert isinstance(result, xr.DataArray)
@@ -102,32 +177,38 @@ class TestMaxOfMinTempMAE:
     def test_max_of_min_temp_mae_wrong_data_var(
         self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
+        """As this metric is meant to be only for surface temperature, make sure
+        it fails if another variable is in its place."""
         mock_forecast_dataarray = mock_forecast_dataarray.rename("bad_name")
         metric = metrics.MaxOfMinTempMAE()
         with pytest.raises(KeyError):
             metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
 
-
-def test_metric_align_datasets(mock_forecast_dataarray, mock_gridded_obs_dataarray):
-    # Test dataset alignment method
-    metric = metrics.Metric()
-    init_time = mock_forecast_dataarray.init_time[0].values
-    init_time_dt = pd.Timestamp(init_time).to_pydatetime()
-
-    aligned_forecast, aligned_obs = metric.align_datasets(
-        mock_forecast_dataarray, mock_gridded_obs_dataarray, init_time_dt
-    )
-
-    # Check aligned datasets have same time coordinates
-    assert (aligned_forecast.time == aligned_obs.time).all()
-
-    # Check forecast was properly subset by init time
-    assert aligned_forecast.init_time.size == 1
-    assert pd.Timestamp(aligned_forecast.init_time.values) == pd.Timestamp(init_time)
+    def test_max_of_min_temp_mae_values(
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
+    ):
+        """Test if the numerical outputs of the metric are producing the correct results,
+        to a reasonable (1e-7) precision."""
+        metric = metrics.MaxOfMinTempMAE()
+        result = metric.compute(
+            mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
+        )
+        assert all(
+            [
+                pd.isna(result.sel({"lead_time": lead_time}))
+                for lead_time in [6, 12, 18, 30, 72, 96, 168, 240]
+            ]
+        )
+        assert pytest.approx(result.sel({"lead_time": 0}), 1e-7) == 0.04544667
+        assert pytest.approx(result.sel({"lead_time": 24}), 1e-7) == 0.04979312
 
 
 class TestOnsetME:
+    """Tests the not-yet-implemented OnsetME Metric child class, which will identify
+    the temporal mean bias error of a case's onset."""
+
     def test_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        """Test if compute returns the proper type and dimensions (in this case an error)."""
         metric = metrics.OnsetME()
         with pytest.raises(
             NotImplementedError, match="Onset mean error not yet implemented."
@@ -136,7 +217,11 @@ class TestOnsetME:
 
 
 class TestDurationME:
+    """Tests the not-yet-implemented DurationME Metric child class, which will identify
+    the temporal mean bias error of a case's duration."""
+
     def test_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        """Test if compute returns the proper type and dimensions (in this case an error)."""
         metric = metrics.DurationME()
         with pytest.raises(
             NotImplementedError, match="Duration mean error not yet implemented."

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,114 @@
+from extremeweatherbench import metrics
+import xarray as xr
+import pytest
+import pandas as pd
+
+
+def dataset_to_dataarray(dataset):
+    """Convert an xarray Dataset to a DataArray."""
+    mock_data_var = [data_var for data_var in dataset.data_vars][0]
+    return dataset[mock_data_var]
+
+
+class TestRegionalRMSE:
+    def test_regional_rmse_compute(
+        self, mock_forecast_dataset, mock_gridded_obs_dataset
+    ):
+        # Instantiate the RegionalRMSE metric
+        metric = metrics.RegionalRMSE()
+        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
+        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
+        # Compute the RMSE
+        result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+
+        # Check the result is an xarray DataArray
+        assert isinstance(result, xr.DataArray)
+        # Check the dimensions of the result
+        assert "lead_time" in result.dims
+
+
+class TestMaximumMAE:
+    def test_base_compute(self, mock_forecast_dataset, mock_gridded_obs_dataset):
+        # Instantiate the MaximumMAE metric
+        metric = metrics.MaximumMAE()
+        # Turn fixtures into dataarrays
+        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
+        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
+        # Compute the RMSE
+
+        result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+        # Check the result is an xarray DataArray
+        assert isinstance(result, xr.DataArray)
+        # Check the dimensions of the result
+        assert "lead_time" in result.dims
+
+    def test_in_forecast_dataarray(
+        self, mock_forecast_dataset, mock_gridded_obs_dataset_max_in_forecast
+    ):
+        # Instantiate the MaximumMAE metric
+        metric = metrics.MaximumMAE()
+
+        # Turn fixtures into dataarrays
+        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
+        mock_gridded_obs_dataarray_max_in_forecast = dataset_to_dataarray(
+            mock_gridded_obs_dataset_max_in_forecast
+        )
+        result = metric.compute(
+            mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
+        )
+        assert all(
+            [
+                pd.isna(result.sel({"lead_time": lead_time}))
+                for lead_time in [0, 24, 48, 72, 96, 168, 240]
+            ]
+        )
+        assert pytest.approx(result.sel({"lead_time": 6}), 1e-7) == 24.94948657
+        assert pytest.approx(result.sel({"lead_time": 30}), 1e-7) == 24.96504733
+
+
+class TestMaxOfMinTempMAE:
+    def test_max_of_min_temp_mae_compute(
+        self, mock_forecast_dataset, mock_gridded_obs_dataset
+    ):
+        # Instantiate the MaxOfMinTempMAE metric
+        metric = metrics.MaxOfMinTempMAE()
+        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
+        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
+        # Compute the RMSE
+        result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+        # Check the result is an xarray DataArray
+        assert isinstance(result, xr.DataArray)
+        # Check the dimensions of the result
+        assert "lead_time" in result.dims
+
+        def test_metric_base_class():
+            # Test base Metric class name property
+            metric = metrics.Metric()
+            assert metric.name == "Metric"
+
+            # Test that compute raises NotImplementedError
+            mock_forecast = xr.DataArray()
+            mock_obs = xr.DataArray()
+            with pytest.raises(NotImplementedError):
+                metric.compute(mock_forecast, mock_obs)
+
+
+def test_metric_align_datasets(mock_forecast_dataset, mock_gridded_obs_dataset):
+    # Test dataset alignment method
+    metric = metrics.Metric()
+    mock_forecast = dataset_to_dataarray(mock_forecast_dataset)
+    mock_obs = dataset_to_dataarray(mock_gridded_obs_dataset)
+
+    init_time = mock_forecast.init_time[0].values
+    init_time_dt = pd.Timestamp(init_time).to_pydatetime()
+
+    aligned_forecast, aligned_obs = metric.align_datasets(
+        mock_forecast, mock_obs, init_time_dt
+    )
+
+    # Check aligned datasets have same time coordinates
+    assert (aligned_forecast.time == aligned_obs.time).all()
+
+    # Check forecast was properly subset by init time
+    assert aligned_forecast.init_time.size == 1
+    assert pd.Timestamp(aligned_forecast.init_time.values) == pd.Timestamp(init_time)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,14 +10,43 @@ def dataset_to_dataarray(dataset):
     return dataset[mock_data_var]
 
 
+class TestMetric:
+    def test_name_property(self):
+        metric = metrics.Metric()
+        assert metric.name == "Metric"
+
+    def test_compute_not_implemented(
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray
+    ):
+        metric = metrics.Metric()
+        with pytest.raises(NotImplementedError):
+            metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+
+    def test_align_datasets(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        metric = metrics.Metric()
+        init_time_datetime = pd.Timestamp(
+            mock_forecast_dataarray.init_time[0].values
+        ).to_pydatetime()
+        aligned_forecast, aligned_obs = metric.align_datasets(
+            mock_forecast_dataarray, mock_gridded_obs_dataarray, init_time_datetime
+        )
+
+        # Check aligned datasets have same time coordinates
+        assert (aligned_forecast.time == aligned_obs.time).all()
+
+        # Check forecast was properly subset by init time
+        assert aligned_forecast.init_time.size == 1
+        assert pd.Timestamp(aligned_forecast.init_time.values) == pd.Timestamp(
+            mock_forecast_dataarray.init_time[0].values
+        )
+
+
 class TestRegionalRMSE:
     def test_regional_rmse_compute(
-        self, mock_forecast_dataset, mock_gridded_obs_dataset
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
         # Instantiate the RegionalRMSE metric
         metric = metrics.RegionalRMSE()
-        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
-        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
         # Compute the RMSE
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
 
@@ -28,12 +57,9 @@ class TestRegionalRMSE:
 
 
 class TestMaximumMAE:
-    def test_base_compute(self, mock_forecast_dataset, mock_gridded_obs_dataset):
+    def test_base_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
         # Instantiate the MaximumMAE metric
         metric = metrics.MaximumMAE()
-        # Turn fixtures into dataarrays
-        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
-        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
         # Compute the RMSE
 
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
@@ -43,16 +69,10 @@ class TestMaximumMAE:
         assert "lead_time" in result.dims
 
     def test_in_forecast_dataarray(
-        self, mock_forecast_dataset, mock_gridded_obs_dataset_max_in_forecast
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
     ):
         # Instantiate the MaximumMAE metric
         metric = metrics.MaximumMAE()
-
-        # Turn fixtures into dataarrays
-        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
-        mock_gridded_obs_dataarray_max_in_forecast = dataset_to_dataarray(
-            mock_gridded_obs_dataset_max_in_forecast
-        )
         result = metric.compute(
             mock_forecast_dataarray, mock_gridded_obs_dataarray_max_in_forecast
         )
@@ -68,12 +88,10 @@ class TestMaximumMAE:
 
 class TestMaxOfMinTempMAE:
     def test_max_of_min_temp_mae_compute(
-        self, mock_forecast_dataset, mock_gridded_obs_dataset
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray
     ):
         # Instantiate the MaxOfMinTempMAE metric
         metric = metrics.MaxOfMinTempMAE()
-        mock_forecast_dataarray = dataset_to_dataarray(mock_forecast_dataset)
-        mock_gridded_obs_dataarray = dataset_to_dataarray(mock_gridded_obs_dataset)
         # Compute the RMSE
         result = metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
         # Check the result is an xarray DataArray
@@ -81,29 +99,23 @@ class TestMaxOfMinTempMAE:
         # Check the dimensions of the result
         assert "lead_time" in result.dims
 
-        def test_metric_base_class():
-            # Test base Metric class name property
-            metric = metrics.Metric()
-            assert metric.name == "Metric"
-
-            # Test that compute raises NotImplementedError
-            mock_forecast = xr.DataArray()
-            mock_obs = xr.DataArray()
-            with pytest.raises(NotImplementedError):
-                metric.compute(mock_forecast, mock_obs)
+    def test_max_of_min_temp_mae_wrong_data_var(
+        self, mock_forecast_dataarray, mock_gridded_obs_dataarray
+    ):
+        mock_forecast_dataarray = mock_forecast_dataarray.rename("bad_name")
+        metric = metrics.MaxOfMinTempMAE()
+        with pytest.raises(KeyError):
+            metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
 
 
-def test_metric_align_datasets(mock_forecast_dataset, mock_gridded_obs_dataset):
+def test_metric_align_datasets(mock_forecast_dataarray, mock_gridded_obs_dataarray):
     # Test dataset alignment method
     metric = metrics.Metric()
-    mock_forecast = dataset_to_dataarray(mock_forecast_dataset)
-    mock_obs = dataset_to_dataarray(mock_gridded_obs_dataset)
-
-    init_time = mock_forecast.init_time[0].values
+    init_time = mock_forecast_dataarray.init_time[0].values
     init_time_dt = pd.Timestamp(init_time).to_pydatetime()
 
     aligned_forecast, aligned_obs = metric.align_datasets(
-        mock_forecast, mock_obs, init_time_dt
+        mock_forecast_dataarray, mock_gridded_obs_dataarray, init_time_dt
     )
 
     # Check aligned datasets have same time coordinates
@@ -112,3 +124,21 @@ def test_metric_align_datasets(mock_forecast_dataset, mock_gridded_obs_dataset):
     # Check forecast was properly subset by init time
     assert aligned_forecast.init_time.size == 1
     assert pd.Timestamp(aligned_forecast.init_time.values) == pd.Timestamp(init_time)
+
+
+class TestOnsetME:
+    def test_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        metric = metrics.OnsetME()
+        with pytest.raises(
+            NotImplementedError, match="Onset mean error not yet implemented."
+        ):
+            metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)
+
+
+class TestDurationME:
+    def test_compute(self, mock_forecast_dataarray, mock_gridded_obs_dataarray):
+        metric = metrics.DurationME()
+        with pytest.raises(
+            NotImplementedError, match="Duration mean error not yet implemented."
+        ):
+            metric.compute(mock_forecast_dataarray, mock_gridded_obs_dataarray)


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR adds in 100% test coverage for the metrics, including both metadata/type checking coverage and output coverage. Small issues such as typos and updated fixtures are included.

Handling random number generation in tests requires RandomState with the seed fixed during each invocation to ensure backwards compatibility. A potentially more robust future solution involves existing datasets that aren't generated on-the-fly. Bonus points if someone can figure out what the seed represents. :)

I removed the handler code in metrics.py if there are duplicate forecast times in the input forecast dataset, which pushes the responsibility to the user on ensuring a clean input dataset and preventing dealing with more testing and pitfalls that will potentially result.

I also removed rioxarray from the test_case.py file to reduce unneeded dependencies. rioxarray has a unique invocation paradigm that requires the library to be imported to enable the .rio accessor, which doesn't play nice with some dependency checkers like deptry. Probably shouldn't have done this in this PR, but it's a one line change that I included in the midst of other updates.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

All tests were run, including pre-commit testing before submitting this PR. Values for tests were generated in a separate, independent jupyter notebook.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules