### PR TITLE
Taylor/ewb-25-point-obs-fails-out-when-data-is-missing

### DIFF
--- a/src/extremeweatherbench/config.py
+++ b/src/extremeweatherbench/config.py
@@ -120,8 +120,33 @@ class PointObservationSchemaConfig:
     """A mapping between standard variable names used across EWB, and their counterpart
     in a provided point observation dataset.
 
-    Allows users to insert custom schemas for decoding default or custom point observation data. Defaults are
-    suggested based on the CF Conventions.
+    Allows users to insert custom schemas for decoding default or custom point observation data.
+    Defaults are suggested based on the CF Conventions.
+    A successful configuration does not need to include all variables, only the required metadata variables
+    (station, id, latitude, longitude, time) and the data variables desired for evaluation if not already named
+    identically to the default values. Others will be ignored.
+
+    Attributes:
+        air_pressure_at_mean_sea_level: The variable name in the point observation dataset
+        for the mean sea level pressure. Defaults to "air_pressure_at_mean_sea_level".
+        surface_air_pressure: The surface air pressure. Defaults to "surface_air_pressure".
+        surface_wind_speed: The surface wind speed. Defaults to "surface_wind_speed".
+        surface_wind_from_direction: The surface wind from direction. Defaults to "surface_wind_from_direction".
+        surface_air_temperature: The surface air temperature. Defaults to "surface_air_temperature".
+        surface_dew_point_temperature: The surface dew point temperature. Defaults to "surface_dew_point_temperature".
+        surface_relative_humidity: The surface relative humidity. Defaults to "surface_relative_humidity".
+        accumulated_1_hour_precipitation: The accumulated 1 hour precipitation.
+        Defaults to "accumulated_1_hour_precipitation".
+        time: The time. Defaults to "time".
+        latitude: The latitude. Defaults to "latitude".
+        longitude: The longitude. Defaults to "longitude".
+        elevation: The elevation. Defaults to "elevation".
+        station_id: The station id. Defaults to "station".
+        station_name: The station name. Defaults to "name".
+        case_id: The case id in the event yaml file.
+        Defaults to "id".
+        metadata_vars: A list of metadata variables to include in the point observation dataset.
+        Default is ["station", "id", "latitude", "longitude", "time"]. All five required for successful configuration.
     """
 
     air_pressure_at_mean_sea_level: Optional[str] = "air_pressure_at_mean_sea_level"
@@ -150,12 +175,12 @@ class PointObservationSchemaConfig:
     )
 
     def extend_metadata_vars(self, input_metadata_variables: List[str]):
-        """Set the metadata variables for the schema config."""
+        """Extend the metadata variables for the schema config if more than the default are needed."""
         self.metadata_vars.extend(input_metadata_variables)
 
     @property
     def mapped_metadata_vars(self):
