### PR TITLE
Taylor/ewb-23-reconfigure-dry-run-to-more-clearly-return-case-metadata

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -247,8 +247,6 @@ def evaluate(
         eval_config: A configuration object defining the evaluation run.
         forecast_schema_config: A mapping of the forecast variable naming schema to use
             when reading / decoding forecast data in the analysis.
-        only_case_metadata: Flag to disable performing actual calculations (but still validate
-            case configurations). Defaults to "False."
 
     Returns:
         A dictionary mapping event types to lists of xarray Datasets containing the

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -363,6 +363,16 @@ def read_event_yaml(input_pth: str | Path) -> dict:
     input_pth = Path(input_pth)
     with open(input_pth, "rb") as f:
         yaml_event_case = yaml.safe_load(f)
+    for k, v in yaml_event_case.items():
+        if k == "cases":
+            for individual_case in v:
+                if "location" in individual_case:
+                    individual_case["location"]["longitude"] = convert_longitude_to_360(
+                        individual_case["location"]["longitude"]
+                    )
+                    individual_case["location"] = Location(
+                        **individual_case["location"]
+                    )
     return yaml_event_case
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,16 +1,15 @@
 import pytest
-from extremeweatherbench import events, case, evaluate
+from extremeweatherbench import case, evaluate, events
 import datetime
 import xarray as xr
 import numpy as np
 import pandas as pd
 
 
-def test_evaluate_no_computation(sample_config):
-    result = evaluate.evaluate(
-        sample_config, only_case_metadata=True, only_case_metadata_event_type="HeatWave"
-    )
-    assert isinstance(result, events.EventContainer)
+def test_get_case_metadata(sample_config):
+    result = evaluate.get_case_metadata(sample_config)
+    assert isinstance(result, list)
+    assert isinstance(result[0], events.EventContainer)
 
 
 def test_evaluate_individualcase(sample_forecast_dataset, sample_gridded_obs_dataset):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 def test_evaluate_no_computation(sample_config):
     result = evaluate.evaluate(
-        sample_config, dry_run=True, dry_run_event_type="HeatWave"
+        sample_config, only_case_metadata=True, only_case_metadata_event_type="HeatWave"
     )
     assert isinstance(result, events.EventContainer)
 


### PR DESCRIPTION
# EWB Pull Request

## Description

cleaned up the evaluate runner function and decoupled extra dry_run argument (which wasn't truly a dry run but returns metadata instead). That is now in a separate function in evaluate.

## How Has This Been Tested?

Tested the new func in a terminal and ran the typical testing suite.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules