### PR TITLE
change all instances of id to case_id_number

### DIFF
--- a/data_prep/subset_heat_cold_events.py
+++ b/data_prep/subset_heat_cold_events.py
@@ -1,17 +1,19 @@
 """Helper functions to identify the date ranges of heat waves and freeze events."""
 
-import xarray as xr
-import numpy as np
-import pandas as pd
-from extremeweatherbench import utils, case
+import datetime
+
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-from cartopy.mpl.gridliner import LongitudeFormatter, LatitudeFormatter
+import numpy as np
+import pandas as pd
 import seaborn as sns
+import xarray as xr
+from cartopy.mpl.gridliner import LatitudeFormatter, LongitudeFormatter
 from matplotlib import dates as mdates
-import datetime
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+from extremeweatherbench import case, utils
 
 sns.set_theme(style="whitegrid", context="talk")
 
@@ -168,7 +170,8 @@ def case_plot(
     gl.xlabel_style = {"size": 12, "color": "k"}
     gl.ylabel_style = {"size": 12, "color": "k"}
     ax1.set_title(
-        f"Event ID {case.id}: 2m Temperature, {merged_dataset['time'].sel(time=subset_timestep).dt.strftime('%Y-%m-%d %Hz').values[0]}",
+        f"Event ID {case.case_id_number}: 2m Temperature, "
+        f"{merged_dataset['time'].sel(time=subset_timestep).dt.strftime('%Y-%m-%d %Hz').values[0]}",
         fontsize=12,
     )
     # Add the location coordinate as a dot on the map

--- a/src/extremeweatherbench/case.py
+++ b/src/extremeweatherbench/case.py
@@ -3,12 +3,14 @@ Some code similarly structured to WeatherBench (Rasp et al.)."""
 
 import dataclasses
 import datetime
-from typing import List, Optional, Type
-from extremeweatherbench import metrics, utils
-import xarray as xr
-from enum import StrEnum
-import numpy as np
 import logging
+from enum import StrEnum
+from typing import List, Optional, Type
+
+import numpy as np
+import xarray as xr
+
+from extremeweatherbench import metrics, utils
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -23,7 +25,7 @@ class IndividualCase:
     simple YAML-based configuration file.
 
     Attributes:
-        id: A unique numerical identifier for the event.
+        case_id_number: A unique numerical identifier for the event.
         start_date: The start date of the case, for use in subsetting data for analysis.
         end_date: The end date of the case, for use in subsetting data for analysis.
         location: A Location object representing the latitude and longitude of the event
@@ -34,7 +36,7 @@ class IndividualCase:
         cross_listed: A list of other event types that this case study is cross-listed under.
     """
 
-    id: int
+    case_id_number: int
     title: str
     start_date: datetime.datetime
     end_date: datetime.datetime
@@ -102,16 +104,20 @@ class IndividualCase:
         lead_time_len = len(forecast_dataset.init_time)
 
         if lead_time_len == 0:
-            logger.warning("No forecast data available for case %s, skipping", self.id)
+            logger.warning(
+                "No forecast data available for case %s, skipping", self.case_id_number
+            )
             return False
         elif lead_time_len < (self.end_date - self.start_date).days:
             logger.warning(
                 "Fewer valid times in forecast than days in case %s, results likely unreliable",
-                self.id,
+                self.case_id_number,
             )
         else:
-            logger.info("Forecast data available for case %s", self.id)
-        logger.info("Lead time length for case %s: %s", self.id, lead_time_len)
+            logger.info("Forecast data available for case %s", self.case_id_number)
+        logger.info(
+            "Lead time length for case %s: %s", self.case_id_number, lead_time_len
+        )
         return True
 
 

--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -1,6 +1,6 @@
 ---
 cases:
-  - id: 1
+  - case_id_number: 1
     title: 2021 Pacific Northwest
     start_date: 2021-06-20 00:00:00
     end_date: 2021-07-03 00:00:00
@@ -9,7 +9,7 @@ cases:
       longitude: -122.3321
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 2
+  - case_id_number: 2
     title: 2022 Upper Midwest
     start_date: 2022-05-07 00:00:00
     end_date: 2022-05-17 00:00:00
@@ -18,7 +18,7 @@ cases:
       longitude: -87.6298
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 3
+  - case_id_number: 3
     title: 2022 California
     start_date: 2022-06-07 00:00:00
     end_date: 2022-06-15 00:00:00
@@ -27,7 +27,7 @@ cases:
       longitude: -118.2437
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 4
+  - case_id_number: 4
     title: 2022 Texas
     start_date: 2022-06-30 00:00:00
     end_date: 2022-07-18 00:00:00
@@ -36,7 +36,7 @@ cases:
       longitude: -96.7970
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 5
+  - case_id_number: 5
     title: 2023 Pacific Northwest
     start_date: 2023-05-10 00:00:00
     end_date: 2023-05-23 00:00:00
@@ -45,7 +45,7 @@ cases:
       longitude: -122.3321
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 6
+  - case_id_number: 6
     title: 2022 Mid-Atlantic
     start_date: 2022-05-17 00:00:00
     end_date: 2022-05-24 00:00:00
@@ -54,7 +54,7 @@ cases:
       longitude: -76.6122
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 7
+  - case_id_number: 7
     title: 2023 Australia
     start_date: 2023-11-18 00:00:00
     end_date: 2023-11-28 00:00:00
@@ -63,7 +63,7 @@ cases:
       longitude: 115.8605
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 8
+  - case_id_number: 8
     title: 2023 Ireland
     start_date: 2023-09-02 00:00:00
     end_date: 2023-09-13 00:00:00
@@ -72,7 +72,7 @@ cases:
       longitude: -7.6921
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 9
+  - case_id_number: 9
     title: 2023 Italy
     start_date: 2023-07-07 00:00:00
     end_date: 2023-07-27 00:00:00
@@ -81,7 +81,7 @@ cases:
       longitude: 12.4964
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 10
+  - case_id_number: 10
     title: 2023 SW Europe
     start_date: 2023-08-17 00:00:00
     end_date: 2023-08-28 00:00:00
@@ -90,7 +90,7 @@ cases:
       longitude: -3.7492
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 11
+  - case_id_number: 11
     title: 2023 South America
     start_date: 2023-07-29 00:00:00
     end_date: 2023-08-04 00:00:00
@@ -99,7 +99,7 @@ cases:
       longitude: -58.3816
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 12
+  - case_id_number: 12
     title: 2023 China (Shanghai)
     start_date: 2023-05-24 00:00:00
     end_date: 2023-06-01 00:00:00
@@ -108,7 +108,7 @@ cases:
       longitude: 121.4737
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 13
+  - case_id_number: 13
     title: 2023 China (Yunnan Province)
     start_date: 2023-04-14 00:00:00
     end_date: 2023-04-23 00:00:00
@@ -117,7 +117,7 @@ cases:
       longitude: 102.7100
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 14
+  - case_id_number: 14
     title: 2023 Algeria
     start_date: 2023-07-05 00:00:00
     end_date: 2023-07-27 00:00:00
@@ -126,7 +126,7 @@ cases:
       longitude: 3.0869
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 15
+  - case_id_number: 15
     title: 2023 Iberian Peninsula
     start_date: 2023-04-22 00:00:00
     end_date: 2023-05-01 00:00:00
@@ -135,7 +135,7 @@ cases:
       longitude: -7.6110
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 16
+  - case_id_number: 16
     title: 2023 Gibraltar
     start_date: 2023-04-22 00:00:00
     end_date: 2023-05-03 00:00:00
@@ -144,7 +144,7 @@ cases:
       longitude: -5.3536
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 17
+  - case_id_number: 17
     title: 2023 India
     start_date: 2023-02-15 00:00:00
     end_date: 2023-03-01 00:00:00
@@ -153,7 +153,7 @@ cases:
       longitude: 77.2090
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 18
+  - case_id_number: 18
     title: 2021 Western Russia
     start_date: 2021-06-18 00:00:00
     end_date: 2021-06-30 00:00:00
@@ -162,7 +162,7 @@ cases:
       longitude: 37.6173
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 19
+  - case_id_number: 19
     title: 2022 Germany
     start_date: 2022-12-23 00:00:00
     end_date: 2022-12-31 00:00:00
@@ -171,7 +171,7 @@ cases:
       longitude: 13.4050
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 20
+  - case_id_number: 20
     title: 2022 UK (August)
     start_date: 2022-08-08 00:00:00
     end_date: 2022-08-16 00:00:00
@@ -180,7 +180,7 @@ cases:
       longitude: -0.1278
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 21
+  - case_id_number: 21
     title: 2022 UK (July)
     start_date: 2022-07-15 00:00:00
     end_date: 2022-07-23 00:00:00
@@ -189,7 +189,7 @@ cases:
       longitude: -0.1278
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 22
+  - case_id_number: 22
     title: 2022 France
     start_date: 2022-06-09 00:00:00
     end_date: 2022-06-21 00:00:00
@@ -198,7 +198,7 @@ cases:
       longitude: -1.5586
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 23
+  - case_id_number: 23
     title: 2022 Japan
     start_date: 2022-06-20 00:00:00
     end_date: 2022-07-05 00:00:00
@@ -207,7 +207,7 @@ cases:
       longitude: 139.6917
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 24
+  - case_id_number: 24
     title: 2022 India
     start_date: 2022-04-24 00:00:00
     end_date: 2022-05-04 00:00:00
@@ -216,7 +216,7 @@ cases:
       longitude: 68.4376
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 25
+  - case_id_number: 25
     title: 2022 East Antarctica
     start_date: 2022-03-12 00:00:00
     end_date: 2022-03-26 00:00:00
@@ -225,7 +225,7 @@ cases:
       longitude: 123.3500
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 26
+  - case_id_number: 26
     title: 2022 West Australia
     start_date: 2022-01-15 00:00:00
     end_date: 2022-01-25 00:00:00
@@ -234,7 +234,7 @@ cases:
       longitude: 115.8605
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 27
+  - case_id_number: 27
     title: 2021 Canada Plains
     start_date: 2021-05-30 00:00:00
     end_date: 2021-06-09 00:00:00
@@ -243,7 +243,7 @@ cases:
       longitude: -97.5667
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 28
+  - case_id_number: 28
     title: 2021 New Zealand
     start_date: 2021-01-12 18:00:00
     end_date: 2021-01-17 18:00:00
@@ -252,7 +252,7 @@ cases:
       longitude: 171.7310
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 29
+  - case_id_number: 29
     title: 2020 Australia
     start_date: 2020-11-25 00:00:00
     end_date: 2020-11-30 00:00:00
@@ -261,7 +261,7 @@ cases:
       longitude: 150.9448
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 30
+  - case_id_number: 30
     title: 2021 Texas
     start_date: 2021-02-10 12:00:00
     end_date: 2021-02-22 00:00:00
@@ -270,7 +270,7 @@ cases:
       longitude: -97.7431
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 31
+  - case_id_number: 31
     title: 2022 Arkansas
     start_date: 2022-02-17 18:00:00
     end_date: 2022-03-01 06:00:00
@@ -279,7 +279,7 @@ cases:
       longitude: -92.2896
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 32
+  - case_id_number: 32
     title: 2023 Germany
     start_date: 2023-12-02 06:00:00
     end_date: 2023-12-05 18:00:00
@@ -288,7 +288,7 @@ cases:
       longitude: 11.5820
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 33
+  - case_id_number: 33
     title: 2023 China
     start_date: 2023-12-15 06:00:00
     end_date: 2023-12-26 18:00:00
@@ -297,7 +297,7 @@ cases:
       longitude: 121.4737
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 34
+  - case_id_number: 34
     title: 2023 Afghanistan
     start_date: 2023-01-11 06:00:00
     end_date: 2023-01-28 00:00:00
@@ -306,7 +306,7 @@ cases:
       longitude: 69.2075
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 35
+  - case_id_number: 35
     title: 2022 Colorado
     start_date: 2022-04-06 00:00:00
     end_date: 2022-04-16 00:00:00
@@ -315,7 +315,7 @@ cases:
       longitude: -104.9903
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 36
+  - case_id_number: 36
     title: July 2024 South Dakota
     start_date: 2024-07-13 00:00:00
     end_date: 2024-07-14 00:00:00
@@ -324,7 +324,7 @@ cases:
       longitude: -100.3516
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 37
+  - case_id_number: 37
     title: July 2024 Chicago
     start_date: 2024-07-14 00:00:00
     end_date: 2024-07-16 00:00:00
@@ -333,7 +333,7 @@ cases:
       longitude: -87.6298
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 38
+  - case_id_number: 38
     title: July 2024 New York
     start_date: 2024-07-16 00:00:00
     end_date: 2024-07-17 00:00:00
@@ -342,7 +342,7 @@ cases:
       longitude: -73.7562
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 39
+  - case_id_number: 39
     title: May 2024 Wisconsin
     start_date: 2024-05-18 00:00:00
     end_date: 2024-05-19 00:00:00
@@ -351,7 +351,7 @@ cases:
       longitude: -89.7373
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 40
+  - case_id_number: 40
     title: May 2024 Kansas
     start_date: 2024-05-19 00:00:00
     end_date: 2024-05-20 00:00:00
@@ -360,7 +360,7 @@ cases:
       longitude: -96.7265
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 41
+  - case_id_number: 41
     title: May 2024 Iowa + Nebraska
     start_date: 2024-05-20 00:00:00
     end_date: 2024-05-21 00:00:00
@@ -369,7 +369,7 @@ cases:
       longitude: -95.9345
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 42
+  - case_id_number: 42
     title: May 2024 Iowa + Wisconsin
     start_date: 2024-05-21 00:00:00
     end_date: 2024-05-22 00:00:00
@@ -378,7 +378,7 @@ cases:
       longitude: -90.6349
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 43
+  - case_id_number: 43
     title: May 2024 Texas
     start_date: 2024-05-22 00:00:00
     end_date: 2024-05-23 00:00:00
@@ -387,7 +387,7 @@ cases:
       longitude: -96.7970
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 44
+  - case_id_number: 44
     title: May 2024 Iowa + Nebraska 2
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-24 00:00:00
@@ -396,7 +396,7 @@ cases:
       longitude: -95.9345
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 45
+  - case_id_number: 45
     title: April 2024 Oklahoma
     start_date: 2024-04-25 12:00:00
     end_date: 2024-04-29 12:00:00
@@ -405,7 +405,7 @@ cases:
       longitude: -96.6398
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 46
+  - case_id_number: 46
     title: April 2024 Midwest
     start_date: 2024-04-02 12:00:00
     end_date: 2024-04-03 12:00:00
@@ -414,7 +414,7 @@ cases:
       longitude: -86.2816
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 47
+  - case_id_number: 47
     title: April 2024 Great Plains + Midwest
     start_date: 2024-04-01 12:00:00
     end_date: 2024-04-02 12:00:00
@@ -423,7 +423,7 @@ cases:
       longitude: -94.6208
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 48
+  - case_id_number: 48
     title: March 2024 Midwest
     start_date: 2024-03-14 12:00:00
     end_date: 2024-03-15 12:00:00
@@ -432,7 +432,7 @@ cases:
       longitude: -86.1581
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 49
+  - case_id_number: 49
     title: February 2024 Midwest
     start_date: 2024-02-27 12:00:00
     end_date: 2024-02-28 12:00:00
@@ -441,7 +441,7 @@ cases:
       longitude: -86.1581
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 50
+  - case_id_number: 50
     title: January 2024 Southeast
     start_date: 2024-01-08 12:00:00
     end_date: 2024-01-10 12:00:00
@@ -450,7 +450,7 @@ cases:
       longitude: -81.9748
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 51
+  - case_id_number: 51
     title: December 2023 South
     start_date: 2023-12-09 12:00:00
     end_date: 2023-12-10 12:00:00
@@ -459,7 +459,7 @@ cases:
       longitude: -89.5192
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 52
+  - case_id_number: 52
     title: August 2023 East Coast
     start_date: 2023-08-07 12:00:00
     end_date: 2023-08-08 12:00:00
@@ -468,7 +468,7 @@ cases:
       longitude: -79.3947
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 53
+  - case_id_number: 53
     title: August 2023 Minnesota
     start_date: 2023-08-11 12:00:00
     end_date: 2023-08-12 12:00:00
@@ -477,7 +477,7 @@ cases:
       longitude: -93.5000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 54
+  - case_id_number: 54
     title: July 2023 Midwest
     start_date: 2023-07-02 12:00:00
     end_date: 2023-07-03 12:00:00
@@ -486,7 +486,7 @@ cases:
       longitude: -82.5943
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 55
+  - case_id_number: 55
     title: July 2023 Midwest 2
     start_date: 2023-07-01 12:00:00
     end_date: 2023-07-02 12:00:00
@@ -495,7 +495,7 @@ cases:
       longitude: -88.7342
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 56
+  - case_id_number: 56
     title: June 2023 Midwest
     start_date: 2023-06-30 12:00:00
     end_date: 2023-07-01 12:00:00
@@ -504,7 +504,7 @@ cases:
       longitude: -92.1735
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 57
+  - case_id_number: 57
     title: June 2023 Front Range
     start_date: 2023-06-21 12:00:00
     end_date: 2023-06-22 12:00:00
@@ -513,7 +513,7 @@ cases:
       longitude: -104.9903
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 58
+  - case_id_number: 58
     title: June 2023 Texas
     start_date: 2023-06-21 12:00:00
     end_date: 2023-06-22 12:00:00
@@ -522,7 +522,7 @@ cases:
       longitude: -99.7970
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 59
+  - case_id_number: 59
     title: June 2023 Great Plains
     start_date: 2023-06-23 12:00:00
     end_date: 2023-06-24 12:00:00
@@ -531,7 +531,7 @@ cases:
       longitude: -103.5000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 60
+  - case_id_number: 60
     title: June 2023 Iowa + Minnesota
     start_date: 2023-06-24 12:00:00
     end_date: 2023-06-25 12:00:00
@@ -540,7 +540,7 @@ cases:
       longitude: -93.5000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 61
+  - case_id_number: 61
     title: June 2023 South + Midwest
     start_date: 2023-06-25 12:00:00
     end_date: 2023-06-26 12:00:00
@@ -549,7 +549,7 @@ cases:
       longitude: -88.2700
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 62
+  - case_id_number: 62
     title: June 2023 East Coast
     start_date: 2023-06-26 12:00:00
     end_date: 2023-06-27 12:00:00
@@ -558,7 +558,7 @@ cases:
       longitude: -78.8743
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 63
+  - case_id_number: 63
     title: June 2023 Midwest + Great Plains
     start_date: 2023-06-29 12:00:00
     end_date: 2023-06-30 12:00:00
@@ -567,7 +567,7 @@ cases:
       longitude: -89.0000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 64
+  - case_id_number: 64
     title: June 2023 Southeast
     start_date: 2023-06-14 12:00:00
     end_date: 2023-06-15 12:00:00
@@ -576,7 +576,7 @@ cases:
       longitude: -88.4700
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 65
+  - case_id_number: 65
     title: June 2023 OK + TX + South
     start_date: 2023-06-15 12:00:00
     end_date: 2023-06-16 12:00:00
@@ -585,7 +585,7 @@ cases:
       longitude: -94.0000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 66
+  - case_id_number: 66
     title: June 2023 South
     start_date: 2023-06-16 12:00:00
     end_date: 2023-06-17 12:00:00
@@ -594,7 +594,7 @@ cases:
       longitude: -88.5000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 67
+  - case_id_number: 67
     title: June 2023 Mid-Atlantic
     start_date: 2023-06-16 12:00:00
     end_date: 2023-06-17 12:00:00
@@ -603,7 +603,7 @@ cases:
       longitude: -77.0369
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 68
+  - case_id_number: 68
     title: June 2023 Great Plains + South
     start_date: 2023-06-17 12:00:00
     end_date: 2023-06-18 12:00:00
@@ -612,7 +612,7 @@ cases:
       longitude: -95.3700
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 69
+  - case_id_number: 69
     title: May 2023 Great Plains
     start_date: 2023-05-10 12:00:00
     end_date: 2023-05-11 12:00:00
@@ -621,7 +621,7 @@ cases:
       longitude: -102.0500
     bounding_box_degrees: 6
     event_type: severe_day
-  - id: 70
+  - case_id_number: 70
     title: May 2023 Great Plains + South
     start_date: 2023-05-11 12:00:00
     end_date: 2023-05-12 12:00:00
@@ -630,7 +630,7 @@ cases:
       longitude: -97.5350
     bounding_box_degrees: 8
     event_type: severe_day
-  - id: 71
+  - case_id_number: 71
     title: May 2023 Nebraska
     start_date: 2023-05-12 12:00:00
     end_date: 2023-05-13 12:00:00
@@ -639,7 +639,7 @@ cases:
       longitude: -96.0000
     bounding_box_degrees: 5
     event_type: severe_day
-  - id: 72
+  - case_id_number: 72
     title: May 2024 Texas
     start_date: 2024-05-25 00:00:00
     end_date: 2024-05-28 00:00:00
@@ -648,7 +648,7 @@ cases:
       longitude: -97.4974
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 73
+  - case_id_number: 73
     title: June 2024 Northeast US
     start_date: 2024-06-17 00:00:00
     end_date: 2024-06-22 00:00:00
@@ -657,7 +657,7 @@ cases:
       longitude: -73.2290
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 74
+  - case_id_number: 74
     title: July 2024 Southwest US
     start_date: 2024-07-04 00:00:00
     end_date: 2024-07-08 00:00:00
@@ -666,7 +666,7 @@ cases:
       longitude: -116.2146
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 75
+  - case_id_number: 75
     title: July 2024 Northeast US
     start_date: 2024-07-07 00:00:00
     end_date: 2024-07-10 00:00:00
@@ -675,7 +675,7 @@ cases:
       longitude: -74.0060
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 76
+  - case_id_number: 76
     title: July 2024 Mid-Atlantic US
     start_date: 2024-07-15 00:00:00
     end_date: 2024-07-20 00:00:00
@@ -684,7 +684,7 @@ cases:
       longitude: -75.1652
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 77
+  - case_id_number: 77
     title: August 2024 Midwest US
     start_date: 2024-08-25 00:00:00
     end_date: 2024-08-31 00:00:00
@@ -693,7 +693,7 @@ cases:
       longitude: -88.2073
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 78
+  - case_id_number: 78
     title: July 2024 Antarctica
     start_date: 2024-07-01 00:00:00
     end_date: 2024-07-31 00:00:00
@@ -702,7 +702,7 @@ cases:
       longitude: 15.0000
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 79
+  - case_id_number: 79
     title: August 2024 Canada
     start_date: 2024-08-09 00:00:00
     end_date: 2024-08-11 00:00:00
@@ -711,7 +711,7 @@ cases:
       longitude: -112.0000
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 80
+  - case_id_number: 80
     title: August 2024 Australia
     start_date: 2024-08-22 00:00:00
     end_date: 2024-08-30 00:00:00
@@ -720,7 +720,7 @@ cases:
       longitude: 120.0000
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 81
+  - case_id_number: 81
     title: July/August 2024 Japan
     start_date: 2024-07-25 00:00:00
     end_date: 2024-08-05 00:00:00
@@ -729,7 +729,7 @@ cases:
       longitude: 138.0000
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 82
+  - case_id_number: 82
     title: June 2024 Saudi Arabia
     start_date: 2024-06-16 00:00:00
     end_date: 2024-06-18 00:00:00
@@ -738,7 +738,7 @@ cases:
       longitude: 45.0000
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 83
+  - case_id_number: 83
     title: August 2024 Europe
     start_date: 2024-08-10 00:00:00
     end_date: 2024-08-15 00:00:00
@@ -747,7 +747,7 @@ cases:
       longitude: 10.8978
     bounding_box_degrees: 10
     event_type: heat_wave
-  - id: 84
+  - case_id_number: 84
     title: July 2024 Ukraine
     start_date: 2024-07-12 00:00:00
     end_date: 2024-07-16 00:00:00
@@ -756,7 +756,7 @@ cases:
       longitude: 30.5234
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 85
+  - case_id_number: 85
     title: June 2024 Europe
     start_date: 2024-06-20 00:00:00
     end_date: 2024-06-30 00:00:00
@@ -765,7 +765,7 @@ cases:
       longitude: 4.9041
     bounding_box_degrees: 6
     event_type: heat_wave
-  - id: 86
+  - case_id_number: 86
     title: May 2024 Central Mexico
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
@@ -774,7 +774,7 @@ cases:
       longitude: -99.1332
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 87
+  - case_id_number: 87
     title: May 2024 Pakistan/India
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
@@ -783,7 +783,7 @@ cases:
       longitude: 76.0000
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 88
+  - case_id_number: 88
     title: August 2023 Chile
     start_date: 2023-08-01 00:00:00
     end_date: 2023-08-03 00:00:00
@@ -792,7 +792,7 @@ cases:
       longitude: -70.6693
     bounding_box_degrees: 5
     event_type: heat_wave
-  - id: 89
+  - case_id_number: 89
     title: January 2024 Pacific Northwest
     start_date: 2024-01-11 12:00:00
     end_date: 2024-01-20 00:00:00
@@ -801,7 +801,7 @@ cases:
       longitude: -122.3321
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 90
+  - case_id_number: 90
     title: April 2022 Nevada
     start_date: 2022-04-11 18:00:00
     end_date: 2022-04-16 12:00:00
@@ -810,7 +810,7 @@ cases:
       longitude: -115.7631
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 91
+  - case_id_number: 91
     title: February/March 2021 New England
     start_date: 2021-03-04 18:00:00
     end_date: 2021-03-09 06:00:00
@@ -819,7 +819,7 @@ cases:
       longitude: -72.5579
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 92
+  - case_id_number: 92
     title: January 2024 Northern Europe
     start_date: 2024-01-01 06:00:00
     end_date: 2024-01-09 12:00:00
@@ -828,7 +828,7 @@ cases:
       longitude: 18.0686
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 93
+  - case_id_number: 93
     title: December 2022 Europe
     start_date: 2022-12-10 06:00:00
     end_date: 2022-12-20 00:00:00
@@ -837,7 +837,7 @@ cases:
       longitude: 13.4050
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 94
+  - case_id_number: 94
     title: April 2024 Europe
     start_date: 2024-04-16 12:00:00
     end_date: 2024-04-27 12:00:00
@@ -846,7 +846,7 @@ cases:
       longitude: 2.3522
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 95
+  - case_id_number: 95
     title: January 2023 North China
     start_date: 2024-01-20 00:00:00
     end_date: 2024-02-04 18:00:00
@@ -855,7 +855,7 @@ cases:
       longitude: 122.3853
     bounding_box_degrees: 5
     event_type: freeze
-  - id: 96
+  - case_id_number: 96
     title: April 2024 Sweden
     start_date: 2024-04-02 00:00:00
     end_date: 2024-04-07 12:00:00

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,13 +1,15 @@
+import datetime
+
 import pytest
+
 import extremeweatherbench.case as case
 from extremeweatherbench.utils import Location
-import datetime
 
 
 class TestGoodCases:
     def test_perform_subsetting_procedure_heatwave(self, sample_forecast_dataset):
         heatwave_case = case.IndividualHeatWaveCase(
-            id=20,
+            case_id_number=20,
             title="Test Heatwave",
             start_date=datetime.datetime(2000, 1, 1),
             end_date=datetime.datetime(2000, 1, 14),
@@ -23,7 +25,7 @@ class TestGoodCases:
 
     def test_individual_case(self, sample_forecast_dataset):
         base_case = case.IndividualCase(
-            id=10,
+            case_id_number=10,
             title="Test Case",
             start_date=datetime.datetime(2000, 1, 1),
             end_date=datetime.datetime(2000, 1, 14),
@@ -32,7 +34,7 @@ class TestGoodCases:
             event_type="heat_wave",
         )
         valid_case = {
-            "id": 10,
+            "case_id_number": 10,
             "title": "Test Case",
             "start_date": datetime.datetime(2000, 1, 1),
             "end_date": datetime.datetime(2000, 1, 14),

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,9 +1,11 @@
-import pytest
-from extremeweatherbench import case, evaluate, events
 import datetime
-import xarray as xr
+
 import numpy as np
 import pandas as pd
+import pytest
+import xarray as xr
+
+from extremeweatherbench import case, evaluate, events
 
 
 def test_get_case_metadata(sample_config):
@@ -14,7 +16,7 @@ def test_get_case_metadata(sample_config):
 
 def test_evaluate_individualcase(sample_forecast_dataset, sample_gridded_obs_dataset):
     base_case = case.IndividualCase(
-        id=1,
+        case_id_number=1,
         title="test_case",
         start_date=datetime.datetime(2021, 6, 20),
         end_date=datetime.datetime(2021, 7, 3),
@@ -87,7 +89,7 @@ def test_case_evaluation_data_init(mocker):
 def test_check_and_subset_forecast_availability(mocker):
     """Test _check_and_subset_forecast_availability function."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = "99"
+    mock_case.case_id_number = "99"
     mock_case.data_vars = ["surface_air_temperature"]
     mock_case.start_date = datetime.datetime(2021, 6, 20)
     mock_case.end_date = datetime.datetime(2021, 6, 25)
@@ -130,7 +132,7 @@ def test_check_and_subset_forecast_availability(mocker):
 def test_check_and_subset_forecast_availability_empty(mocker):
     """Test _check_and_subset_forecast_availability function with empty forecast."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = "test_case"
+    mock_case.case_id_number = "test_case"
     mock_case._subset_valid_times.return_value = mocker.MagicMock(spec=xr.Dataset)
     mock_case._subset_valid_times.return_value.init_time = []
     mock_case.start_date = datetime.datetime(2021, 6, 20)
@@ -155,7 +157,7 @@ def test_build_dataset_subsets_with_existing_forecast(
     """Test build_dataset_subsets with an existing forecast dataset."""
     # Create a mock case
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = "test_case"
+    mock_case.case_id_number = "test_case"
     mock_case.data_vars = "2m_temperature"
     mock_case.start_date = datetime.datetime(2021, 6, 20)
     mock_case.end_date = datetime.datetime(2021, 6, 25)
@@ -207,7 +209,7 @@ def test_build_dataset_subsets_with_existing_forecast(
 def test_build_dataarray_subsets_no_forecast(mocker):
     """Test build_dataarray_subsets with no forecast data."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = "test_case"
+    mock_case.case_id_number = "test_case"
     mock_case.data_vars = "2m_temperature"
 
     mock_forecast = mocker.MagicMock(spec=xr.Dataset)
@@ -237,7 +239,7 @@ def test_build_dataarray_subsets_gridded(
 ):
     """Test build_dataarray_subsets with gridded observation data."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = "test_case"
+    mock_case.case_id_number = "test_case"
     mock_case.data_vars = "2m_temperature"
     mock_case.start_date = datetime.datetime(2021, 6, 20)
     mock_case.end_date = datetime.datetime(2021, 6, 25)
@@ -281,7 +283,7 @@ def test_build_dataarray_subsets_point(
 ):
     """Test build_dataarray_subsets with point observation data."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = 1  # Match the ID in sample_point_obs_df
+    mock_case.case_id_number = 1  # Match the ID in sample_point_obs_df
     mock_case.data_vars = "surface_air_temperature"
 
     case_eval_data = evaluate.CaseEvaluationData(
@@ -323,7 +325,7 @@ def test_subset_gridded_obs(
 ):
     """Test _subset_gridded_obs function."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = 99
+    mock_case.case_id_number = 99
     mock_case.start_date = datetime.datetime(2021, 6, 20)
     mock_case.end_date = datetime.datetime(2021, 6, 25)
     mock_case.data_vars = "2m_temperature"
@@ -351,7 +353,7 @@ def test_subset_point_obs(
 ):
     """Test _subset_point_obs function."""
     mock_case = mocker.MagicMock(spec=case.IndividualCase)
-    mock_case.id = 1
+    mock_case.case_id_number = 1
     mock_case.start_date = datetime.datetime(2021, 6, 20)
     mock_case.end_date = datetime.datetime(2021, 6, 25)
     mock_case.data_vars = ["surface_air_temperature"]


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR changes the case "id" field and variable, an integer value used to refer simplistically to a case, to "case_id_number". This serves two distinct purposes: it makes an ambiguous name more explicit, and avoids conflict with the `id` builtin function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

All pytest suite was run to confirm no issues or conflicts within the library.