### PR TITLE
Manage longitude conversions and plotting

### DIFF
--- a/src/extremeweatherbench/regions.py
+++ b/src/extremeweatherbench/regions.py
@@ -42,16 +42,6 @@ class Region(ABC):
         mask_array = ~np.isnan(mask)
         return dataset.where(mask_array, drop=drop)
 
-    @property
-    def _lon_as_180(self) -> float:
-        """Return the longitude in the -180 to 180 degree range."""
-        return utils.convert_longitude_to_180(self.longitude)
-
-    @property
-    def _lon_as_360(self) -> float:
-        """Return the longitude in the 0-360 degree range."""
-        return utils.convert_longitude_to_360(self.longitude)
-
 
 class CenteredRegion(Region):
     """A region defined by a center point and a bounding box.


### PR DESCRIPTION
# EWB Pull Request

## Description

When dealing with longitude conversions, geopandas + shapely geometries have an inherent problem at either the prime or anti meridian, depending on whether the system is in 0-360 or -180-180, respectively. Shapely operates exclusively on cartesian coordinates and is not aware of longitude wrapping on a sphere.

To fix this, we introduce an opinionated set of behaviors:

1. All inputs are converted to 0-360 for consistency when diagnosing the created regions via text outputs.

2. When the geopandas accessor is called, it automatically converts longitudes to -180-180. If the outputs cross the antimeridian, the polygon is split into a multipolygon for correct plotting in cartopy/matplotlib/etc. 

Note: `regionmask` handles the longitudes automatically when creating the mask, making the coordinate systems a moot point when using `.mask`, as it accesses the GeoDataframe for the mask on the xarray Dataset.
