### PR TITLE
Speed up point obs processing when forecast data already loaded into memory

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -60,7 +60,7 @@ class CaseEvaluationData:
     observation: Optional[Union[xr.Dataset | pd.DataFrame]] = None
 
 
-def build_dataarray_subsets(
+def build_dataset_subsets(
     case_evaluation_data: CaseEvaluationData,
     compute: bool = True,
     existing_forecast: Optional[xr.Dataset] = None,
@@ -401,11 +401,15 @@ def _maybe_evaluate_individual_case(
         forecast=forecast_dataset,
     )
 
-    gridded_case_eval = build_dataarray_subsets(gridded_obs_evaluation, compute=True)
-    point_case_eval = build_dataarray_subsets(
+    gridded_case_eval = build_dataset_subsets(gridded_obs_evaluation, compute=True)
+    point_case_eval = build_dataset_subsets(
         point_obs_evaluation,
         compute=True,
-        existing_forecast=gridded_case_eval.forecast,
+        existing_forecast=(
+            gridded_case_eval.forecast
+            if gridded_case_eval.forecast is not None
+            else None
+        ),
     )
     for data_var, metric in itertools.product(
         individual_case.data_vars, individual_case.metrics_list

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -393,7 +393,11 @@ def _maybe_evaluate_individual_case(
     )
 
     gridded_case_eval = build_dataarray_subsets(gridded_obs_evaluation, compute=True)
-    point_case_eval = build_dataarray_subsets(point_obs_evaluation, compute=True)
+    point_case_eval = build_dataarray_subsets(
+        point_obs_evaluation,
+        compute=True,
+        existing_forecast=gridded_case_eval.forecast,
+    )
     for data_var, metric in itertools.product(
         individual_case.data_vars, individual_case.metrics_list
     ):


### PR DESCRIPTION
# EWB Pull Request

## Description

Adding functionality to use existing in-memory forecast data shared from gridded to point obs case evaluation classes if both are computed to speed up computation. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Pytest, pre-commit, and sample run on jupyter notebook.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules