### PR TITLE
add nonetype check to load_data

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -33,9 +33,11 @@ class CaseEvaluationInput:
 
     def load_data(self):
         """Load the evaluation inputs into memory."""
-        logger.debug("Loading evaluation inputs into memory")
-        self.observation = self.observation.compute()
-        self.forecast = self.forecast.compute()
+        logger.debug("Loading evaluation inputs into memory if not None")
+        if self.observation is not None:
+            self.observation = self.observation.compute()
+        if self.forecast is not None:
+            self.forecast = self.forecast.compute()
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
# EWB Pull Request

## Description

This is a small bugfix to handle if there's a nonetype in the obs or forecast data for a case evaluation input (CaseEvaluationInput) class.

NoneTypes are being currently utilized for if there is either an issue (missing data) or a choice by the user to not include an observation in their runthrough.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)