-        """Get the metadata variables from the schema config."""
+        """Returns the dataclass field names mapped to the given input variable names."""
         return [
             field.name
             for field in dataclasses.fields(self)

--- a/src/extremeweatherbench/data_loader.py
+++ b/src/extremeweatherbench/data_loader.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import numpy as np
 import pandas as pd
@@ -114,6 +114,7 @@ def open_kerchunk_reference(
 
 def open_obs_datasets(
     eval_config: config.Config,
+    point_obs_schema_config: config.PointObservationSchemaConfig,
 ) -> Tuple[Optional[pd.DataFrame], Optional[xr.Dataset]]:
     """Open the observation datasets specified for evaluation.
 
@@ -126,9 +127,13 @@ def open_obs_datasets(
     point_obs = None
     gridded_obs = None
     if eval_config.point_obs_path:
-        point_obs = pd.read_parquet(
+        raw_point_obs = pd.read_parquet(
             eval_config.point_obs_path, storage_options=dict(token="anon")
         )
+        point_obs = _rename_point_obs_dataset(raw_point_obs, point_obs_schema_config)
+        point_obs.attrs = {
+            "metadata_vars": point_obs_schema_config.mapped_metadata_vars
+        }
     if eval_config.gridded_obs_path:
         gridded_obs = xr.open_zarr(
             eval_config.gridded_obs_path,
@@ -136,6 +141,39 @@ def open_obs_datasets(
             storage_options=dict(token="anon"),
         )
     return point_obs, gridded_obs
+
+
+def _rename_point_obs_dataset(
+    point_obs: pd.DataFrame,
+    point_obs_schema_config: config.PointObservationSchemaConfig,
+) -> pd.DataFrame:
+    """Rename the point observation dataset to the correct names expected by the evaluation routines.
+
+    Args:
+        point_obs: The point observation dataframe to rename.
+        point_obs_schema_config: The point observation schema configuration.
+
+    Returns:
+        The renamed point observation dataframe.
+    """
+    # Mapping here is used to rename the incoming data variables to the correct
+    # names expected by the evaluation routines.
+    mapping = {
+        getattr(point_obs_schema_config, field.name): field.name
+        for field in dataclasses.fields(point_obs_schema_config)
+        if field.type is not List[str]
+    }
+
+    # Application of the mapping to coords and data variables.
+    filtered_mapping_columns = {
+        old: new for old, new in mapping.items() if old in point_obs.columns
+    }
+    # Combine the mapping for coords and data variables and rename them in the forecast dataset.
+    filtered_mapping = {**filtered_mapping_columns}
+
+    # Dataframes need "columns=" unlike xarray datasets
+    point_obs = point_obs.rename(columns=filtered_mapping)
+    return point_obs
 
 
 def _rename_forecast_dataset(

--- a/src/extremeweatherbench/data_loader.py
+++ b/src/extremeweatherbench/data_loader.py
@@ -172,8 +172,8 @@ def _rename_point_obs_dataset(
     filtered_mapping = {**filtered_mapping_columns}
 
     # Dataframes need "columns=" unlike xarray datasets
-    point_obs = point_obs.rename(columns=filtered_mapping)
-    return point_obs
+    renamed_point_obs = point_obs.rename(columns=filtered_mapping)
+    return renamed_point_obs
 
 
 def _rename_forecast_dataset(

--- a/src/extremeweatherbench/data_loader.py
+++ b/src/extremeweatherbench/data_loader.py
@@ -120,6 +120,7 @@ def open_obs_datasets(
 
     Args:
         eval_config: The evaluation configuration.
+        point_obs_schema_config: The point observation schema configuration.
 
     Returns:
         The point observation dataset and the gridded observation dataset.

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -100,16 +100,20 @@ def build_dataset_subsets(
         )
     else:
         if case_evaluation_data.observation_type == "gridded":
-            evaluation_result = _subset_gridded_obs(case_evaluation_data)
+            evaluation_result = _gridded_inputs_to_evaluation_input(
+                case_evaluation_data
+            )
         elif case_evaluation_data.observation_type == "point":
             # point obs needs to be computed if compute is True due to complex subsetting operations
-            evaluation_result = _subset_point_obs(case_evaluation_data, compute=compute)
+            evaluation_result = _point_inputs_to_evaluation_input(
+                case_evaluation_data, compute=compute
+            )
         if compute:
             evaluation_result.load_data()
         return evaluation_result
 
 
-def _subset_gridded_obs(
+def _gridded_inputs_to_evaluation_input(
     case_evaluation_data: CaseEvaluationData,
 ) -> CaseEvaluationInput:
     """Subset the gridded observation dataarray for a given data variable."""
@@ -141,7 +145,7 @@ def _subset_gridded_obs(
     )
 
 
-def _subset_point_obs(
+def _point_inputs_to_evaluation_input(
     case_evaluation_data: CaseEvaluationData, compute: bool = True
 ) -> CaseEvaluationInput:
     """Subset the point observation dataarray for a given data variable."""

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -243,6 +243,8 @@ def evaluate(
         eval_config: A configuration object defining the evaluation run.
         forecast_schema_config: A mapping of the forecast variable naming schema to use
             when reading / decoding forecast data in the analysis.
+        point_obs_schema_config: A mapping of the point observation variable naming schema to use
+            when reading / decoding point observation data in the analysis.
 
     Returns:
         A dictionary mapping event types to lists of xarray Datasets containing the

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -544,23 +544,3 @@ def derive_indices_from_init_time_and_lead_time(
     init_time_subset_indices = valid_time_indices[0]
 
     return init_time_subset_indices
-
-
-def maybe_filter_df_columns(
-    df: pd.DataFrame, variables: List[List[str]]
-) -> pd.DataFrame:
-    """Filter columns of a dataframe based on a list of variables.
-
-    Args:
-        df: The dataframe to filter.
-        variables: A list of lists of column names to filter.
-
-    Returns:
-        The filtered dataframe.
-    """
-    filtered_variable_list = []
-    for variable_list in variables:
-        for var in variable_list:
-            if var in df.columns:
-                filtered_variable_list.append(var)
-    return df[filtered_variable_list]

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -568,3 +568,23 @@ def derive_indices_from_init_time_and_lead_time(
     init_time_subset_indices = valid_time_indices[0]
 
     return init_time_subset_indices
+
+
+def maybe_filter_df_columns(
+    df: pd.DataFrame, variables: List[List[str]]
+) -> pd.DataFrame:
+    """Filter columns of a dataframe based on a list of variables.
+
+    Args:
+        df: The dataframe to filter.
+        variables: A list of lists of column names to filter.
+
+    Returns:
+        The filtered dataframe.
+    """
+    filtered_variable_list = []
+    for variable_list in variables:
+        for var in variable_list:
+            if var in df.columns:
+                filtered_variable_list.append(var)
+    return df[filtered_variable_list]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import xarray as xr
 import pandas as pd
 import numpy as np
-from extremeweatherbench import config, events
+from extremeweatherbench import config, events, data_loader
 
 
 def make_sample_gridded_obs_dataset():
@@ -28,6 +28,23 @@ def make_sample_gridded_obs_dataset():
         )
     ] = 25
     return dataset
+
+
+def make_sample_point_obs_df():
+    # Create sample point observations DataFrame
+    data = {
+        "time": pd.to_datetime(["2023-01-01 00:00", "2023-01-01 06:00"]),
+        "station": ["A100", "B200"],
+        "call": ["KWEW", "KBCE"],
+        "name": ["WEST CENTRAL", "EAST CENTRAL"],
+        "latitude": [40.5, 41.8],
+        "longitude": [-99.5, -99.8],
+        "elev": [1000, 1100],
+        "id": [1, 2],
+        "surface_air_temperature": [20.0, 21.0],
+    }
+    df = pd.DataFrame(data)
+    return df
 
 
 def make_sample_forecast_dataset():
@@ -81,6 +98,22 @@ def make_sample_forecast_dataset():
     return dataset
 
 
+def make_sample_results_dataarray_list():
+    results_da_list = [
+        xr.DataArray(
+            data=[5],
+            dims=["lead_time"],
+            coords={"lead_time": [0]},
+        ),
+        xr.DataArray(
+            data=[6],
+            dims=["lead_time"],
+            coords={"lead_time": [6]},
+        ),
+    ]
+    return results_da_list
+
+
 def dataset_to_dataarray(dataset):
     """Convert an xarray Dataset to a DataArray."""
     mock_data_var = [data_var for data_var in dataset.data_vars][0]
@@ -91,6 +124,13 @@ def dataset_to_dataarray(dataset):
 def sample_forecast_dataset():
     sample_forecast_dataset = make_sample_forecast_dataset()
     return sample_forecast_dataset
+
+
+@pytest.fixture
+def sample_schema_config_point_obs_df():
+    sample_schema_config_point_obs_df = make_sample_point_obs_df()
+
+    return sample_schema_config_point_obs_df
 
 
 @pytest.fixture
@@ -149,34 +189,29 @@ def sample_subset_gridded_obs_dataarray():
 
 @pytest.fixture
 def sample_results_dataarray_list():
-    results_da_list = [
-        xr.DataArray(
-            data=[5],
-            dims=["lead_time"],
-            coords={"lead_time": [0]},
-        ),
-        xr.DataArray(
-            data=[6],
-            dims=["lead_time"],
-            coords={"lead_time": [6]},
-        ),
-    ]
-    return results_da_list
+    sample_results_dataarray_list = make_sample_results_dataarray_list()
+    return sample_results_dataarray_list
 
 
 @pytest.fixture
 def sample_point_obs_df():
-    # Create sample point observations DataFrame
-    data = {
-        "time": pd.to_datetime(["2023-01-01 00:00", "2023-01-01 06:00"]),
-        "station": ["A100", "B200"],
-        "call": ["KWEW", "KBCE"],
-        "name": ["WEST CENTRAL", "EAST CENTRAL"],
-        "latitude": [40.5, 41.8],
-        "longitude": [-99.5, -99.8],
-        "elev": [1000, 1100],
-        "id": [1, 2],
-        "surface_air_temperature": [20.0, 21.0],
+    sample_point_obs_df = make_sample_point_obs_df()
+    return sample_point_obs_df
+
+
+@pytest.fixture
+def sample_point_obs_df_with_attrs():
+    sample_point_obs_schema_config = config.PointObservationSchemaConfig(
+        case_id="id",
+        station_name="name",
+        station_id="call",
+        elevation="elev",
+    )
+    sample_point_obs_df = make_sample_point_obs_df()
+    sample_point_obs_df.attrs = {
+        "metadata_vars": sample_point_obs_schema_config.mapped_metadata_vars
     }
-    df = pd.DataFrame(data)
-    return df
+    sample_point_obs_df = data_loader._rename_point_obs_dataset(
+        sample_point_obs_df, sample_point_obs_schema_config
+    )
+    return sample_point_obs_df

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -243,3 +243,132 @@ def test_maybe_convert_dataset_lead_time_to_int(sample_config):
     )
     assert result_int["lead_time"].dtype == np.dtype("int64")
     assert all(result_int["lead_time"].values == [0, 6, 12, 18, 24])
+
+
+def test_point_observation_schema_config():
+    """Test the PointObservationSchemaConfig class functionality."""
+    # Test default configuration
+    default_config = config.PointObservationSchemaConfig()
+    assert default_config.surface_air_temperature == "surface_air_temperature"
+    assert default_config.time == "time"
+    assert default_config.latitude == "latitude"
+    assert default_config.longitude == "longitude"
+    assert default_config.station_id == "station"
+    assert default_config.station_name == "name"
+    assert default_config.case_id == "id"
+
+    # Test default metadata vars
+    assert "station" in default_config.metadata_vars
+    assert "id" in default_config.metadata_vars
+    assert "latitude" in default_config.metadata_vars
+    assert "longitude" in default_config.metadata_vars
+    assert "time" in default_config.metadata_vars
+
+    # Test extending metadata vars
+    new_vars = ["elevation", "surface_air_pressure"]
+    default_config.extend_metadata_vars(new_vars)
+    assert "elevation" in default_config.metadata_vars
+    assert "surface_air_pressure" in default_config.metadata_vars
+
+    # Test mapped_metadata_vars property
+    mapped_vars = default_config.mapped_metadata_vars
+    assert "station_id" in mapped_vars  # Maps to "station"
+    assert "case_id" in mapped_vars  # Maps to "id"
+    assert "latitude" in mapped_vars
+    assert "longitude" in mapped_vars
+    assert "time" in mapped_vars
+
+
+def test_rename_point_obs_dataset(sample_point_obs_df):
+    """Test that _rename_point_obs_dataset correctly renames variables according to the schema config."""
+    # Create a copy of the sample dataframe to avoid modifying the original
+    df = sample_point_obs_df.copy()
+
+    # Create a custom schema config for sample point obs df
+    schema_config = config.PointObservationSchemaConfig(
+        surface_air_temperature="surface_air_temperature",
+        time="time",
+        latitude="latitude",
+        longitude="longitude",
+        station_id="call",
+        station_name="name",
+        case_id="id",
+        elevation="elev",
+    )
+
+    # Store original values for later comparison
+    temp_values = df["surface_air_temperature"].values
+    time_values = df["time"].values
+    lat_values = df["latitude"].values
+    lon_values = df["longitude"].values
+    name_values = df["name"].values
+    id_values = df["id"].values
+
+    # Call the function being tested
+    renamed_df = data_loader._rename_point_obs_dataset(df, schema_config)
+
+    # Verify that variables were correctly renamed
+    assert "surface_air_temperature" in renamed_df.columns
+    assert "time" in renamed_df.columns
+    assert "latitude" in renamed_df.columns
+    assert "longitude" in renamed_df.columns
+    assert "station_id" in renamed_df.columns
+    assert "station_name" in renamed_df.columns
+    assert "case_id" in renamed_df.columns
+
+    # Verify that original variable names are no longer present
+    assert "temp" not in renamed_df.columns
+    assert "timestamp" not in renamed_df.columns
+    assert "lat" not in renamed_df.columns
+    assert "lon" not in renamed_df.columns
+    assert "station_code" not in renamed_df.columns
+    assert "event_id" not in renamed_df.columns
+
+    # Verify that the data values remain unchanged after renaming
+    np.testing.assert_array_equal(
+        renamed_df["surface_air_temperature"].values, temp_values
+    )
+    np.testing.assert_array_equal(renamed_df["time"].values, time_values)
+    np.testing.assert_array_equal(renamed_df["latitude"].values, lat_values)
+    np.testing.assert_array_equal(renamed_df["longitude"].values, lon_values)
+    np.testing.assert_array_equal(renamed_df["station_name"].values, name_values)
+    np.testing.assert_array_equal(renamed_df["case_id"].values, id_values)
+
+
+def test_rename_point_obs_dataset_partial_mapping(sample_point_obs_df):
+    """Test that _rename_point_obs_dataset correctly handles partial mappings."""
+    # Create a copy of the sample dataframe to avoid modifying the original
+    df = sample_point_obs_df.copy()
+
+    # Create a schema config where only some variables match
+    schema_config = config.PointObservationSchemaConfig(
+        surface_air_temperature="surface_air_temperature",
+        time="timestamp",  # Not in dataset
+        latitude="lat",  # Not in dataset
+        longitude="lon",  # Not in dataset
+    )
+
+    # Store original values for later comparison
+    temp_values = df["surface_air_temperature"].values
+    name_values = df["name"].values
+    id_values = df["id"].values
+
+    # Call the function being tested
+    renamed_df = data_loader._rename_point_obs_dataset(df, schema_config)
+
+    # Verify that matching variables were renamed
+    assert "surface_air_temperature" in renamed_df.columns
+
+    # Verify that non-matching variables were left unchanged
+    assert "time" in renamed_df.columns
+    assert "latitude" in renamed_df.columns
+    assert "longitude" in renamed_df.columns
+    assert "station_name" in renamed_df.columns
+    assert "case_id" in renamed_df.columns
+
+    # Verify that the data values remain unchanged
+    np.testing.assert_array_equal(
+        renamed_df["surface_air_temperature"].values, temp_values
+    )
+    np.testing.assert_array_equal(renamed_df["station_name"].values, name_values)
+    np.testing.assert_array_equal(renamed_df["case_id"].values, id_values)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -344,7 +344,9 @@ def test_subset_gridded_obs(
     assert isinstance(result.forecast, xr.Dataset)
 
 
-def test_subset_point_obs(mocker, sample_point_obs_df, sample_forecast_dataset):
+def test_subset_point_obs(
+    mocker, sample_point_obs_df_with_attrs, sample_forecast_dataset
+):
     """Test _subset_point_obs function."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
     mock_case.id = 1
@@ -354,25 +356,18 @@ def test_subset_point_obs(mocker, sample_point_obs_df, sample_forecast_dataset):
     valid_time = pd.Timestamp(
         sample_forecast_dataset.init_time[0].values
     ) + pd.Timedelta(hours=6)
-    sample_point_obs_df.iloc[0, sample_point_obs_df.columns.get_loc("time")] = (
-        valid_time
-    )
-    sample_point_obs_df.iloc[1, sample_point_obs_df.columns.get_loc("time")] = (
-        valid_time
-    )
-    # mocker.patch(
-    #     'point_forecast_da.groupby(["init_time", "lead_time", "latitude", "longitude"]).mean()',
-    #     return_value=sample_forecast_dataset,
-    # )
-    # mocker.patch(
-    #     'subset_point_obs_da.groupby(["time", "latitude", "longitude"]).first()',
-    #     return_value=sample_point_obs_df,
-    # )
+    sample_point_obs_df_with_attrs.iloc[
+        0, sample_point_obs_df_with_attrs.columns.get_loc("time")
+    ] = valid_time
+    sample_point_obs_df_with_attrs.iloc[
+        1, sample_point_obs_df_with_attrs.columns.get_loc("time")
+    ] = valid_time
+
     case_eval_data = evaluate.CaseEvaluationData(
         individual_case=mock_case,
         observation_type="point",
         forecast=sample_forecast_dataset,
-        observation=sample_point_obs_df,
+        observation=sample_point_obs_df_with_attrs,
     )
 
     result = evaluate._subset_point_obs(case_eval_data)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -178,7 +178,8 @@ def test_build_dataset_subsets_with_existing_forecast(
         forecast=existing_forecast["surface_air_temperature"],
     )
     mocker.patch(
-        "extremeweatherbench.evaluate._subset_gridded_obs", return_value=mock_result
+        "extremeweatherbench.evaluate._gridded_inputs_to_evaluation_input",
+        return_value=mock_result,
     )
 
     # Spy on _check_and_subset_forecast_availability to verify it's not called
@@ -264,7 +265,8 @@ def test_build_dataarray_subsets_gridded(
         forecast=sample_forecast_dataset["surface_air_temperature"],
     )
     mocker.patch(
-        "extremeweatherbench.evaluate._subset_gridded_obs", return_value=mock_result
+        "extremeweatherbench.evaluate._gridded_inputs_to_evaluation_input",
+        return_value=mock_result,
     )
 
     result = evaluate.build_dataset_subsets(case_eval_data, compute=False)
@@ -306,9 +308,9 @@ def test_build_dataarray_subsets_point(
         observation_type="point", observation=mock_obs, forecast=mock_forecast
     )
     mocker.patch(
-        "extremeweatherbench.evaluate._subset_point_obs", return_value=mock_result
+        "extremeweatherbench.evaluate._point_inputs_to_evaluation_input",
+        return_value=mock_result,
     )
-
     result = evaluate.build_dataset_subsets(case_eval_data, compute=False)
 
     assert result.observation_type == "point"
@@ -336,7 +338,7 @@ def test_subset_gridded_obs(
         observation=sample_gridded_obs_dataset,
     )
 
-    result = evaluate._subset_gridded_obs(case_eval_data)
+    result = evaluate._gridded_inputs_to_evaluation_input(case_eval_data)
 
     assert isinstance(result, evaluate.CaseEvaluationInput)
     assert result.observation_type == "gridded"
@@ -370,7 +372,7 @@ def test_subset_point_obs(
         observation=sample_point_obs_df_with_attrs,
     )
 
-    result = evaluate._subset_point_obs(case_eval_data)
+    result = evaluate._point_inputs_to_evaluation_input(case_eval_data)
 
     assert isinstance(result, evaluate.CaseEvaluationInput)
     assert result.observation_type == "point"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,57 +236,57 @@ def test_clip_dataset_to_bounding_box_degrees():
 
 def test_align_point_obs_from_gridded_input_validation():
     # Test with invalid inputs
-    with pytest.raises((AttributeError, TypeError)):
+    with pytest.raises((KeyError)):
         utils.align_point_obs_from_gridded(
-            None,  # invalid forecast
+            xr.Dataset(),  # invalid forecast
             pd.DataFrame(),  # empty dataframe
-            [],  # empty metadata vars
+            [],  # empty data vars
         )
 
 
 def test_align_point_obs_from_gridded_basic(
-    sample_forecast_dataset, sample_point_obs_df
+    sample_forecast_dataset, sample_point_obs_df_with_attrs
 ):
     """Test basic functionality of align_point_obs_from_gridded."""  # Adjust point obs to match forecast time
     valid_time = pd.Timestamp(
         sample_forecast_dataset.init_time[0].values
     ) + pd.Timedelta(hours=6)
-    sample_point_obs_df.iloc[0, sample_point_obs_df.columns.get_loc("time")] = (
-        valid_time
-    )
-    sample_point_obs_df.iloc[1, sample_point_obs_df.columns.get_loc("time")] = (
-        valid_time
-    )
+    sample_point_obs_df_with_attrs.iloc[
+        0, sample_point_obs_df_with_attrs.columns.get_loc("time")
+    ] = valid_time
+    sample_point_obs_df_with_attrs.iloc[
+        1, sample_point_obs_df_with_attrs.columns.get_loc("time")
+    ] = valid_time
     # Convert longitude to 0-360 range to match forecast
-    sample_point_obs_df["longitude"] = sample_point_obs_df["longitude"].apply(
-        lambda x: x + 360 if x < 0 else x
-    )
+    sample_point_obs_df_with_attrs["longitude"] = sample_point_obs_df_with_attrs[
+        "longitude"
+    ].apply(lambda x: x + 360 if x < 0 else x)
 
     data_var = ["surface_air_temperature"]
-    metadata_vars = ["latitude", "longitude", "station", "time"]
     forecast, obs = utils.align_point_obs_from_gridded(
-        sample_forecast_dataset, sample_point_obs_df, data_var, metadata_vars
+        sample_forecast_dataset, sample_point_obs_df_with_attrs, data_var
     )
     # Check basic properties
     assert isinstance(forecast, xr.Dataset)
     assert isinstance(obs, xr.Dataset)
-    assert "station" in forecast.dims
-    assert "station" in obs.dims
-    assert len(forecast.station) == len(sample_point_obs_df)
-    assert len(obs.station) == len(sample_point_obs_df)
+    assert "station_id" in forecast.dims
+    assert "station_id" in obs.dims
+    assert len(forecast.station_id) == len(sample_point_obs_df_with_attrs)
+    assert len(obs.station_id) == len(sample_point_obs_df_with_attrs)
     assert all(
-        station in forecast.station.values for station in sample_point_obs_df["station"]
+        station in forecast.station_id.values
+        for station in sample_point_obs_df_with_attrs["station_id"]
     )
 
 
 def test_align_point_obs_from_gridded_multiple_times(
-    sample_forecast_dataarray, sample_point_obs_df
+    sample_forecast_dataarray, sample_point_obs_df_with_attrs
 ):
     """Test aligning point observations with multiple valid times."""
     # Create a larger dataframe with multiple times
     dfs = []
     for i in range(3):
-        df_copy = sample_point_obs_df.copy()
+        df_copy = sample_point_obs_df_with_attrs.copy()
         valid_time = pd.Timestamp(
             sample_forecast_dataarray.init_time[0].values
         ) + pd.Timedelta(hours=i * 6)
@@ -307,19 +307,18 @@ def test_align_point_obs_from_gridded_multiple_times(
     )  # ~-99.5, ~-99.8 in 0-360 space
 
     data_var = ["surface_air_temperature"]
-    metadata_vars = ["latitude", "longitude", "station", "time"]
 
     forecast, obs = utils.align_point_obs_from_gridded(
-        sample_forecast_dataarray, multi_time_df, data_var, metadata_vars
+        sample_forecast_dataarray, multi_time_df, data_var
     )
 
     # Check there are multiple stations and times
-    assert len(forecast.station) == len(multi_time_df)
+    assert len(forecast.station_id) == len(multi_time_df)
     assert len(np.unique(forecast.time.values)) == 3
 
 
 def test_align_point_obs_from_gridded_missing_times(
-    sample_forecast_dataarray, sample_point_obs_df
+    sample_forecast_dataarray, sample_point_obs_df_with_attrs
 ):
     """Test behavior when some observation times don't match forecast times."""
     # Create a dataframe with some matching times and some that don't match
@@ -330,7 +329,7 @@ def test_align_point_obs_from_gridded_missing_times(
         sample_forecast_dataarray.init_time[0].values
     ) + pd.Timedelta(hours=7)  # Not in forecast
 
-    df = sample_point_obs_df.copy()
+    df = sample_point_obs_df_with_attrs.copy()
     df.iloc[0, df.columns.get_loc("time")] = valid_time1
     df.iloc[1, df.columns.get_loc("time")] = valid_time2
 
@@ -342,42 +341,42 @@ def test_align_point_obs_from_gridded_missing_times(
     df["longitude"] = np.array([260.5, 260.2])  # ~-99.5, ~-99.8 in 0-360 space
 
     data_var = ["surface_air_temperature"]
-    metadata_vars = ["latitude", "longitude", "station", "time"]
 
     forecast, obs = utils.align_point_obs_from_gridded(
-        sample_forecast_dataarray, df, data_var, metadata_vars
+        sample_forecast_dataarray, df, data_var
     )
 
     # Should only include the valid time that matches a forecast time
-    assert len(forecast.station) == 1
+    assert len(forecast.station_id) == 1
 
 
 def test_align_point_obs_from_gridded_out_of_bounds(
-    sample_forecast_dataarray, sample_point_obs_df
+    sample_forecast_dataarray, sample_point_obs_df_with_attrs
 ):
     """Test behavior when point observations are outside the forecast domain."""
     # Set timestamp to match forecast
     valid_time = pd.Timestamp(
         sample_forecast_dataarray.init_time[0].values
     ) + pd.Timedelta(hours=6)
-    sample_point_obs_df["time"] = valid_time
+    sample_point_obs_df_with_attrs["time"] = valid_time
 
     # Put one point within forecast domain and one outside
-    sample_point_obs_df["latitude"] = np.array(
+    sample_point_obs_df_with_attrs["latitude"] = np.array(
         [40.5, 95.0]
     )  # 95 is outside valid range
-    sample_point_obs_df["longitude"] = np.array([260.5, 260.2])
+    sample_point_obs_df_with_attrs["longitude"] = np.array([260.5, 260.2])
 
     data_var = ["surface_air_temperature"]
-    metadata_vars = ["latitude", "longitude", "station", "time"]
 
     forecast, obs = utils.align_point_obs_from_gridded(
-        sample_forecast_dataarray, sample_point_obs_df, data_var, metadata_vars
+        sample_forecast_dataarray, sample_point_obs_df_with_attrs, data_var
     )
 
     # Should only include the point within the domain
-    assert len(forecast.station) == 1
-    assert forecast.station.values[0] == sample_point_obs_df["station"][0]
+    assert len(forecast.station_id) == 1
+    assert (
+        forecast.station_id.values[0] == sample_point_obs_df_with_attrs["station_id"][0]
+    )
 
 
 def test_location_subset_point_obs():


### PR DESCRIPTION
# EWB Pull Request

## Description

When new cases were added, a bug was found that stopped point observations from working properly. It resulted that when data was missing for a case, the process broke. Concurrently, a transition to GHCN instead of ISD coincided with different metadata columns. To address this, a new configuration dataclass, `PointObservationSchemaConfig`, is added.

A default requirement of a column name for station, case id, latitude, longitude, and time are required for EWB to work.

The pandas `.attrs` method is used to carry metadata through the EWB point obs piece of the pipeline after a new `_rename_point_obs_dataset` is used, similar to `_rename_forecast_dataset` but handles a pandas dataframe instead.

The applicable changes are made to utils to use the new naming conventions and `.attrs` approach.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

pytest and pre-commit hooks as typical.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules