### PR TITLE
Clarify naming for metric vars

### DIFF
--- a/docs/examples/applied_ar.py
+++ b/docs/examples/applied_ar.py
@@ -73,7 +73,7 @@ hres_forecast = inputs.ZarrForecast(
 ar_metric_list = [
     inputs.EvaluationObject(
         event_type="atmospheric_river",
-        metric=[
+        metric_list=[
             metrics.MAE,
         ],
         target=era5_target,

--- a/docs/examples/applied_ghcn.py
+++ b/docs/examples/applied_ghcn.py
@@ -34,7 +34,7 @@ hres_forecast = inputs.ZarrForecast(
 heatwave_metric_list = [
     inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,

--- a/docs/examples/applied_heatwave.py
+++ b/docs/examples/applied_heatwave.py
@@ -66,7 +66,7 @@ hres_forecast = inputs.ZarrForecast(
 heatwave_metric_list = [
     inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -78,7 +78,7 @@ heatwave_metric_list = [
     ),
     # rs.EvaluationObject(
     #     event_type="heat_wave",
-    #     metric=[
+    #     metric_list=[
     #         crs.MaximumMAE,
     #         crs.RMSE,
     #         crs.OnsetME,

--- a/docs/examples/applied_heatwave_parallel.py
+++ b/docs/examples/applied_heatwave_parallel.py
@@ -99,7 +99,7 @@ cira_forecast_config = config.ForecastConfig(
 heatwave_metric_list = [
     config.MetricEvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -111,7 +111,7 @@ heatwave_metric_list = [
     ),
     # rs.MetricEvaluationObject(
     #     event_type="heat_wave",
-    #     metric=[
+    #     metric_list=[
     #         crs.MaximumMAE,
     #         crs.RMSE,
     #         crs.OnsetME,

--- a/docs/examples/applied_tc.py
+++ b/docs/examples/applied_tc.py
@@ -18,7 +18,6 @@
 import logging
 
 # %%
-
 # %%
 from extremeweatherbench import derived, evaluate, inputs, metrics, utils
 
@@ -64,7 +63,7 @@ hres_forecast = inputs.ZarrForecast(
 tc_metric_list = [
     inputs.EvaluationObject(
         event_type="tropical_cyclone",
-        metric=[
+        metric_list=[
             metrics.MAE,
         ],
         target=ibtracs_target,

--- a/docs/examples/example_config.py
+++ b/docs/examples/example_config.py
@@ -33,7 +33,7 @@ custom_forecast = inputs.KerchunkForecast(
 evaluation_objects = [
     inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,

--- a/src/extremeweatherbench/cases.py
+++ b/src/extremeweatherbench/cases.py
@@ -7,7 +7,7 @@ import dataclasses
 import datetime
 import itertools
 import logging
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Callable, Union
 
 import dacite
 
@@ -68,7 +68,7 @@ class CaseOperator:
     """
 
     case_metadata: IndividualCase
-    metric_list: list[Union["metrics.BaseMetric", "metrics.AppliedMetric"]]
+    metric_list: list[Union[Callable, "metrics.BaseMetric", "metrics.AppliedMetric"]]
     target: "inputs.TargetBase"
     forecast: "inputs.ForecastBase"
 

--- a/src/extremeweatherbench/cases.py
+++ b/src/extremeweatherbench/cases.py
@@ -1,13 +1,13 @@
 """Classes for defining individual units of case studies for analysis.
 
-Some code similarly structured to WeatherBench (Rasp et al.).
+Some code similarly structured to WeatherBenchX (Rasp et al.).
 """
 
 import dataclasses
 import datetime
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import dacite
 
@@ -62,13 +62,13 @@ class CaseOperator:
 
     Attributes:
         case_metadata: IndividualCase metadata
-        metric: A metric that is intended to be evaluated for the case
+        metric_list: A list of metrics that are intended to be evaluated for the case
         target_config: A TargetConfig object
         forecast_config: A ForecastConfig object
     """
 
     case_metadata: IndividualCase
-    metric: "metrics.BaseMetric"
+    metric_list: list[Union["metrics.BaseMetric", "metrics.AppliedMetric"]]
     target: "inputs.TargetBase"
     forecast: "inputs.ForecastBase"
 
@@ -108,7 +108,7 @@ def build_case_operators(
             case_operators.append(
                 CaseOperator(
                     case_metadata=single_case,
-                    metric=metric_evaluation_object.metric,
+                    metric_list=metric_evaluation_object.metric_list,
                     target=metric_evaluation_object.target,
                     forecast=metric_evaluation_object.forecast,
                 )

--- a/src/extremeweatherbench/cases.py
+++ b/src/extremeweatherbench/cases.py
@@ -75,13 +75,13 @@ class CaseOperator:
 
 def build_case_operators(
     cases_dict: dict[str, list],
-    metric_evaluation_objects: list["inputs.EvaluationObject"],
+    evaluation_objects: list["inputs.EvaluationObject"],
 ) -> list[CaseOperator]:
     """Build a CaseOperator from the case metadata and metric evaluation objects.
 
     Args:
         cases_dict: The case metadata to use for the case operators.
-        metric_evaluation_objects: The metric evaluation objects to use for the
+        evaluation_objects: The evaluation objects to use for the
             case operators.
 
     Returns:
@@ -100,17 +100,17 @@ def build_case_operators(
 
     # build list of case operators based on information provided in case dict and
     case_operators = []
-    for single_case, metric_evaluation_object in itertools.product(
-        case_metadata_collection.cases, metric_evaluation_objects
+    for single_case, evaluation_object in itertools.product(
+        case_metadata_collection.cases, evaluation_objects
     ):
         # checks if case matches the event type provided in metric eval object
-        if single_case.event_type in metric_evaluation_object.event_type:
+        if single_case.event_type in evaluation_object.event_type:
             case_operators.append(
                 CaseOperator(
                     case_metadata=single_case,
-                    metric_list=metric_evaluation_object.metric_list,
-                    target=metric_evaluation_object.target,
-                    forecast=metric_evaluation_object.forecast,
+                    metric_list=evaluation_object.metric_list,
+                    target=evaluation_object.target,
+                    forecast=evaluation_object.forecast,
                 )
             )
     return case_operators

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -205,7 +205,7 @@ cira_freeze_forecast = inputs.KerchunkForecast(
 BRIGHTBAND_EVALUATION_OBJECTS = [
     inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -217,7 +217,7 @@ BRIGHTBAND_EVALUATION_OBJECTS = [
     ),
     inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[
+        metric_list=[
             metrics.MaximumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -229,7 +229,7 @@ BRIGHTBAND_EVALUATION_OBJECTS = [
     ),
     inputs.EvaluationObject(
         event_type="freeze",
-        metric=[
+        metric_list=[
             metrics.MinimumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -240,7 +240,7 @@ BRIGHTBAND_EVALUATION_OBJECTS = [
     ),
     inputs.EvaluationObject(
         event_type="freeze",
-        metric=[
+        metric_list=[
             metrics.MinimumMAE,
             metrics.RMSE,
             metrics.OnsetME,
@@ -252,7 +252,7 @@ BRIGHTBAND_EVALUATION_OBJECTS = [
     # TODO: Re-enable when severe convection forecast is implemented
     # inputs.EvaluationObject(
     #     event_type="severe_convection",
-    #     metric=[
+    #     metric_list=[
     #         metrics.CSI,
     #         metrics.FAR,
     #         metrics.RegionalHitsMisses,
@@ -264,14 +264,14 @@ BRIGHTBAND_EVALUATION_OBJECTS = [
     # TODO: Re-enable when atmospheric river forecast is implemented
     # inputs.EvaluationObject(
     #     event_type="atmospheric_river",
-    #     metric=[metrics.CSI, metrics.SpatialDisplacement, metrics.EarlySignal],
+    #     metric_list=[metrics.CSI, metrics.SpatialDisplacement, metrics.EarlySignal],
     #     target=era5_atmospheric_river_target,
     #     forecast=cira_atmospheric_river_forecast,
     # ),
     # TODO: Re-enable when tropical cyclone forecast is implemented
     # inputs.EvaluationObject(
     #     event_type="tropical_cyclone",
-    #     metric=[
+    #     metric_list=[
     #         metrics.EarlySignal,
     #         metrics.LandfallDisplacement,
     #         metrics.LandfallTimeME,

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -26,8 +26,9 @@ class ExtremeWeatherBench:
 
     This class is used to run the ExtremeWeatherBench workflow. It is a
     wrapper around the
-    case operators and metrics to create either a serial loop or will return the built
-    case operators to run in parallel as defined by the user.
+    case operators and evaluation objects to create either a serial loop or will return
+    the built case operators to run in parallel as defined by the user.
+
 
     Attributes:
         cases: A dictionary of cases to run.
@@ -39,11 +40,11 @@ class ExtremeWeatherBench:
     def __init__(
         self,
         cases: dict[str, list],
-        metrics: list["inputs.EvaluationObject"],
+        evaluation_objects: list["inputs.EvaluationObject"],
         cache_dir: Optional[Union[str, Path]] = None,
     ):
         self.cases = cases
-        self.metrics = metrics
+        self.evaluation_objects = evaluation_objects
         self.cache_dir = Path(cache_dir) if cache_dir else None
 
     # case operators as a property are a convenience method for users to use
@@ -51,7 +52,7 @@ class ExtremeWeatherBench:
     # if desired for a parallel workflow
     @property
     def case_operators(self) -> list["cases.CaseOperator"]:
-        return cases.build_case_operators(self.cases, self.metrics)
+        return cases.build_case_operators(self.cases, self.evaluation_objects)
 
     def run(
         self,
@@ -135,7 +136,7 @@ def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
             case_operator.forecast.variables,
             case_operator.target.variables,
         ),
-        case_operator.metric,
+        case_operator.metric_list,
     ):
         results.append(
             _evaluate_metric_and_return_df(
@@ -216,7 +217,7 @@ def _ensure_output_schema(df: pd.DataFrame, **metadata) -> pd.DataFrame:
         df = _ensure_output_schema(
             metric_df,
             target_variable=target_var,
-            metric=metric.name,
+            metric_list=metric.name,
             target_source=target_ds.attrs["source"],
             forecast_source=forecast_ds.attrs["source"],
             case_id_number=case_id,

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -12,7 +12,7 @@ from extremeweatherbench import defaults
 from extremeweatherbench.evaluate import ExtremeWeatherBench, compute_case_operator
 
 
-@click.command(no_args_is_help=True)
+@click.command()
 @click.option(
     "--default",
     is_flag=True,
@@ -92,6 +92,9 @@ def cli_runner(
         # Use precompute for faster execution (higher memory usage)
         $ ewb --default --precompute
     """
+    # Store original output_dir value before setting default
+    original_output_dir = output_dir
+
     # Set default output directory to current working directory
     if output_dir is None:
         output_dir = os.getcwd()
@@ -101,7 +104,25 @@ def cli_runner(
 
     # Validate that either default or config_file is provided
     if not default and not config_file:
-        raise click.UsageError("Either --default or --config-file must be specified")
+        ctx = click.get_current_context()
+        # Check if any non-default arguments were provided
+        args_provided = (
+            original_output_dir is not None
+            or cache_dir is not None
+            or parallel != 1
+            or save_case_operators is not None
+            or precompute
+        )
+
+        if not args_provided:
+            # No arguments provided, show help and exit 0
+            click.echo(ctx.get_help())
+            ctx.exit(0)
+        else:
+            # Some arguments provided but missing required flags, show error
+            raise click.UsageError(
+                "Either --default or --config-file must be specified"
+            )
 
     if default and config_file:
         raise click.UsageError("Cannot specify both --default and --config-file")

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -119,7 +119,7 @@ def cli_runner(
     # Initialize ExtremeWeatherBench
     ewb = ExtremeWeatherBench(
         cases=cases_dict,
-        metrics=evaluation_objects,
+        evaluation_objects=evaluation_objects,
         cache_dir=cache_dir if cache_dir else None,
     )
 

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -304,7 +304,7 @@ class EvaluationObject:
     """
 
     event_type: str
-    metric_list: list["metrics.BaseMetric"]
+    metric_list: list[Union[Callable, "metrics.BaseMetric", "metrics.AppliedMetric"]]
     target: "TargetBase"
     forecast: "ForecastBase"
 

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -286,24 +286,25 @@ class ForecastBase(InputBase):
 
 @dataclasses.dataclass
 class EvaluationObject:
-    """A class to store the evaluation object for a metric.
+    """A class to store the evaluation object for a forecast and target pairing.
 
-    A EvaluationObject is a metric evaluation object for all cases in an event.
-    The evaluation is a set of all metrics, target variables, and forecast variables.
+    A EvaluationObject is an evaluation object which contains a forecast, target,
+    and metrics to evaluate. The evaluation is a set of all metrics, target variables,
+    and forecast variables.
 
     Multiple EvaluationObjects can be used to evaluate a single event type.
     This is useful for
-    evaluating distinct Targets or metrics with unique variables to evaluate.
+    evaluating distinct targets or metrics with unique variables to evaluate.
 
     Attributes:
         event_type: The event type to evaluate.
-        metric: A list of BaseMetric objects.
+        metric_list: A list of BaseMetric objects.
         target: A TargetBase object.
         forecast: A ForecastBase object.
     """
 
     event_type: str
-    metric: list["metrics.BaseMetric"]
+    metric_list: list["metrics.BaseMetric"]
     target: "TargetBase"
     forecast: "ForecastBase"
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -157,13 +157,13 @@ class TestCaseOperator:
 
         operator = cases.CaseOperator(
             case_metadata=case,
-            metric=mock_metric,
+            metric_list=[mock_metric],
             target=mock_target,
             forecast=mock_forecast,
         )
 
         assert operator.case_metadata == case
-        assert operator.metric == mock_metric
+        assert operator.metric_list == [mock_metric]
         assert operator.target == mock_target
         assert operator.forecast == mock_forecast
 
@@ -281,13 +281,13 @@ class TestBuildCaseOperators:
         # Create mock evaluation objects
         mock_eval_obj1 = Mock()
         mock_eval_obj1.event_type = ["heat_wave"]
-        mock_eval_obj1.metric = Mock()
+        mock_eval_obj1.metric_list = Mock()
         mock_eval_obj1.target = Mock()
         mock_eval_obj1.forecast = Mock()
 
         mock_eval_obj2 = Mock()
         mock_eval_obj2.event_type = ["drought", "heat_wave"]
-        mock_eval_obj2.metric = Mock()
+        mock_eval_obj2.metric_list = Mock()
         mock_eval_obj2.target = Mock()
         mock_eval_obj2.forecast = Mock()
 
@@ -305,7 +305,7 @@ class TestBuildCaseOperators:
         for operator in operators:
             assert isinstance(operator, cases.CaseOperator)
             assert hasattr(operator, "case_metadata")
-            assert hasattr(operator, "metric")
+            assert hasattr(operator, "metric_list")
             assert hasattr(operator, "target")
             assert hasattr(operator, "forecast")
 
@@ -334,7 +334,7 @@ class TestBuildCaseOperators:
         # Create evaluation object that doesn't match storm
         mock_eval_obj = Mock()
         mock_eval_obj.event_type = ["heat_wave", "drought"]
-        mock_eval_obj.metric = Mock()
+        mock_eval_obj.metric_list = Mock()
         mock_eval_obj.target = Mock()
         mock_eval_obj.forecast = Mock()
 
@@ -405,13 +405,13 @@ class TestCasesIntegration:
         # Create mock evaluation objects
         heat_wave_eval = Mock()
         heat_wave_eval.event_type = ["heat_wave"]
-        heat_wave_eval.metric = Mock()
+        heat_wave_eval.metric_list = Mock()
         heat_wave_eval.target = Mock()
         heat_wave_eval.forecast = Mock()
 
         multi_event_eval = Mock()
         multi_event_eval.event_type = ["heat_wave", "drought", "storm"]
-        multi_event_eval.metric = Mock()
+        multi_event_eval.metric_list = Mock()
         multi_event_eval.target = Mock()
         multi_event_eval.forecast = Mock()
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -115,7 +115,7 @@ def sample_evaluation_object(mock_target_base, mock_forecast_base, mock_base_met
     """Create a sample EvaluationObject."""
     return inputs.EvaluationObject(
         event_type="heat_wave",
-        metric=[mock_base_metric],
+        metric_list=[mock_base_metric],
         target=mock_target_base,
         forecast=mock_forecast_base,
     )
@@ -128,7 +128,7 @@ def sample_case_operator(
     """Create a sample CaseOperator."""
     return cases.CaseOperator(
         case_metadata=sample_individual_case,
-        metric=mock_base_metric,
+        metric_list=mock_base_metric,
         target=mock_target_base,
         forecast=mock_forecast_base,
     )
@@ -200,11 +200,11 @@ class TestExtremeWeatherBench:
         """Test ExtremeWeatherBench initialization."""
         ewb = evaluate.ExtremeWeatherBench(
             cases=sample_cases_dict,
-            metrics=[sample_evaluation_object],
+            evaluation_objects=[sample_evaluation_object],
         )
 
         assert ewb.cases == sample_cases_dict
-        assert ewb.metrics == [sample_evaluation_object]
+        assert ewb.evaluation_objects == [sample_evaluation_object]
         assert ewb.cache_dir is None
 
     def test_initialization_with_cache_dir(
@@ -214,7 +214,7 @@ class TestExtremeWeatherBench:
         cache_dir = "/tmp/test_cache"
         ewb = evaluate.ExtremeWeatherBench(
             cases=sample_cases_dict,
-            metrics=[sample_evaluation_object],
+            evaluation_objects=[sample_evaluation_object],
             cache_dir=cache_dir,
         )
 
@@ -228,7 +228,7 @@ class TestExtremeWeatherBench:
         cache_dir = Path("/tmp/test_cache")
         ewb = evaluate.ExtremeWeatherBench(
             cases=sample_cases_dict,
-            metrics=[sample_evaluation_object],
+            evaluation_objects=[sample_evaluation_object],
             cache_dir=cache_dir,
         )
 
@@ -247,7 +247,7 @@ class TestExtremeWeatherBench:
 
         ewb = evaluate.ExtremeWeatherBench(
             cases=sample_cases_dict,
-            metrics=[sample_evaluation_object],
+            evaluation_objects=[sample_evaluation_object],
         )
 
         result = ewb.case_operators
@@ -282,7 +282,7 @@ class TestExtremeWeatherBench:
 
             ewb = evaluate.ExtremeWeatherBench(
                 cases=sample_cases_dict,
-                metrics=[sample_evaluation_object],
+                evaluation_objects=[sample_evaluation_object],
             )
 
             result = ewb.run()
@@ -319,7 +319,7 @@ class TestExtremeWeatherBench:
 
                 ewb = evaluate.ExtremeWeatherBench(
                     cases=sample_cases_dict,
-                    metrics=[sample_evaluation_object],
+                    evaluation_objects=[sample_evaluation_object],
                     cache_dir=cache_dir,
                 )
 
@@ -354,7 +354,7 @@ class TestExtremeWeatherBench:
 
             ewb = evaluate.ExtremeWeatherBench(
                 cases=sample_cases_dict,
-                metrics=[sample_evaluation_object],
+                evaluation_objects=[sample_evaluation_object],
             )
 
             result = ewb.run()
@@ -404,7 +404,7 @@ class TestComputeCaseOperator:
         mock_evaluate_metric.return_value = mock_result
 
         # Setup the case operator mocks - metric should be a list for iteration
-        sample_case_operator.metric = [mock_base_metric]
+        sample_case_operator.metric_list = [mock_base_metric]
         sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
             sample_forecast_dataset,
             sample_target_dataset,
@@ -436,7 +436,7 @@ class TestComputeCaseOperator:
             sample_forecast_dataset,
             sample_target_dataset,
         )
-        sample_case_operator.metric = [Mock()]
+        sample_case_operator.metric_list = [Mock()]
 
         with patch(
             "extremeweatherbench.evaluate._compute_and_maybe_cache"
@@ -475,7 +475,7 @@ class TestComputeCaseOperator:
         # Create multiple metrics
         metric_1 = Mock()
         metric_2 = Mock()
-        sample_case_operator.metric = [metric_1, metric_2]
+        sample_case_operator.metric_list = [metric_1, metric_2]
 
         sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
             sample_forecast_dataset,
@@ -843,7 +843,7 @@ class TestErrorHandling:
 
         ewb = evaluate.ExtremeWeatherBench(
             cases=empty_cases,
-            metrics=[sample_evaluation_object],
+            evaluation_objects=[sample_evaluation_object],
         )
 
         with patch("extremeweatherbench.cases.build_case_operators") as mock_build:
@@ -974,7 +974,7 @@ class TestIntegration:
             # Create and run the workflow
             ewb = evaluate.ExtremeWeatherBench(
                 cases=sample_cases_dict,
-                metrics=[sample_evaluation_object],
+                evaluation_objects=[sample_evaluation_object],
             )
 
             result = ewb.run()
@@ -1009,7 +1009,7 @@ class TestIntegration:
         # Create evaluation object with multiple metrics and variables
         eval_obj = Mock(spec=inputs.EvaluationObject)
         eval_obj.event_type = "heat_wave"
-        eval_obj.metric = [metric_1, metric_2]
+        eval_obj.metric_list = [metric_1, metric_2]
 
         # Mock target and forecast with variables that match our datasets
         eval_obj.target = Mock(spec=inputs.TargetBase)
@@ -1062,7 +1062,7 @@ class TestIntegration:
 
                 ewb = evaluate.ExtremeWeatherBench(
                     cases=sample_cases_dict,
-                    metrics=[eval_obj],
+                    evaluation_objects=[eval_obj],
                 )
 
                 result = ewb.run()

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -25,7 +25,7 @@ def suppress_cli_output():
 @pytest.fixture
 def runner():
     """Create a Click test runner with output suppression."""
-    return click.testing.CliRunner(mix_stderr=False)
+    return click.testing.CliRunner()
 
 
 @pytest.fixture

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -606,13 +606,13 @@ class TestEvaluationObject:
 
         eval_obj = inputs.EvaluationObject(
             event_type="test_event",
-            metric=[mock_metric],
+            metric_list=[mock_metric],
             target=mock_target,
             forecast=mock_forecast,
         )
 
         assert eval_obj.event_type == "test_event"
-        assert eval_obj.metric == [mock_metric]
+        assert eval_obj.metric_list == [mock_metric]
         assert eval_obj.target == mock_target
         assert eval_obj.forecast == mock_forecast
 

--- a/tests/test_variable_pairing_integration.py
+++ b/tests/test_variable_pairing_integration.py
@@ -154,7 +154,7 @@ def create_case_operator(
     target_vars: List[str],
     forecast_dataset: xr.Dataset,
     target_dataset: xr.Dataset,
-    mock_metric,
+    mock_metric_list,
 ):
     """Helper to create a CaseOperator with specified variables."""
     # Create datasets that contain the requested variables
@@ -202,7 +202,7 @@ def create_case_operator(
 
     return cases.CaseOperator(
         case_metadata=sample_case,
-        metric=[mock_metric],
+        metric_list=[mock_metric_list],
         target=mock_target,
         forecast=mock_forecast,
     )
@@ -227,7 +227,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x"],
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -258,7 +258,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x", "var_y"],
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -291,7 +291,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x", "var_y"],  # Different target variables
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -324,7 +324,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x", "var_y"],  # Two target variables
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -332,9 +332,9 @@ class TestVariablePairingIntegration:
 
         # Verify results
         assert isinstance(result, pd.DataFrame)
-        assert (
-            len(result) == 1
-        ), "Should have exactly one evaluation result (only first pairing)"
+        assert len(result) == 1, (
+            "Should have exactly one evaluation result (only first pairing)"
+        )
 
         # Check that only the first pairing was created: var_a <-> var_x
         assert result["target_variable"].iloc[0] == "var_x"
@@ -354,7 +354,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x"],  # Single target variable
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -362,9 +362,9 @@ class TestVariablePairingIntegration:
 
         # Verify results
         assert isinstance(result, pd.DataFrame)
-        assert (
-            len(result) == 1
-        ), "Should have exactly one evaluation result (only first pairing)"
+        assert len(result) == 1, (
+            "Should have exactly one evaluation result (only first pairing)"
+        )
 
         # Check that only the first pairing was created: var_a <-> var_x
         assert result["target_variable"].iloc[0] == "var_x"
@@ -384,7 +384,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x", "var_y", "var_z"],
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -418,7 +418,7 @@ class TestVariablePairingIntegration:
             target_vars=[],
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -452,7 +452,7 @@ class TestVariablePairingIntegration:
             target_vars=["var_x", "var_y"],
             forecast_dataset=base_forecast_dataset,
             target_dataset=base_target_dataset,
-            mock_metric=mock_metric,
+            mock_metric_list=mock_metric,
         )
 
         # Execute evaluation
@@ -510,7 +510,7 @@ class TestExtremeWeatherBenchVariablePairing:
 
         evaluation_obj = inputs.EvaluationObject(
             event_type="test_event",
-            metric=[mock_metric],
+            metric_list=[mock_metric],
             target=mock_target,
             forecast=mock_forecast,
         )
@@ -539,7 +539,7 @@ class TestExtremeWeatherBenchVariablePairing:
         # Create and run ExtremeWeatherBench
         ewb = evaluate.ExtremeWeatherBench(
             cases=cases_dict,
-            metrics=[evaluation_obj],
+            evaluation_objects=[evaluation_obj],
         )
 
         result = ewb.run()
@@ -591,7 +591,7 @@ class TestExtremeWeatherBenchVariablePairing:
 
         evaluation_obj = inputs.EvaluationObject(
             event_type="test_event",
-            metric=[mock_metric],
+            metric_list=[mock_metric],
             target=mock_target,
             forecast=mock_forecast,
         )
@@ -620,7 +620,7 @@ class TestExtremeWeatherBenchVariablePairing:
         # Create and run ExtremeWeatherBench
         ewb = evaluate.ExtremeWeatherBench(
             cases=cases_dict,
-            metrics=[evaluation_obj],
+            evaluation_objects=[evaluation_obj],
         )
 
         result = ewb.run()

--- a/tests/test_variable_pairing_integration.py
+++ b/tests/test_variable_pairing_integration.py
@@ -332,9 +332,9 @@ class TestVariablePairingIntegration:
 
         # Verify results
         assert isinstance(result, pd.DataFrame)
-        assert len(result) == 1, (
-            "Should have exactly one evaluation result (only first pairing)"
-        )
+        assert (
+            len(result) == 1
+        ), "Should have exactly one evaluation result (only first pairing)"
 
         # Check that only the first pairing was created: var_a <-> var_x
         assert result["target_variable"].iloc[0] == "var_x"
@@ -362,9 +362,9 @@ class TestVariablePairingIntegration:
 
         # Verify results
         assert isinstance(result, pd.DataFrame)
-        assert len(result) == 1, (
-            "Should have exactly one evaluation result (only first pairing)"
-        )
+        assert (
+            len(result) == 1
+        ), "Should have exactly one evaluation result (only first pairing)"
 
         # Check that only the first pairing was created: var_a <-> var_x
         assert result["target_variable"].iloc[0] == "var_x"


### PR DESCRIPTION
# EWB Pull Request

## Description

This is a quick PR that renams and clarifies metrics, metric lists, and EvaluationObjects.

`metric` -> `metric_list` for CaseOperator and EvaluationObject

`metrics` -> `evaluation_objects` for ExtremeWeatherBench