### PR TITLE
Dataframe groupby optimization for point obs

### DIFF
--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -401,7 +401,6 @@ def align_point_obs_from_gridded(
     case_subset_point_obs_df: pd.DataFrame,
     data_var: List[str],
     point_obs_metadata_vars: List[str],
-    compute: bool = True,
 ) -> Tuple[xr.Dataset, xr.Dataset]:
     """Takes in a forecast dataarray and point observation dataframe, aligning them by
     reducing dimensions.


### PR DESCRIPTION
# EWB Pull Request

## Description

Adding in a speedup to point obs computation by converting to a dataframe prior to groupby, which is much, much slower in xarray. Also removing a redundant function.

## How Has This Been Tested?

Pytest, pre-commit.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules