### PR TITLE
add input type attribute + tests

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -176,7 +176,15 @@ class InputBase(ABC):
         )
 
     def add_source_to_dataset_attrs(self, ds: xr.Dataset) -> xr.Dataset:
-        """Add the name of the dataset to the dataset attributes."""
+        """Add the name and type of the dataset to the dataset attributes."""
+        # Check if this instance is a ForecastBase or TargetBase subclass
+        if isinstance(self, ForecastBase):
+            ds.attrs["dataset_type"] = "forecast"
+        elif isinstance(self, TargetBase):
+            ds.attrs["dataset_type"] = "target"
+        else:
+            # Fallback to class name for other InputBase subclasses
+            ds.attrs["dataset_type"] = self.__class__.__name__
         ds.attrs["source"] = self.name
         return ds
 


### PR DESCRIPTION
# EWB Pull Request

## Description

Adds an extra attribute to incoming xarray datasets - input type. 

If it's a target, it'll be `ds.attrs['data_type'] = 'target'`. 

If it's a forecast, `ds.attrs['data_type'] = 'forecast'`. 

If it's neither (if a user creates a new child class, for example), it will be marked as 'unknown' unless changed in the function.