### PR TITLE
Move mapping function outside of loop

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -275,19 +275,19 @@ def evaluate(
         point_obs is not None,
         gridded_obs is not None,
     )
+    # map era5 vars by renaming and dropping extra vars
+    if gridded_obs is not None:
+        gridded_obs = utils.map_era5_vars_to_forecast(
+            forecast_schema_config,
+            forecast_dataset=forecast_dataset,
+            era5_dataset=gridded_obs,
+        )
     for event in eval_config.event_types:
         cases = dacite.from_dict(
             data_class=event,
             data=yaml_event_case,
         )
 
-        # map era5 vars by renaming and dropping extra vars
-        if gridded_obs is not None:
-            gridded_obs = utils.map_era5_vars_to_forecast(
-                forecast_schema_config,
-                forecast_dataset=forecast_dataset,
-                era5_dataset=gridded_obs,
-            )
         logger.debug("beginning evaluation loop for %s", event.event_type)
         results = _maybe_evaluate_individual_cases_loop(
             cases, forecast_dataset, gridded_obs, point_obs


### PR DESCRIPTION
# EWB Pull Request

## Description

If using ERA5 (the only gridded dataset that works for EWB at the moment), at some point the variable names need to be mapped to the forecast dataset. The mapping also subsets the ERA5 variables in the forecast dataset, preventing significant load times. This PR moves this mapping function outside of the event_types loop as there is no benefit to subsetting the same data multiple times.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Pytest et al