### PR TITLE
Targets ABC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ dependencies = [
     "tqdm>=4.67.1",
     "ujson>=5.10.0",
     "xarray[io]>=2024.11.0",
-    "zarr>=3.0.2",
+    "zarr==3.0.9",
     "kerchunk[dev]",
     "flox>=0.10.0",
     "click>=8.1.8",
+    "polars>=1.32.0",
 ]
 
 [project.optional-dependencies]

--- a/src/extremeweatherbench/targets.py
+++ b/src/extremeweatherbench/targets.py
@@ -136,7 +136,7 @@ class TargetBase(ABC):
                 case=case,
             )
             # converts the target data to an xarray dataset if it is not already
-            .pipe(self._maybe_convert_to_dataset)
+            .pipe(self.maybe_convert_to_dataset)
             # derives variables from the target data if derived variables are defined
             .pipe(derived.maybe_derive_variables, variables=case.target_variables)
         )

--- a/src/extremeweatherbench/targets.py
+++ b/src/extremeweatherbench/targets.py
@@ -1,0 +1,137 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import xarray as xr
+
+from extremeweatherbench import derived  # type: ignore
+from extremeweatherbench.case import CaseOperator
+
+# will be an import from derived once it is implemented
+from extremeweatherbench.utils import IncomingDataInput, maybe_map_variable_names
+
+
+class TargetBase(ABC):
+    """
+    An abstract base class for target data.
+
+    A TargetBase is data that acts as the "truth" for a case. It can be a gridded dataset,
+    a point observation dataset, or any other reference dataset. Targets in EWB
+    are not required to be the same variable as the forecast dataset, but they must be in the
+    same coordinate system for evaluation.
+    """
+
+    source: str
+
+    @abstractmethod
+    def open_data_from_source(
+        self, storage_options: Optional[dict] = None
+    ) -> IncomingDataInput:
+        """
+        Open the target data from the source, opting to avoid loading the entire dataset into memory if possible.
+
+        Args:
+            source: The source of the observation data, which can be a local path or a remote URL.
+            storage_options: Optional storage options for the source if the source is a remote URL.
+
+        Returns:
+            The target data with a type determined by the user.
+        """
+
+    @abstractmethod
+    def subset_data_to_case(
+        self,
+        data: IncomingDataInput,
+        case: CaseOperator,
+    ) -> IncomingDataInput:
+        """
+        Subset the target data to the case information provided in CaseOperator.
+
+        Time information, spatial bounds, and variables are captured in the case metadata
+        where this method is used to subset.
+
+        Args:
+            data: The observation data to subset, which should be a xarray dataset, xarray dataarray, polars lazyframe,
+            pandas dataframe, or numpy array.
+            case: The case operator to subset the data to; includes time information, spatial bounds, and variables.
+
+        Returns:
+            The target data with the variables subset to the case metadata.
+        """
+
+    @abstractmethod
+    def maybe_convert_to_dataset(self, data: IncomingDataInput) -> xr.Dataset:
+        """
+        Abstract method to convert the target data to an xarray dataset.
+
+        In the case of a target object already being a dataset, this method should return the data unchanged.
+        Some data, such as a LazyFrame or DataFrame, could have more complex steps to convert to a dataset
+        with the proper dimensions; this method is primarily used to handle these cases.
+
+        Args:
+            data: The target data already run through _subset_data_to_case.
+
+        Returns:
+            The target data as an xarray dataset.
+        """
+        pass
+
+    def _maybe_convert_to_dataset(self, data: IncomingDataInput) -> xr.Dataset:
+        """
+        Convert the target data to an xarray dataset if it is not already.
+
+        Args:
+            data: The target data already run through
+
+        Returns:
+            The target data as an xarray dataset.
+        """
+        if isinstance(data, xr.Dataset):
+            return data
+        elif isinstance(data, xr.DataArray):
+            return data.to_dataset()
+        else:
+            return self._maybe_convert_to_dataset(data)
+
+    def run_pipeline(
+        self,
+        case: CaseOperator,
+        target_storage_options: Optional[dict] = None,
+        target_variable_mapping: dict = {},
+    ) -> xr.Dataset:
+        """
+        Shared method for running the target pipeline.
+
+        Args:
+            source: The source of the target data, which can be a local path or a remote URL.
+            storage_options: Optional storage options for the source if the source is a remote URL.
+            target_variables: The variables to include in the target. Some target objects may not have variables, or
+            only have a singular variable; thus, this is optional.
+            target_variable_mapping: A dictionary of variable names to map to the target data.
+            **kwargs: Additional keyword arguments to pass in as needed.
+
+        Returns:
+            The target data with a type determined by the user.
+        """
+
+        # Open data and process through pipeline steps
+        data = (
+            # opens data from user-defined source
+            self.open_data_from_source(
+                storage_options=target_storage_options,
+            )
+            # maps variable names to the target data if not already using EWB naming conventions
+            .pipe(
+                maybe_map_variable_names,
+                variable_mapping=target_variable_mapping,
+            )
+            # subsets the target data to the case information
+            .pipe(
+                self.subset_data_to_case,
+                case=case,
+            )
+            # converts the target data to an xarray dataset if it is not already
+            .pipe(self._maybe_convert_to_dataset)
+            # derives variables from the target data if derived variables are defined
+            .pipe(derived.maybe_derive_variables, variables=case.target_variables)
+        )
+        return data

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -893,6 +893,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "regionmask" },
@@ -947,6 +948,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "polars", specifier = ">=1.32.0" },
     { name = "pyarrow", specifier = ">=19.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "regionmask", specifier = ">=0.13.0" },
@@ -957,7 +959,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "ujson", specifier = ">=5.10.0" },
     { name = "xarray", extras = ["io"], specifier = ">=2024.11.0" },
