### PR TITLE
Enhancement/handling-no-data-in-forecast

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -234,10 +234,13 @@ def _build_datasets(
     """
     logger.info("running forecast pipeline")
     forecast_ds = run_pipeline(case_operator, "forecast")
-    if len(forecast_ds.valid_time) == 0:
+
+    # Check if any dimension has zero length
+    zero_length_dims = [dim for dim, size in forecast_ds.sizes.items() if size == 0]
+    if zero_length_dims:
         logger.warning(
             f"forecast dataset for case {case_operator.case_metadata.case_id_number} "
-            f"has no valid times for case time range "
+            f"has zero-length dimensions {zero_length_dims} for case time range "
             f"{case_operator.case_metadata.start_date} to "
             f"{case_operator.case_metadata.end_date}"
         )

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -19,6 +19,16 @@ if TYPE_CHECKING:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+OUTPUT_COLUMNS = [
+    "value",
+    "target_variable",
+    "metric",
+    "target_source",
+    "forecast_source",
+    "case_id_number",
+    "event_type",
+]
+
 
 class ExtremeWeatherBench:
     """A class to run the ExtremeWeatherBench workflow.
@@ -85,17 +95,7 @@ class ExtremeWeatherBench:
             return pd.concat(run_results, ignore_index=True)
         else:
             # Return empty DataFrame with expected columns
-            return pd.DataFrame(
-                columns=[
-                    "value",
-                    "target_variable",
-                    "metric",
-                    "target_source",
-                    "forecast_source",
-                    "case_id_number",
-                    "event_type",
-                ]
-            )
+            return pd.DataFrame(columns=OUTPUT_COLUMNS)
 
 
 def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
@@ -168,17 +168,7 @@ def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
         return pd.concat(results, ignore_index=True)
     else:
         # Return empty DataFrame with expected columns
-        return pd.DataFrame(
-            columns=[
-                "value",
-                "target_variable",
-                "metric",
-                "target_source",
-                "forecast_source",
-                "case_id_number",
-                "event_type",
-            ]
-        )
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
 
 
 def _evaluate_metric_and_return_df(

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Columns for the evaluation output dataframe
 OUTPUT_COLUMNS = [
     "value",
     "target_variable",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -493,6 +493,46 @@ class TestComputeCaseOperator:
                 assert mock_evaluate.call_count == 2
                 assert len(result) == 2
 
+    @patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_empty_forecast_dataset(
+        self, mock_build_datasets, sample_case_operator
+    ):
+        """Test compute_case_operator when _build_datasets returns empty forecast
+        dataset."""
+        # Mock _build_datasets to return empty datasets (simulating zero valid times)
+        empty_forecast_ds = xr.Dataset()
+        empty_target_ds = xr.Dataset()
+        mock_build_datasets.return_value = (empty_forecast_ds, empty_target_ds)
+
+        result = evaluate.compute_case_operator(sample_case_operator)
+
+        # Should return empty DataFrame with correct columns
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+        assert list(result.columns) == evaluate.OUTPUT_COLUMNS
+
+        # _build_datasets should be called, but no further processing should occur
+        mock_build_datasets.assert_called_once_with(sample_case_operator)
+
+    @patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_empty_target_dataset(
+        self, mock_build_datasets, sample_case_operator, sample_forecast_dataset
+    ):
+        """Test compute_case_operator when _build_datasets returns empty
+        target dataset."""
+        # Mock _build_datasets to return empty target dataset
+        empty_target_ds = xr.Dataset()
+        mock_build_datasets.return_value = (sample_forecast_dataset, empty_target_ds)
+
+        result = evaluate.compute_case_operator(sample_case_operator)
+
+        # Should return empty DataFrame with correct columns
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+        assert list(result.columns) == evaluate.OUTPUT_COLUMNS
+
+        mock_build_datasets.assert_called_once_with(sample_case_operator)
+
 
 # =============================================================================
 # Test Pipeline Functions

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -918,7 +918,9 @@ class TestIntegration:
         )
 
         # Mock the pipeline methods to return our test datasets
-        sample_evaluation_object.forecast.open_and_maybe_preprocess_data_from_source.return_value = sample_forecast_dataset
+        sample_evaluation_object.forecast.open_and_maybe_preprocess_data_from_source.return_value = (  # noqa: E501
+            sample_forecast_dataset
+        )
         sample_evaluation_object.forecast.maybe_map_variable_names.return_value = (
             sample_forecast_dataset
         )
@@ -932,7 +934,9 @@ class TestIntegration:
             sample_forecast_dataset
         )
 
-        sample_evaluation_object.target.open_and_maybe_preprocess_data_from_source.return_value = sample_target_dataset  # noqa: E501
+        sample_evaluation_object.target.open_and_maybe_preprocess_data_from_source.return_value = (  # noqa: E501
+            sample_target_dataset
+        )
         sample_evaluation_object.target.maybe_map_variable_names.return_value = (
             sample_target_dataset
         )


### PR DESCRIPTION
# EWB Pull Request

## Description
When there's no valid forecast data, the code will eventually ungracefully fail out somewhere downstream when a valid_time calculation is required. 

This PR fixes this by skipping when there's such missing data, or if a dimension ended up with size 0.