-    { name = "zarr", specifier = ">=3.0.2" },
+    { name = "zarr", specifier = "==3.0.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -1376,7 +1378,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2186,6 +2188,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "polars"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/23/6a5f151981f3ac409bed6dc48a3eaecd0592a03eb382693d4c7e749eda8b/polars-1.32.0.tar.gz", hash = "sha256:b01045981c0f23eeccfbfc870b782f93e73b74b29212fdfc8aae0be9024bc1fb", size = 4761045 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/40/5b27067d10b5a77ab4094932118e16629ffb20ea9ae5f7d1178e04087891/polars-1.32.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:94f7c6a3b30bc99bc6b682ea42bb1ae983e33a302ca21aacbac50ae19e34fcf2", size = 37479518 },
+    { url = "https://files.pythonhosted.org/packages/08/b7/ca28ac10d340fb91bffb2751efd52aebc9799ae161b867214c6299c8f75b/polars-1.32.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8bf14c16164839e62c741a863942a94a9a463db21e797452fca996c8afaf8827", size = 34214196 },
+    { url = "https://files.pythonhosted.org/packages/61/97/fe3797e8e1d4f9eadab32ffe218a841b8874585b6c9bd0f1a26469fb2992/polars-1.32.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4c15adb97d44766d30c759f5cebbdb64d361e8349ef10b5afc7413f71bf4b72", size = 37985353 },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/2baa2858556e970cc6a35c0d8ad34b2f9d982f1766c0a1fec20ca529a947/polars-1.32.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:13af55890734f89b76016a395fb2e7460e7d9feecf50ed2f55cf0f05a1c0c991", size = 35183912 },
+    { url = "https://files.pythonhosted.org/packages/ef/41/0e6821dccc5871186a9b95af3990404aa283318263918d33ac974b35cb37/polars-1.32.0-cp39-abi3-win_amd64.whl", hash = "sha256:0397fc2501a5d5f1bb3fe8d27e0c26c7a5349b4110157c0fb7833cd3f5921c9e", size = 37747905 },
+    { url = "https://files.pythonhosted.org/packages/c2/93/d06df0817da93f922a67e27e9e0f407856991374daa62687e2a45a18935c/polars-1.32.0-cp39-abi3-win_arm64.whl", hash = "sha256:dd84e24422509e1ec9be46f67f758d0bd9944d1ae4eacecee4f53adaa8ecd822", size = 33978543 },
 ]
 
 [[package]]
@@ -3073,7 +3089,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
@@ -3364,7 +3380,7 @@ wheels = [
 
 [[package]]
 name = "zarr"
-version = "3.0.2"
+version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "donfig" },
@@ -3373,9 +3389,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/3b/8b7f89229d010d3b7c90893b85dde006cf69b097a5c9deb720abdeb469ab/zarr-3.0.2.tar.gz", hash = "sha256:036b2dabffa9f0148cad57a7be6c69d9761f6b3b833b61b7d29c2ee8a836b46c", size = 220048 }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5c/8f7875034629ce58adb7724acf64b06fc4b933e30978faf1b8d72ba28267/zarr-3.0.9.tar.gz", hash = "sha256:7635084efec55511d2940975528c42b8885634fb09e7ab75591a980122950d1e", size = 263587 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/83/4316503558c57a2d1928afaf0e77f47cf00d394347c88aaafbf0efaf5685/zarr-3.0.2-py3-none-any.whl", hash = "sha256:cd57949934a339cddc4853c0e819fd7f8e0370022e8eeddec2e56a6b13dc5021", size = 184410 },
+    { url = "https://files.pythonhosted.org/packages/54/69/9d703fee22236dc8c610eb6d728f102340fb8a1dfb4ae649564d77c6fb79/zarr-3.0.9-py3-none-any.whl", hash = "sha256:90775a238a56f98b79d0a9853a04b5ba6236f643c7c8560740583126a409b529", size = 209583 },
 ]
 
 [[package]]


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR establishes the ABC for target data. I decided on renaming the convention to targets as observations isn't necessarily accurate when including reanalysis data and indirect analytical datasets like practically perfect hindcasts.

The intention of the ABC is to establish an opinionated and easy to extend flow:

1. Define the source for an xarray, pandas, or polars based data object

2. Align the naming convention with EWB's so targets and forecasts are eventually standardized into the same variable names

3. Use the CaseOperator's metadata to subset time, space, and variables if needed

4. Convert the incoming data into an xarray dataset

5. Derive any variables part of the evaluation

The pipeline requires functions to be defined to open the source data, subset the data using the case metadata, and convert to dataset (or passthrough if it is already).

This should provide a middle ground between flexibility and simplicity. The abstractmethods can include more arguments if needed.