### PR TITLE
Replace duplicate case 16 with South Asia heatwave

### DIFF
--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -1,3421 +1,3386 @@
 cases:
-- case_id_number: 1
-  title: 2021 Pacific Northwest
-  start_date: 2021-06-20 00:00:00
-  end_date: 2021-07-03 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 47.6062
-      longitude: 237.6679
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 2
-  title: 2022 Upper Midwest
-  start_date: 2022-05-07 00:00:00
-  end_date: 2022-05-17 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 41.8781
-      longitude: 272.3702
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 3
-  title: 2022 California
-  start_date: 2022-06-07 00:00:00
-  end_date: 2022-06-15 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 34.0522
-      longitude: 241.7563
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 4
-  title: 2022 Texas
-  start_date: 2022-06-30 00:00:00
-  end_date: 2022-07-18 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 32.7767
-      longitude: 263.203
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 5
-  title: 2023 Pacific Northwest
-  start_date: 2023-05-10 00:00:00
-  end_date: 2023-05-23 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 47.6062
-      longitude: 237.6679
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 6
-  title: 2022 Mid-Atlantic
-  start_date: 2022-05-17 00:00:00
-  end_date: 2022-05-24 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 39.2904
-      longitude: 283.38779999999997
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 7
-  title: 2023 Australia
-  start_date: 2023-11-18 00:00:00
-  end_date: 2023-11-28 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -31.9505
-      longitude: 115.8605
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 8
-  title: 2023 Ireland
-  start_date: 2023-09-02 00:00:00
-  end_date: 2023-09-13 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 53.1424
-      longitude: 352.3079
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 9
-  title: 2023 Italy
-  start_date: 2023-07-07 00:00:00
-  end_date: 2023-07-27 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 41.9028
-      longitude: 12.4964
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 10
-  title: 2023 SW Europe
-  start_date: 2023-08-17 00:00:00
-  end_date: 2023-08-28 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 40.4637
-      longitude: 356.2508
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 11
-  title: 2023 South America
-  start_date: 2023-07-29 00:00:00
-  end_date: 2023-08-04 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -34.6037
-      longitude: 301.6184
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 12
-  title: 2023 China (Shanghai)
-  start_date: 2023-05-24 00:00:00
-  end_date: 2023-06-01 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 31.2304
-      longitude: 121.4737
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 13
-  title: 2023 China (Yunnan Province)
-  start_date: 2023-04-14 00:00:00
-  end_date: 2023-04-23 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 25.0458
-      longitude: 102.71
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 14
-  title: 2023 Algeria
-  start_date: 2023-07-05 00:00:00
-  end_date: 2023-07-27 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 36.7372
-      longitude: 3.0869
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 15
-  title: 2023 Iberian Peninsula
-  start_date: 2023-04-22 00:00:00
-  end_date: 2023-05-01 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 41.1496
-      longitude: 352.389
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 16
-  title: 2023 Gibraltar
-  start_date: 2023-04-22 00:00:00
-  end_date: 2023-05-03 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 36.1408
-      longitude: 354.64639999999997
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 17
-  title: 2023 India
-  start_date: 2023-02-15 00:00:00
-  end_date: 2023-03-01 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 28.6139
-      longitude: 77.209
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 18
-  title: 2021 Western Russia
-  start_date: 2021-06-18 00:00:00
-  end_date: 2021-06-30 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 55.7558
-      longitude: 37.6173
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 19
-  title: 2022 Germany
-  start_date: 2022-12-23 00:00:00
-  end_date: 2022-12-31 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 52.52
-      longitude: 13.405
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 20
-  title: 2022 UK (August)
-  start_date: 2022-08-08 00:00:00
-  end_date: 2022-08-16 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 51.5074
-      longitude: 359.8722
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 21
-  title: 2022 UK (July)
-  start_date: 2022-07-15 00:00:00
-  end_date: 2022-07-23 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 51.5074
-      longitude: 359.8722
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 22
-  title: 2022 France
-  start_date: 2022-06-09 00:00:00
-  end_date: 2022-06-21 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 43.4832
-      longitude: 358.4414
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 23
-  title: 2022 Japan
-  start_date: 2022-06-20 00:00:00
-  end_date: 2022-07-05 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 35.6895
-      longitude: 139.6917
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 24
-  title: 2022 India
-  start_date: 2022-04-24 00:00:00
-  end_date: 2022-05-04 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 28.2769
-      longitude: 68.4376
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 25
-  title: 2022 East Antarctica
-  start_date: 2022-03-12 00:00:00
-  end_date: 2022-03-26 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -75.1
-      longitude: 123.35
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 26
-  title: 2022 West Australia
-  start_date: 2022-01-15 00:00:00
-  end_date: 2022-01-25 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -31.9505
-      longitude: 115.8605
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 27
-  title: 2021 Canada Plains
-  start_date: 2021-05-30 00:00:00
-  end_date: 2021-06-09 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 49.0
-      longitude: 262.43330000000003
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 28
-  title: 2021 New Zealand
-  start_date: 2021-01-12 18:00:00
-  end_date: 2021-01-17 18:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -43.8983
-      longitude: 171.731
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 29
-  title: 2020 Australia
-  start_date: 2020-11-25 00:00:00
-  end_date: 2020-11-30 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -33.8245
-      longitude: 150.9448
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 30
-  title: 2021 Texas
-  start_date: 2021-02-10 12:00:00
-  end_date: 2021-02-22 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 30.2672
-      longitude: 262.2569
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 31
-  title: 2022 Arkansas
-  start_date: 2022-02-17 18:00:00
-  end_date: 2022-03-01 06:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 34.7445
-      longitude: 267.7104
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 32
-  title: 2023 Germany
-  start_date: 2023-12-02 06:00:00
-  end_date: 2023-12-05 18:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 48.1351
-      longitude: 11.582
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 33
-  title: 2023 China
-  start_date: 2023-12-15 06:00:00
-  end_date: 2023-12-26 18:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 31.2304
-      longitude: 121.4737
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 34
-  title: 2023 Afghanistan
-  start_date: 2023-01-11 06:00:00
-  end_date: 2023-01-28 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 34.5553
-      longitude: 69.2075
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 35
-  title: 2022 Colorado
-  start_date: 2022-04-06 00:00:00
-  end_date: 2022-04-16 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 39.7392
-      longitude: 255.0097
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 36
-  title: July 2024 South Dakota
-  start_date: 2024-07-13 00:00:00
-  end_date: 2024-07-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 49.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 37
-  title: July 2024 Chicago
-  start_date: 2024-07-14 00:00:00
-  end_date: 2024-07-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 49.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 38
-  title: July 2024 New York
-  start_date: 2024-07-16 00:00:00
-  end_date: 2024-07-17 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 49.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 39
-  title: May 2024 Wisconsin
-  start_date: 2024-05-18 00:00:00
-  end_date: 2024-05-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 40
-  title: May 2024 Kansas
-  start_date: 2024-05-19 00:00:00
-  end_date: 2024-05-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 41
-  title: May 2024 Iowa + Nebraska
-  start_date: 2024-05-20 00:00:00
-  end_date: 2024-05-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 42
-  title: May 2024 Iowa + Wisconsin
-  start_date: 2024-05-21 00:00:00
-  end_date: 2024-05-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 43
-  title: May 2024 Texas
-  start_date: 2024-05-22 00:00:00
-  end_date: 2024-05-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 44
-  title: May 2024 Iowa + Nebraska 2
-  start_date: 2024-05-23 00:00:00
-  end_date: 2024-05-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 45
-  title: April 2024 Oklahoma
-  start_date: 2024-04-25 12:00:00
-  end_date: 2024-04-29 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 46
-  title: April 2024 Midwest
-  start_date: 2024-04-02 12:00:00
-  end_date: 2024-04-03 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 47
-  title: April 2024 Great Plains + Midwest
-  start_date: 2024-04-01 12:00:00
-  end_date: 2024-04-02 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 48
-  title: March 2024 Midwest
-  start_date: 2024-03-14 12:00:00
-  end_date: 2024-03-15 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 49
-  title: February 2024 Midwest
-  start_date: 2024-02-27 12:00:00
-  end_date: 2024-02-28 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 50
-  title: January 2024 Southeast
-  start_date: 2024-01-08 12:00:00
-  end_date: 2024-01-10 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 51
-  title: December 2023 South
-  start_date: 2023-12-09 12:00:00
-  end_date: 2023-12-10 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 52
-  title: August 2023 East Coast
-  start_date: 2023-08-07 12:00:00
-  end_date: 2023-08-08 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 53
-  title: August 2023 Minnesota
-  start_date: 2023-08-11 12:00:00
-  end_date: 2023-08-12 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 54
-  title: July 2023 Midwest
-  start_date: 2023-07-02 12:00:00
-  end_date: 2023-07-03 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 55
-  title: July 2023 Midwest 2
-  start_date: 2023-07-01 12:00:00
-  end_date: 2023-07-02 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 56
-  title: June 2023 Midwest
-  start_date: 2023-06-30 12:00:00
-  end_date: 2023-07-01 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 57
-  title: June 2023 Front Range
-  start_date: 2023-06-21 12:00:00
-  end_date: 2023-06-22 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 58
-  title: June 2023 Texas
-  start_date: 2023-06-21 12:00:00
-  end_date: 2023-06-22 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 59
-  title: June 2023 Great Plains
-  start_date: 2023-06-23 12:00:00
-  end_date: 2023-06-24 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 60
-  title: June 2023 Iowa + Minnesota
-  start_date: 2023-06-24 12:00:00
-  end_date: 2023-06-25 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 61
-  title: June 2023 South + Midwest
-  start_date: 2023-06-25 12:00:00
-  end_date: 2023-06-26 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 62
-  title: June 2023 East Coast
-  start_date: 2023-06-26 12:00:00
-  end_date: 2023-06-27 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 63
-  title: June 2023 Midwest + Great Plains
-  start_date: 2023-06-29 12:00:00
-  end_date: 2023-06-30 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 64
-  title: June 2023 Southeast
-  start_date: 2023-06-14 12:00:00
-  end_date: 2023-06-15 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 65
-  title: June 2023 OK + TX + South
-  start_date: 2023-06-15 12:00:00
-  end_date: 2023-06-16 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 66
-  title: June 2023 South
-  start_date: 2023-06-16 12:00:00
-  end_date: 2023-06-17 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 67
-  title: June 2023 Mid-Atlantic
-  start_date: 2023-06-16 12:00:00
-  end_date: 2023-06-17 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 68
-  title: June 2023 Great Plains + South
-  start_date: 2023-06-17 12:00:00
-  end_date: 2023-06-18 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 69
-  title: May 2023 Great Plains
-  start_date: 2023-05-10 12:00:00
-  end_date: 2023-05-11 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 70
-  title: May 2023 Great Plains + South
-  start_date: 2023-05-11 12:00:00
-  end_date: 2023-05-12 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 71
-  title: May 2023 Nebraska
-  start_date: 2023-05-12 12:00:00
-  end_date: 2023-05-13 12:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 54.0
-      longitude_min: 245.0
-      longitude_max: 295.0
-  event_type: severe_convection
-- case_id_number: 72
-  title: May 2024 Texas
-  start_date: 2024-05-25 00:00:00
-  end_date: 2024-05-28 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 25.9017
-      longitude: 262.50260000000003
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 73
-  title: June 2024 Northeast US
-  start_date: 2024-06-17 00:00:00
-  end_date: 2024-06-22 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 41.8781
-      longitude: 286.771
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 74
-  title: July 2024 Southwest US
-  start_date: 2024-07-04 00:00:00
-  end_date: 2024-07-08 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 33.7701
-      longitude: 243.78539999999998
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 75
-  title: July 2024 Northeast US
-  start_date: 2024-07-07 00:00:00
-  end_date: 2024-07-10 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 40.7128
-      longitude: 285.994
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 76
-  title: July 2024 Mid-Atlantic US
-  start_date: 2024-07-15 00:00:00
-  end_date: 2024-07-20 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 39.9526
-      longitude: 284.8348
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 77
-  title: August 2024 Midwest US
-  start_date: 2024-08-25 00:00:00
-  end_date: 2024-08-31 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 40.1106
-      longitude: 271.79269999999997
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 78
-  title: July 2024 Antarctica
-  start_date: 2024-07-01 00:00:00
-  end_date: 2024-07-31 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -75.0
-      longitude: 15.0
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 79
-  title: August 2024 Canada
-  start_date: 2024-08-09 00:00:00
-  end_date: 2024-08-11 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 67.0
-      longitude: 248.0
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 80
-  title: August 2024 Australia
-  start_date: 2024-08-22 00:00:00
-  end_date: 2024-08-30 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -20.0
-      longitude: 120.0
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 81
-  title: July/August 2024 Japan
-  start_date: 2024-07-25 00:00:00
-  end_date: 2024-08-05 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 36.0
-      longitude: 138.0
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 82
-  title: June 2024 Saudi Arabia
-  start_date: 2024-06-16 00:00:00
-  end_date: 2024-06-18 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 24.0
-      longitude: 45.0
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 83
-  title: August 2024 Europe
-  start_date: 2024-08-10 00:00:00
-  end_date: 2024-08-15 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 48.3794
-      longitude: 10.8978
-      bounding_box_degrees: 10
-  event_type: heat_wave
-- case_id_number: 84
-  title: July 2024 Ukraine
-  start_date: 2024-07-12 00:00:00
-  end_date: 2024-07-16 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 50.4501
-      longitude: 30.5234
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 85
-  title: June 2024 Europe
-  start_date: 2024-06-20 00:00:00
-  end_date: 2024-06-30 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 52.3676
-      longitude: 4.9041
-      bounding_box_degrees: 6
-  event_type: heat_wave
-- case_id_number: 86
-  title: May 2024 Central Mexico
-  start_date: 2024-05-23 00:00:00
-  end_date: 2024-05-31 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 19.4326
-      longitude: 260.8668
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 87
-  title: May 2024 Pakistan/India
-  start_date: 2024-05-23 00:00:00
-  end_date: 2024-05-31 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 34.0
-      longitude: 76.0
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 88
-  title: August 2023 Chile
-  start_date: 2023-08-01 00:00:00
-  end_date: 2023-08-03 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: -33.4489
-      longitude: 289.3307
-      bounding_box_degrees: 5
-  event_type: heat_wave
-- case_id_number: 89
-  title: January 2024 Pacific Northwest
-  start_date: 2024-01-11 12:00:00
-  end_date: 2024-01-20 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 47.6062
-      longitude: 237.6679
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 90
-  title: April 2022 Nevada
-  start_date: 2022-04-11 18:00:00
-  end_date: 2022-04-16 12:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 40.8324
-      longitude: 244.2369
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 91
-  title: February/March 2021 New England
-  start_date: 2021-03-04 18:00:00
-  end_date: 2021-03-09 06:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 42.8509
-      longitude: 287.4421
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 92
-  title: January 2024 Northern Europe
-  start_date: 2024-01-01 06:00:00
-  end_date: 2024-01-09 12:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 59.3293
-      longitude: 18.0686
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 93
-  title: December 2022 Europe
-  start_date: 2022-12-10 06:00:00
-  end_date: 2022-12-20 00:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 52.52
-      longitude: 13.405
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 94
-  title: April 2024 Europe
-  start_date: 2024-04-16 12:00:00
-  end_date: 2024-04-27 12:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 48.8566
-      longitude: 2.3522
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 95
-  title: January 2023 North China
-  start_date: 2024-01-20 00:00:00
-  end_date: 2024-02-04 18:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 42.5246
-      longitude: 122.3853
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 96
-  title: April 2024 Sweden
-  start_date: 2024-04-02 00:00:00
-  end_date: 2024-04-07 12:00:00
-  location:
-    type: centered_region
-    parameters:
-      latitude: 60.1282
-      longitude: 18.6435
-      bounding_box_degrees: 5
-  event_type: freeze
-- case_id_number: 97
-  title: November 2024 West Coast US
-  start_date: 2024-11-20 00:00:00
-  end_date: 2024-11-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 35.0
-      latitude_max: 50.0
-      longitude_min: 230.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 98
-  title: October 2024 British Columbia
-  start_date: 2024-10-18 00:00:00
-  end_date: 2024-10-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 55.0
-      longitude_min: 225.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 99
-  title: September 2024 SW Alaska and British Columbia
-  start_date: 2024-09-22 00:00:00
-  end_date: 2024-09-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 45.0
-      latitude_max: 60.0
-      longitude_min: 220.0
-      longitude_max: 240.0
-  event_type: atmospheric_river
-- case_id_number: 100
-  title: November 2024 Western US & Canada Bomb Cyclone and AR
-  start_date: 2024-11-18 00:00:00
-  end_date: 2024-11-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 230.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 101
-  title: October 2024 Alaska and BC Canada Atmospheric River
-  start_date: 2024-10-18 00:00:00
-  end_date: 2024-10-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 50.0
-      latitude_max: 65.0
-      longitude_min: 210.0
-      longitude_max: 240.0
-  event_type: atmospheric_river
-- case_id_number: 102
-  title: September 2024 Alaska and BC Canada Atmospheric River
-  start_date: 2024-09-22 00:00:00
-  end_date: 2024-09-25 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 50.0
-      latitude_max: 65.0
-      longitude_min: 210.0
-      longitude_max: 240.0
-  event_type: atmospheric_river
-- case_id_number: 103
-  title: October 2024 Bosnia
-  start_date: 2024-10-03 00:00:00
-  end_date: 2024-10-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 42.0
-      latitude_max: 46.0
-      longitude_min: 16.0
-      longitude_max: 20.0
-  event_type: atmospheric_river
-- case_id_number: 104
-  title: April 2024 Eastern Australia
-  start_date: 2024-04-04 00:00:00
-  end_date: 2024-04-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -38.0
-      latitude_max: -25.0
-      longitude_min: 140.0
-      longitude_max: 155.0
-  event_type: atmospheric_river
-- case_id_number: 105
-  title: April 2024 Persian Gulf
-  start_date: 2024-04-14 00:00:00
-  end_date: 2024-04-18 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 24.0
-      latitude_max: 30.0
-      longitude_min: 48.0
-      longitude_max: 58.0
-  event_type: atmospheric_river
-- case_id_number: 106
-  title: February 2024 Pacific Northwest
-  start_date: 2024-02-28 00:00:00
-  end_date: 2024-03-04 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 107
-  title: February 2024 California
-  start_date: 2024-02-18 00:00:00
-  end_date: 2024-02-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 108
-  title: February 2024 California
-  start_date: 2024-02-03 00:00:00
-  end_date: 2024-02-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 109
-  title: January 2024 Alaska to California
-  start_date: 2024-01-26 00:00:00
-  end_date: 2024-02-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 65.0
-      longitude_min: 210.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 110
-  title: January 2024 California and Arizona
-  start_date: 2024-01-22 00:00:00
-  end_date: 2024-01-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 38.0
-      longitude_min: 240.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 111
-  title: December 2023 East Coast Cyclone
-  start_date: 2023-12-17 00:00:00
-  end_date: 2023-12-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 25.0
-      latitude_max: 45.0
-      longitude_min: 275.0
-      longitude_max: 295.0
-  event_type: atmospheric_river
-- case_id_number: 112
-  title: June 2023 Northwest Cloudband
-  start_date: 2023-06-25 00:00:00
-  end_date: 2023-06-28 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -28.0
-      latitude_max: -15.0
-      longitude_min: 120.0
-      longitude_max: 140.0
-  event_type: atmospheric_river
-- case_id_number: 113
-  title: April 2023 Middle East
-  start_date: 2023-04-01 00:00:00
-  end_date: 2023-05-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 20.0
-      latitude_max: 40.0
-      longitude_min: 30.0
-      longitude_max: 60.0
-  event_type: atmospheric_river
-- case_id_number: 114
-  title: March 2023 California and Arizona
-  start_date: 2023-03-20 00:00:00
-  end_date: 2023-03-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 38.0
-      longitude_min: 240.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 115
-  title: March 2023 California
-  start_date: 2023-03-09 00:00:00
-  end_date: 2023-03-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 116
-  title: February 2023 Pacific Northwest
-  start_date: 2023-02-19 00:00:00
-  end_date: 2023-02-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 117
-  title: December 2022 - January 2023 California
-  start_date: 2022-12-01 00:00:00
-  end_date: 2023-02-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 118
-  title: December 2022 California
-  start_date: 2022-12-26 00:00:00
-  end_date: 2022-12-28 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 119
-  title: December 2022 Oregon and California
-  start_date: 2022-12-09 00:00:00
-  end_date: 2022-12-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 45.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 120
-  title: November 2022 - December 2022 California
-  start_date: 2022-11-29 00:00:00
-  end_date: 2022-12-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 121
-  title: October 2022 Victoria
-  start_date: 2022-10-13 00:00:00
-  end_date: 2022-10-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -39.0
-      latitude_max: -34.0
-      longitude_min: 140.0
-      longitude_max: 150.0
-  event_type: atmospheric_river
-- case_id_number: 122
-  title: October 2022 Victoria
-  start_date: 2022-10-30 00:00:00
-  end_date: 2022-10-31 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -39.0
-      latitude_max: -34.0
-      longitude_min: 140.0
-      longitude_max: 150.0
-  event_type: atmospheric_river
-- case_id_number: 123
-  title: November 2022 California
-  start_date: 2022-11-07 00:00:00
-  end_date: 2022-11-09 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 124
-  title: November 2022 Pacific Northwest
-  start_date: 2022-11-03 00:00:00
-  end_date: 2022-11-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 125
-  title: August 2022 Japan
-  start_date: 2022-08-01 00:00:00
-  end_date: 2022-09-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 35.0
-      latitude_max: 45.0
-      longitude_min: 130.0
-      longitude_max: 145.0
-  event_type: atmospheric_river
-- case_id_number: 126
-  title: June 2022 Pacific Northwest, Wyoming, and Montana
-  start_date: 2022-06-09 00:00:00
-  end_date: 2022-06-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 127
-  title: March 2022 East Antarctica
-  start_date: 2022-03-15 00:00:00
-  end_date: 2022-03-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -90.0
-      latitude_max: -70.0
-      longitude_min: 60.0
-      longitude_max: 160.0
-  event_type: atmospheric_river
-- case_id_number: 128
-  title: February 2022 Southeast QLD / Northern NSW
-  start_date: 2022-02-26 00:00:00
-  end_date: 2022-03-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -30.0
-      latitude_max: -25.0
-      longitude_min: 150.0
-      longitude_max: 155.0
-  event_type: atmospheric_river
-- case_id_number: 129
-  title: February 2022 Pacific Northwest
-  start_date: 2022-02-26 00:00:00
-  end_date: 2022-03-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 130
-  title: January 2022 Norway and Sweden
-  start_date: 2022-01-14 00:00:00
-  end_date: 2022-01-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 58.0
-      latitude_max: 65.0
-      longitude_min: 5.0
-      longitude_max: 20.0
-  event_type: atmospheric_river
-- case_id_number: 131
-  title: January 2022 Colorado
-  start_date: 2022-01-04 00:00:00
-  end_date: 2022-01-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 37.0
-      latitude_max: 41.0
-      longitude_min: 251.0
-      longitude_max: 258.0
-  event_type: atmospheric_river
-- case_id_number: 132
-  title: January 2022 Pacific Northwest
-  start_date: 2022-01-02 00:00:00
-  end_date: 2022-01-09 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 133
-  title: December 2021 - January 2022 Western US
-  start_date: 2021-12-22 00:00:00
-  end_date: 2022-01-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 134
-  title: December 2021 Pacific NW
-  start_date: 2021-12-10 00:00:00
-  end_date: 2021-12-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 135
-  title: November 2021 Pacific Northwest
-  start_date: 2021-11-10 00:00:00
-  end_date: 2021-11-17 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 136
-  title: October 2021 California
-  start_date: 2021-10-19 00:00:00
-  end_date: 2021-10-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 42.0
-      longitude_min: 235.0
-      longitude_max: 245.0
-  event_type: atmospheric_river
-- case_id_number: 137
-  title: September 2021 Pacific Northwest
-  start_date: 2021-09-16 00:00:00
-  end_date: 2021-09-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 138
-  title: June 2021 Bloomington Indiana
-  start_date: 2021-06-18 00:00:00
-  end_date: 2021-06-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 39.0
-      latitude_max: 40.0
-      longitude_min: 273.0
-      longitude_max: 274.0
-  event_type: atmospheric_river
-- case_id_number: 139
-  title: June 2021 Alaska Trans-Pacific
-  start_date: 2021-06-24 00:00:00
-  end_date: 2021-06-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 55.0
-      latitude_max: 70.0
-      longitude_min: 190.0
-      longitude_max: 230.0
-  event_type: atmospheric_river
-- case_id_number: 140
-  title: March 2021 Sydney
-  start_date: 2021-03-17 00:00:00
-  end_date: 2021-03-25 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -34.0
-      latitude_max: -33.0
-      longitude_min: 150.0
-      longitude_max: 152.0
-  event_type: atmospheric_river
-- case_id_number: 141
-  title: February 2021 Pacific Northwest
-  start_date: 2021-02-21 00:00:00
-  end_date: 2021-02-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 142
-  title: January 2021 Pacific NW
-  start_date: 2021-01-11 00:00:00
-  end_date: 2021-01-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 143
-  title: January 2021 Pacific Northwest
-  start_date: 2021-01-01 00:00:00
-  end_date: 2021-01-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 144
-  title: December 2020 Pacific Northwest
-  start_date: 2020-12-17 00:00:00
-  end_date: 2020-12-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 145
-  title: December 2020 Western US
-  start_date: 2020-12-11 00:00:00
-  end_date: 2020-12-18 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 146
-  title: December 2020 Alaska
-  start_date: 2020-12-01 00:00:00
-  end_date: 2020-12-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 55.0
-      latitude_max: 65.0
-      longitude_min: 200.0
-      longitude_max: 230.0
-  event_type: atmospheric_river
-- case_id_number: 147
-  title: November 2020 Western US
-  start_date: 2020-11-16 00:00:00
-  end_date: 2020-11-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 148
-  title: October 2020 Western Alps
-  start_date: 2020-10-02 00:00:00
-  end_date: 2020-10-04 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 44.0
-      latitude_max: 47.0
-      longitude_min: 5.0
-      longitude_max: 9.0
-  event_type: atmospheric_river
-- case_id_number: 149
-  title: September 2020 Pacific Northwest
-  start_date: 2020-09-23 00:00:00
-  end_date: 2020-09-28 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 150
-  title: September 2020 Pacific Northwest
-  start_date: 2020-09-14 00:00:00
-  end_date: 2020-09-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 151
-  title: May 2020 Western US
-  start_date: 2020-05-16 00:00:00
-  end_date: 2020-05-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 152
-  title: March 2020 Southwestern US
-  start_date: 2020-03-09 00:00:00
-  end_date: 2020-03-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 30.0
-      latitude_max: 40.0
-      longitude_min: 240.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 153
-  title: February 2020 Southwestern US
-  start_date: 2020-02-21 00:00:00
-  end_date: 2020-02-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 30.0
-      latitude_max: 40.0
-      longitude_min: 240.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 154
-  title: February 2020 Western US
-  start_date: 2020-02-04 00:00:00
-  end_date: 2020-02-09 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 32.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 255.0
-  event_type: atmospheric_river
-- case_id_number: 155
-  title: January 2020 Pacific Northwest
-  start_date: 2020-01-26 00:00:00
-  end_date: 2020-02-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 40.0
-      latitude_max: 50.0
-      longitude_min: 235.0
-      longitude_max: 250.0
-  event_type: atmospheric_river
-- case_id_number: 156
-  title: Milton
-  start_date: 2024-10-02 00:00:00
-  end_date: 2024-10-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 18.6
-      latitude_max: 31.7
-      longitude_min: 262.1
-      longitude_max: 296.5
-  event_type: tropical_cyclone
-- case_id_number: 157
-  title: Helene
-  start_date: 2024-09-21 00:00:00
-  end_date: 2024-09-30 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 15.0
-      latitude_max: 40.3
-      longitude_min: 269.5
-      longitude_max: 280.7
-  event_type: tropical_cyclone
-- case_id_number: 158
-  title: Francine
-  start_date: 2024-09-06 00:00:00
-  end_date: 2024-09-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 19.2
-      latitude_max: 38.1
-      longitude_min: 261.4
-      longitude_max: 272.7
-  event_type: tropical_cyclone
-- case_id_number: 159
-  title: Debby
-  start_date: 2024-07-31 00:00:00
-  end_date: 2024-08-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 18.2
-      latitude_max: 52.2
-      longitude_min: 273.2
-      longitude_max: 302.9
-  event_type: tropical_cyclone
-- case_id_number: 160
-  title: Beryl
-  start_date: 2024-06-26 00:00:00
-  end_date: 2024-07-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 6.7
-      latitude_max: 45.3
-      longitude_min: 261.7
-      longitude_max: 322.7
-  event_type: tropical_cyclone
-- case_id_number: 161
-  title: John
-  start_date: 2024-09-20 00:00:00
-  end_date: 2024-09-29 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.6
-      latitude_max: 20.5
-      longitude_min: 254.5
-      longitude_max: 263.9
-  event_type: tropical_cyclone
-- case_id_number: 162
-  title: Hone
-  start_date: 2024-08-17 00:00:00
-  end_date: 2024-09-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.5
-      latitude_max: 28.3
-      longitude_min: 177.9
-      longitude_max: 231.5
-  event_type: tropical_cyclone
-- case_id_number: 163
-  title: Trami
-  start_date: 2024-10-18 00:00:00
-  end_date: 2024-10-31 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.9
-      latitude_max: 19.9
-      longitude_min: 105.0
-      longitude_max: 139.8
-  event_type: tropical_cyclone
-- case_id_number: 164
-  title: Prapiroon (Butchoy)
-  start_date: 2024-07-17 00:00:00
-  end_date: 2024-07-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.9
-      latitude_max: 24.0
-      longitude_min: 104.3
-      longitude_max: 120.4
-  event_type: tropical_cyclone
-- case_id_number: 165
-  title: Gaemi (Carina)
-  start_date: 2024-07-17 00:00:00
-  end_date: 2024-07-30 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.4
-      latitude_max: 32.0
-      longitude_min: 110.6
-      longitude_max: 135.5
-  event_type: tropical_cyclone
-- case_id_number: 166
-  title: Shanshan
-  start_date: 2024-08-19 00:00:00
-  end_date: 2024-09-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.8
-      latitude_max: 37.8
-      longitude_min: 127.7
-      longitude_max: 146.3
-  event_type: tropical_cyclone
-- case_id_number: 167
-  title: Yagi (Enteng)
-  start_date: 2024-08-30 00:00:00
-  end_date: 2024-09-10 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.9
-      latitude_max: 23.8
-      longitude_min: 101.8
-      longitude_max: 128.7
-  event_type: tropical_cyclone
-- case_id_number: 168
-  title: Bebinca (Ferdie)
-  start_date: 2024-09-07 00:00:00
-  end_date: 2024-09-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.9
-      latitude_max: 35.7
-      longitude_min: 112.4
-      longitude_max: 149.9
-  event_type: tropical_cyclone
-- case_id_number: 169
-  title: Soulik (Gener)
-  start_date: 2024-09-13 00:00:00
-  end_date: 2024-09-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.3
-      latitude_max: 19.9
-      longitude_min: 102.2
-      longitude_max: 128.8
-  event_type: tropical_cyclone
-- case_id_number: 170
-  title: Krathon
-  start_date: 2024-09-24 00:00:00
-  end_date: 2024-10-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 16.2
-      latitude_max: 25.0
-      longitude_min: 116.8
-      longitude_max: 129.8
-  event_type: tropical_cyclone
-- case_id_number: 171
-  title: Asna
-  start_date: 2024-08-28 00:00:00
-  end_date: 2024-09-04 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 18.8
-      latitude_max: 26.1
-      longitude_min: 59.0
-      longitude_max: 70.7
-  event_type: tropical_cyclone
-- case_id_number: 172
-  title: Kirrily
-  start_date: 2024-01-15 00:00:00
-  end_date: 2024-02-07 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -31.8
-      latitude_max: -11.3
-      longitude_min: 135.3
-      longitude_max: 159.0
-  event_type: tropical_cyclone
-- case_id_number: 173
-  title: Belal
-  start_date: 2024-01-10 00:00:00
-  end_date: 2024-01-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -26.5
-      latitude_max: -11.1
-      longitude_min: 50.8
-      longitude_max: 68.1
-  event_type: tropical_cyclone
-- case_id_number: 174
-  title: Alvaro
-  start_date: 2023-12-30 00:00:00
-  end_date: 2024-01-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -31.3
-      latitude_max: -18.5
-      longitude_min: 38.2
-      longitude_max: 59.9
-  event_type: tropical_cyclone
-- case_id_number: 175
-  title: Franklin
-  start_date: 2023-08-17 00:00:00
-  end_date: 2023-09-11 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.6
-      latitude_max: 50.8
-      longitude_min: 286.3
-      longitude_max: 346.3
-  event_type: tropical_cyclone
-- case_id_number: 176
-  title: Harold
-  start_date: 2023-08-19 00:00:00
-  end_date: 2023-08-25 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -37.2
-      latitude_max: -7.0
-      longitude_min: 152.2
-      longitude_max: 214.7
-  event_type: tropical_cyclone
-- case_id_number: 177
-  title: Idalia
-  start_date: 2023-08-24 00:00:00
-  end_date: 2023-09-10 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 17.6
-      latitude_max: 47.4
-      longitude_min: 270.8
-      longitude_max: 304.9
-  event_type: tropical_cyclone
-- case_id_number: 178
-  title: Lee
-  start_date: 2023-09-03 00:00:00
-  end_date: 2023-09-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.0
-      latitude_max: 55.2
-      longitude_min: 289.4
-      longitude_max: 322.7
-  event_type: tropical_cyclone
-- case_id_number: 179
-  title: Ophelia
-  start_date: 2023-09-19 00:00:00
-  end_date: 2023-09-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 26.3
-      latitude_max: 41.1
-      longitude_min: 279.8
-      longitude_max: 287.5
-  event_type: tropical_cyclone
-- case_id_number: 180
-  title: Tammy
-  start_date: 2023-10-16 00:00:00
-  end_date: 2023-11-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.7
-      latitude_max: 35.5
-      longitude_min: 293.7
-      longitude_max: 314.2
-  event_type: tropical_cyclone
-- case_id_number: 181
-  title: Hilary
-  start_date: 2023-08-14 00:00:00
-  end_date: 2023-08-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.7
-      latitude_max: 33.6
-      longitude_min: 241.6
-      longitude_max: 261.5
-  event_type: tropical_cyclone
-- case_id_number: 182
-  title: Lidia
-  start_date: 2023-10-01 00:00:00
-  end_date: 2023-10-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.0
-      latitude_max: 26.7
-      longitude_min: 244.9
-      longitude_max: 261.8
-  event_type: tropical_cyclone
-- case_id_number: 183
-  title: Max
-  start_date: 2023-10-06 00:00:00
-  end_date: 2023-10-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.6
-      latitude_max: 20.1
-      longitude_min: 256.1
-      longitude_max: 262.4
-  event_type: tropical_cyclone
-- case_id_number: 184
-  title: Norman
-  start_date: 2023-10-17 00:00:00
-  end_date: 2023-10-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.0
-      latitude_max: 25.0
-      longitude_min: 250.0
-      longitude_max: 265.0
-  event_type: tropical_cyclone
-- case_id_number: 185
-  title: Otis
-  start_date: 2023-10-19 00:00:00
-  end_date: 2023-10-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.1
-      latitude_max: 20.8
-      longitude_min: 257.0
-      longitude_max: 266.5
-  event_type: tropical_cyclone
-- case_id_number: 186
-  title: Mawar (Betty)
-  start_date: 2023-05-16 00:00:00
-  end_date: 2023-06-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 2.2
-      latitude_max: 36.3
-      longitude_min: 122.7
-      longitude_max: 153.2
-  event_type: tropical_cyclone
-- case_id_number: 187
-  title: Talim (Dodong)
-  start_date: 2023-07-11 00:00:00
-  end_date: 2023-07-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.6
-      latitude_max: 25.6
-      longitude_min: 101.0
-      longitude_max: 125.1
-  event_type: tropical_cyclone
-- case_id_number: 188
-  title: Doksuri (Egay)
-  start_date: 2023-07-18 00:00:00
-  end_date: 2023-08-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.5
-      latitude_max: 39.6
-      longitude_min: 110.5
-      longitude_max: 136.0
-  event_type: tropical_cyclone
-- case_id_number: 189
-  title: Khanun (Falcon)
-  start_date: 2023-07-24 00:00:00
-  end_date: 2023-08-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 6.7
-      latitude_max: 41.3
-      longitude_min: 121.8
-      longitude_max: 143.6
-  event_type: tropical_cyclone
-- case_id_number: 190
-  title: Lan
-  start_date: 2023-08-04 00:00:00
-  end_date: 2023-08-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 21.1
-      latitude_max: 50.0
-      longitude_min: 132.3
-      longitude_max: 152.0
-  event_type: tropical_cyclone
-- case_id_number: 191
-  title: Saola (Goring)
-  start_date: 2023-08-20 00:00:00
-  end_date: 2023-09-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.8
-      latitude_max: 24.2
-      longitude_min: 106.8
-      longitude_max: 130.3
-  event_type: tropical_cyclone
-- case_id_number: 192
-  title: Haikui
-  start_date: 2023-08-25 00:00:00
-  end_date: 2023-09-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 15.9
-      latitude_max: 25.9
-      longitude_min: 107.0
-      longitude_max: 146.8
-  event_type: tropical_cyclone
-- case_id_number: 193
-  title: Koinu (Jenny)
-  start_date: 2023-09-25 00:00:00
-  end_date: 2023-10-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 12.0
-      latitude_max: 24.4
-      longitude_min: 109.0
-      longitude_max: 146.1
-  event_type: tropical_cyclone
-- case_id_number: 194
-  title: Mocha
-  start_date: 2023-05-06 00:00:00
-  end_date: 2023-05-17 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 5.4
-      latitude_max: 27.3
-      longitude_min: 85.7
-      longitude_max: 100.1
-  event_type: tropical_cyclone
-- case_id_number: 195
-  title: Biparjoy
-  start_date: 2023-06-03 00:00:00
-  end_date: 2023-06-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 8.1
-      latitude_max: 28.5
-      longitude_min: 63.6
-      longitude_max: 78.3
-  event_type: tropical_cyclone
-- case_id_number: 196
-  title: Hamoon
-  start_date: 2023-10-18 00:00:00
-  end_date: 2023-10-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.2
-      latitude_max: 24.9
-      longitude_min: 83.5
-      longitude_max: 94.8
-  event_type: tropical_cyclone
-- case_id_number: 197
-  title: Freddy
-  start_date: 2023-02-02 00:00:00
-  end_date: 2023-03-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -26.3
-      latitude_max: -8.9
-      longitude_min: 29.0
-      longitude_max: 121.6
-  event_type: tropical_cyclone
-- case_id_number: 198
-  title: Jasper
-  start_date: 2023-11-30 00:00:00
-  end_date: 2023-12-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -20.0
-      latitude_max: -5.3
-      longitude_min: 139.0
-      longitude_max: 167.2
-  event_type: tropical_cyclone
-- case_id_number: 199
-  title: Daniel - Europe
-  start_date: 2023-09-02 00:00:00
-  end_date: 2023-09-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 30.0
-      latitude_max: 45.0
-      longitude_min: 10.0
-      longitude_max: 30.0
-  event_type: tropical_cyclone
-- case_id_number: 200
-  title: Alex
-  start_date: 2022-05-31 00:00:00
-  end_date: 2022-06-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 19.1
-      latitude_max: 36.9
-      longitude_min: 270.1
-      longitude_max: 300.2
-  event_type: tropical_cyclone
-- case_id_number: 201
-  title: Fiona
-  start_date: 2022-09-12 00:00:00
-  end_date: 2022-09-29 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.5
-      latitude_max: 66.2
-      longitude_min: 285.9
-      longitude_max: 314.4
-  event_type: tropical_cyclone
-- case_id_number: 202
-  title: Ian
-  start_date: 2022-09-20 00:00:00
-  end_date: 2022-10-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.1
-      latitude_max: 37.5
-      longitude_min: 274.0
-      longitude_max: 296.0
-  event_type: tropical_cyclone
-- case_id_number: 203
-  title: Julia
-  start_date: 2022-10-04 00:00:00
-  end_date: 2022-10-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.2
-      latitude_max: 15.9
-      longitude_min: 267.8
-      longitude_max: 295.8
-  event_type: tropical_cyclone
-- case_id_number: 204
-  title: Nicole
-  start_date: 2022-11-04 00:00:00
-  end_date: 2022-11-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 18.4
-      latitude_max: 37.6
-      longitude_min: 272.9
-      longitude_max: 295.7
-  event_type: tropical_cyclone
-- case_id_number: 205
-  title: Agatha
-  start_date: 2022-05-25 00:00:00
-  end_date: 2022-06-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.6
-      latitude_max: 20.5
-      longitude_min: 258.6
-      longitude_max: 267.7
-  event_type: tropical_cyclone
-- case_id_number: 206
-  title: Kay
-  start_date: 2022-09-02 00:00:00
-  end_date: 2022-09-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.9
-      latitude_max: 33.4
-      longitude_min: 235.8
-      longitude_max: 261.4
-  event_type: tropical_cyclone
-- case_id_number: 207
-  title: Roslyn
-  start_date: 2022-10-18 00:00:00
-  end_date: 2022-10-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 12.9
-      latitude_max: 27.8
-      longitude_min: 251.0
-      longitude_max: 261.4
-  event_type: tropical_cyclone
-- case_id_number: 208
-  title: Megi (Agaton)
-  start_date: 2022-04-06 00:00:00
-  end_date: 2022-04-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.7
-      latitude_max: 13.5
-      longitude_min: 122.4
-      longitude_max: 130.7
-  event_type: tropical_cyclone
-- case_id_number: 209
-  title: Hinnamnor (Henry)
-  start_date: 2022-08-25 00:00:00
-  end_date: 2022-09-10 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 19.1
-      latitude_max: 62.0
-      longitude_min: 122.2
-      longitude_max: 153.4
-  event_type: tropical_cyclone
-- case_id_number: 210
-  title: Muifa (Inday)
-  start_date: 2022-09-02 00:00:00
-  end_date: 2022-09-18 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.7
-      latitude_max: 45.6
-      longitude_min: 118.0
-      longitude_max: 147.7
-  event_type: tropical_cyclone
-- case_id_number: 211
-  title: Nanmadol (Josie)
-  start_date: 2022-09-09 00:00:00
-  end_date: 2022-09-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 19.5
-      latitude_max: 41.1
-      longitude_min: 128.0
-      longitude_max: 149.7
-  event_type: tropical_cyclone
-- case_id_number: 212
-  title: Noru (Karding)
-  start_date: 2022-09-19 00:00:00
-  end_date: 2022-10-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 12.8
-      latitude_max: 20.2
-      longitude_min: 101.0
-      longitude_max: 136.8
-  event_type: tropical_cyclone
-- case_id_number: 213
-  title: Nalgae (Paeng)
-  start_date: 2022-10-24 00:00:00
-  end_date: 2022-11-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.0
-      latitude_max: 24.3
-      longitude_min: 111.0
-      longitude_max: 136.6
-  event_type: tropical_cyclone
-- case_id_number: 214
-  title: Sitrang
-  start_date: 2022-10-19 00:00:00
-  end_date: 2022-10-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.4
-      latitude_max: 26.7
-      longitude_min: 85.8
-      longitude_max: 95.6
-  event_type: tropical_cyclone
-- case_id_number: 215
-  title: Ana
-  start_date: 2022-01-18 00:00:00
-  end_date: 2022-01-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -32.5
-      latitude_max: -13.3
-      longitude_min: 168.8
-      longitude_max: 191.7
-  event_type: tropical_cyclone
-- case_id_number: 216
-  title: Batsirai
-  start_date: 2022-01-22 00:00:00
-  end_date: 2022-02-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -41.7
-      latitude_max: -7.2
-      longitude_min: 38.5
-      longitude_max: 94.0
-  event_type: tropical_cyclone
-- case_id_number: 217
-  title: Gombe
-  start_date: 2022-03-04 00:00:00
-  end_date: 2022-03-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -20.7
-      latitude_max: -12.7
-      longitude_min: 34.2
-      longitude_max: 57.6
-  event_type: tropical_cyclone
-- case_id_number: 218
-  title: Seth
-  start_date: 2021-12-21 00:00:00
-  end_date: 2022-01-09 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -30.3
-      latitude_max: -6.5
-      longitude_min: 127.3
-      longitude_max: 161.5
-  event_type: tropical_cyclone
-- case_id_number: 219
-  title: Blas
-  start_date: 2022-06-12 00:00:00
-  end_date: 2022-06-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.4
-      latitude_max: 21.5
-      longitude_min: 240.9
-      longitude_max: 260.3
-  event_type: tropical_cyclone
-- case_id_number: 220
-  title: Apollo
-  start_date: 2021-10-23 00:00:00
-  end_date: 2021-11-03 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 30.0
-      latitude_max: 40.0
-      longitude_min: 10.0
-      longitude_max: 25.0
-  event_type: tropical_cyclone
-- case_id_number: 221
-  title: Elsa
-  start_date: 2021-06-28 00:00:00
-  end_date: 2021-07-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.1
-      latitude_max: 49.0
-      longitude_min: 274.1
-      longitude_max: 319.5
-  event_type: tropical_cyclone
-- case_id_number: 222
-  title: Fred
-  start_date: 2021-08-07 00:00:00
-  end_date: 2021-08-22 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.7
-      latitude_max: 44.9
-      longitude_min: 271.8
-      longitude_max: 303.6
-  event_type: tropical_cyclone
-- case_id_number: 223
-  title: Grace
-  start_date: 2021-08-11 00:00:00
-  end_date: 2021-08-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 12.8
-      latitude_max: 23.0
-      longitude_min: 259.7
-      longitude_max: 315.6
-  event_type: tropical_cyclone
-- case_id_number: 224
-  title: Henri
-  start_date: 2021-08-13 00:00:00
-  end_date: 2021-08-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 27.3
-      latitude_max: 44.5
-      longitude_min: 283.0
-      longitude_max: 299.9
-  event_type: tropical_cyclone
-- case_id_number: 225
-  title: Ida
-  start_date: 2021-08-24 00:00:00
-  end_date: 2021-09-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.3
-      latitude_max: 51.0
-      longitude_min: 266.8
-      longitude_max: 299.9
-  event_type: tropical_cyclone
-- case_id_number: 226
-  title: Larry
-  start_date: 2021-08-29 00:00:00
-  end_date: 2021-09-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.3
-      latitude_max: 57.5
-      longitude_min: 295.4
-      longitude_max: 341.7
-  event_type: tropical_cyclone
-- case_id_number: 227
-  title: Nicholas
-  start_date: 2021-09-10 00:00:00
-  end_date: 2021-09-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 18.8
-      latitude_max: 33.0
-      longitude_min: 260.9
-      longitude_max: 270.8
-  event_type: tropical_cyclone
-- case_id_number: 228
-  title: Claudette
-  start_date: 2021-06-15 00:00:00
-  end_date: 2021-06-25 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 20.3
-      latitude_max: 46.3
-      longitude_min: 265.4
-      longitude_max: 302.8
-  event_type: tropical_cyclone
-- case_id_number: 229
-  title: Nora
-  start_date: 2021-08-22 00:00:00
-  end_date: 2021-09-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.0
-      latitude_max: 26.5
-      longitude_min: 250.3
-      longitude_max: 267.3
-  event_type: tropical_cyclone
-- case_id_number: 230
-  title: Olaf
-  start_date: 2021-09-04 00:00:00
-  end_date: 2021-09-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.9
-      latitude_max: 26.9
-      longitude_min: 242.8
-      longitude_max: 256.6
-  event_type: tropical_cyclone
-- case_id_number: 231
-  title: Pamela
-  start_date: 2021-10-08 00:00:00
-  end_date: 2021-10-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.9
-      latitude_max: 27.3
-      longitude_min: 248.4
-      longitude_max: 259.9
-  event_type: tropical_cyclone
-- case_id_number: 232
-  title: Surigae (Bising)
-  start_date: 2021-04-09 00:00:00
-  end_date: 2021-05-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 3.3
-      latitude_max: 49.7
-      longitude_min: 122.5
-      longitude_max: 186.8
-  event_type: tropical_cyclone
-- case_id_number: 233
-  title: In-fa (Fabian)
-  start_date: 2021-07-14 00:00:00
-  end_date: 2021-08-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.9
-      latitude_max: 42.4
-      longitude_min: 114.4
-      longitude_max: 137.6
-  event_type: tropical_cyclone
-- case_id_number: 234
-  title: Kompasu (Maring)
-  start_date: 2021-10-05 00:00:00
-  end_date: 2021-10-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.8
-      latitude_max: 21.7
-      longitude_min: 103.4
-      longitude_max: 136.5
-  event_type: tropical_cyclone
-- case_id_number: 235
-  title: Rai
-  start_date: 2021-12-09 00:00:00
-  end_date: 2021-12-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 3.1
-      latitude_max: 23.9
-      longitude_min: 108.3
-      longitude_max: 147.3
-  event_type: tropical_cyclone
-- case_id_number: 236
-  title: Tauktae
-  start_date: 2021-05-11 00:00:00
-  end_date: 2021-05-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.8
-      latitude_max: 28.0
-      longitude_min: 68.6
-      longitude_max: 77.1
-  event_type: tropical_cyclone
-- case_id_number: 237
-  title: Yaas
-  start_date: 2021-05-21 00:00:00
-  end_date: 2021-05-29 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.2
-      latitude_max: 26.9
-      longitude_min: 82.5
-      longitude_max: 92.3
-  event_type: tropical_cyclone
-- case_id_number: 238
-  title: Gulab and Shaheen
-  start_date: 2021-09-21 00:00:00
-  end_date: 2021-10-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 15.9
-      latitude_max: 26.6
-      longitude_min: 53.7
-      longitude_max: 96.5
-  event_type: tropical_cyclone
-- case_id_number: 239
-  title: Eloise
-  start_date: 2021-01-09 00:00:00
-  end_date: 2021-01-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -24.7
-      latitude_max: -9.3
-      longitude_min: 28.8
-      longitude_max: 88.1
-  event_type: tropical_cyclone
-- case_id_number: 240
-  title: Amanda and Cristobal
-  start_date: 2020-05-28 00:00:00
-  end_date: 2020-06-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.0
-      latitude_max: 55.6
-      longitude_min: 265.0
-      longitude_max: 283.3
-  event_type: tropical_cyclone
-- case_id_number: 241
-  title: Hanna
-  start_date: 2020-07-21 00:00:00
-  end_date: 2020-07-28 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 23.5
-      latitude_max: 29.4
-      longitude_min: 257.2
-      longitude_max: 274.2
-  event_type: tropical_cyclone
-- case_id_number: 242
-  title: Isaias
-  start_date: 2020-07-26 00:00:00
-  end_date: 2020-08-07 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.3
-      latitude_max: 48.9
-      longitude_min: 277.7
-      longitude_max: 308.3
-  event_type: tropical_cyclone
-- case_id_number: 243
-  title: Laura
-  start_date: 2020-08-18 00:00:00
-  end_date: 2020-08-31 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 12.2
-      latitude_max: 40.5
-      longitude_min: 264.3
-      longitude_max: 315.0
-  event_type: tropical_cyclone
-- case_id_number: 244
-  title: Nana
-  start_date: 2020-08-30 00:00:00
-  end_date: 2020-09-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 13.6
-      latitude_max: 19.3
-      longitude_min: 266.3
-      longitude_max: 287.1
-  event_type: tropical_cyclone
-- case_id_number: 245
-  title: Paulette
-  start_date: 2020-09-05 00:00:00
-  end_date: 2020-09-30 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.7
-      latitude_max: 49.3
-      longitude_min: 292.8
-      longitude_max: 345.7
-  event_type: tropical_cyclone
-- case_id_number: 246
-  title: Sally
-  start_date: 2020-09-09 00:00:00
-  end_date: 2020-09-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 23.2
-      latitude_max: 36.3
-      longitude_min: 269.4
-      longitude_max: 283.9
-  event_type: tropical_cyclone
-- case_id_number: 247
-  title: Teddy
-  start_date: 2020-09-10 00:00:00
-  end_date: 2020-09-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 8.8
-      latitude_max: 55.0
-      longitude_min: 293.4
-      longitude_max: 330.9
-  event_type: tropical_cyclone
-- case_id_number: 248
-  title: Delta
-  start_date: 2020-10-02 00:00:00
-  end_date: 2020-10-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 14.2
-      latitude_max: 37.3
-      longitude_min: 263.9
-      longitude_max: 286.1
-  event_type: tropical_cyclone
-- case_id_number: 249
-  title: Zeta
-  start_date: 2020-10-22 00:00:00
-  end_date: 2020-11-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 15.5
-      latitude_max: 41.7
-      longitude_min: 265.9
-      longitude_max: 290.7
-  event_type: tropical_cyclone
-- case_id_number: 250
-  title: Eta
-  start_date: 2020-10-29 00:00:00
-  end_date: 2020-11-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 11.4
-      latitude_max: 37.9
-      longitude_min: 269.9
-      longitude_max: 293.1
-  event_type: tropical_cyclone
-- case_id_number: 251
-  title: Iota
-  start_date: 2020-11-10 00:00:00
-  end_date: 2020-11-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.3
-      latitude_max: 17.7
-      longitude_min: 268.7
-      longitude_max: 291.4
-  event_type: tropical_cyclone
-- case_id_number: 252
-  title: Genevieve
-  start_date: 2020-08-14 00:00:00
-  end_date: 2020-08-24 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 9.1
-      latitude_max: 29.2
-      longitude_min: 240.3
-      longitude_max: 265.8
-  event_type: tropical_cyclone
-- case_id_number: 253
-  title: Hagupit (Dindo)
-  start_date: 2020-07-29 00:00:00
-  end_date: 2020-08-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 15.0
-      latitude_max: 54.5
-      longitude_min: 117.9
-      longitude_max: 182.5
-  event_type: tropical_cyclone
-- case_id_number: 254
-  title: Maysak
-  start_date: 2020-08-24 00:00:00
-  end_date: 2020-09-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.6
-      latitude_max: 55.4
-      longitude_min: 120.7
-      longitude_max: 136.2
-  event_type: tropical_cyclone
-- case_id_number: 255
-  title: Noul (Leon)
-  start_date: 2020-09-12 00:00:00
-  end_date: 2020-09-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 8.8
-      latitude_max: 18.7
-      longitude_min: 98.2
-      longitude_max: 129.6
-  event_type: tropical_cyclone
-- case_id_number: 256
-  title: Linfa
-  start_date: 2020-10-05 00:00:00
-  end_date: 2020-10-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.3
-      latitude_max: 17.3
-      longitude_min: 104.6
-      longitude_max: 127.1
-  event_type: tropical_cyclone
-- case_id_number: 257
-  title: Molave (Quinta)
-  start_date: 2020-10-19 00:00:00
-  end_date: 2020-10-31 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 6.5
-      latitude_max: 17.8
-      longitude_min: 101.8
-      longitude_max: 139.8
-  event_type: tropical_cyclone
-- case_id_number: 258
-  title: Goni (Rolly)
-  start_date: 2020-10-23 00:00:00
-  end_date: 2020-11-08 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 8.4
-      latitude_max: 18.9
-      longitude_min: 105.6
-      longitude_max: 146.2
-  event_type: tropical_cyclone
-- case_id_number: 259
-  title: Vamco (Ulysse)
-  start_date: 2020-11-06 00:00:00
-  end_date: 2020-11-18 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 5.8
-      latitude_max: 21.5
-      longitude_min: 101.3
-      longitude_max: 137.2
-  event_type: tropical_cyclone
-- case_id_number: 260
-  title: Remal
-  start_date: 2024-05-23 00:00:00
-  end_date: 2024-05-29 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 16.6
-      latitude_max: 26.4
-      longitude_min: 86.0
-      longitude_max: 92.8
-  event_type: tropical_cyclone
-- case_id_number: 261
-  title: Amphan
-  start_date: 2020-05-13 00:00:00
-  end_date: 2020-05-23 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 7.3
-      latitude_max: 27.6
-      longitude_min: 83.8
-      longitude_max: 92.4
-  event_type: tropical_cyclone
-- case_id_number: 262
-  title: Nisarga
-  start_date: 2020-05-29 00:00:00
-  end_date: 2020-06-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 10.7
-      latitude_max: 24.4
-      longitude_min: 68.8
-      longitude_max: 79.9
-  event_type: tropical_cyclone
-- case_id_number: 263
-  title: Damien
-  start_date: 2020-02-01 00:00:00
-  end_date: 2020-02-12 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -27.9
-      latitude_max: -13.8
-      longitude_min: 113.9
-      longitude_max: 131.8
-  event_type: tropical_cyclone
-- case_id_number: 264
-  title: Harold
-  start_date: 2023-08-19 00:00:00
-  end_date: 2023-08-25 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -37.2
-      latitude_max: -7.0
-      longitude_min: 152.2
-      longitude_max: 214.7
-  event_type: tropical_cyclone
-- case_id_number: 265
-  title: Ianos
-  start_date: 2020-09-16 00:00:00
-  end_date: 2020-09-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: 30.0
-      latitude_max: 40.0
-      longitude_min: 15.0
-      longitude_max: 25.0
-  event_type: tropical_cyclone
-- case_id_number: 266
-  title: January 2020 Australia
-  start_date: 2020-01-20 00:00:00
-  end_date: 2020-01-21 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 267
-  title: April 2020 Australia
-  start_date: 2020-04-03 00:00:00
-  end_date: 2020-04-04 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 268
-  title: May 2020 Australia
-  start_date: 2020-05-31 00:00:00
-  end_date: 2020-06-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 269
-  title: September 2020 Australia
-  start_date: 2020-09-05 00:00:00
-  end_date: 2020-09-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 270
-  title: October 2020 Australia
-  start_date: 2020-10-31 00:00:00
-  end_date: 2020-11-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 271
-  title: December 2020 Australia
-  start_date: 2020-12-05 00:00:00
-  end_date: 2020-12-06 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 272
-  title: September 2021 Australia
-  start_date: 2021-09-30 00:00:00
-  end_date: 2021-10-01 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 273
-  title: October 2021 Australia
-  start_date: 2021-10-14 00:00:00
-  end_date: 2021-10-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 274
-  title: October 2021 Australia
-  start_date: 2021-10-18 00:00:00
-  end_date: 2021-10-19 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 275
-  title: October 2021 Australia
-  start_date: 2021-10-19 00:00:00
-  end_date: 2021-10-20 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 276
-  title: October 2021 Australia
-  start_date: 2021-10-28 00:00:00
-  end_date: 2021-10-29 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 277
-  title: December 2021 Australia
-  start_date: 2021-12-03 00:00:00
-  end_date: 2021-12-04 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 278
-  title: December 2021 Australia
-  start_date: 2021-12-09 00:00:00
-  end_date: 2021-12-10 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 279
-  title: January 2022 Australia
-  start_date: 2022-01-15 00:00:00
-  end_date: 2022-01-16 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 280
-  title: March 2022 Australia
-  start_date: 2022-03-04 00:00:00
-  end_date: 2022-03-05 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 281
-  title: December 2022 Australia
-  start_date: 2022-12-08 00:00:00
-  end_date: 2022-12-09 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 282
-  title: February 2023 Australia
-  start_date: 2023-02-14 00:00:00
-  end_date: 2023-02-15 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 283
-  title: December 2023 Australia
-  start_date: 2023-12-12 00:00:00
-  end_date: 2023-12-13 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 284
-  title: December 2023 Australia
-  start_date: 2023-12-25 00:00:00
-  end_date: 2023-12-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 285
-  title: December 2023 Australia
-  start_date: 2023-12-26 00:00:00
-  end_date: 2023-12-27 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 286
-  title: August 2024 Australia
-  start_date: 2024-08-25 00:00:00
-  end_date: 2024-08-26 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 287
-  title: October 2024 Australia
-  start_date: 2024-10-09 00:00:00
-  end_date: 2024-10-10 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 288
-  title: October 2024 Australia
-  start_date: 2024-10-17 00:00:00
-  end_date: 2024-10-18 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 289
-  title: November 2024 Australia
-  start_date: 2024-11-01 00:00:00
-  end_date: 2024-11-02 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
-- case_id_number: 290
-  title: November 2024 Australia
-  start_date: 2024-11-13 00:00:00
-  end_date: 2024-11-14 00:00:00
-  location:
-    type: bounded_region
-    parameters:
-      latitude_min: -40.0
-      latitude_max: -10.0
-      longitude_min: 110.0
-      longitude_max: 155.0
-  event_type: severe_convection
+  - case_id_number: 1
+    title: 2021 Pacific Northwest
+    start_date: 2021-06-20 00:00:00
+    end_date: 2021-07-03 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 47.6062
+        longitude: 237.6679
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 2
+    title: 2022 Upper Midwest
+    start_date: 2022-05-07 00:00:00
+    end_date: 2022-05-17 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 41.8781
+        longitude: 272.3702
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 3
+    title: 2022 California
+    start_date: 2022-06-07 00:00:00
+    end_date: 2022-06-15 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 34.0522
+        longitude: 241.7563
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 4
+    title: 2022 Texas
+    start_date: 2022-06-30 00:00:00
+    end_date: 2022-07-18 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 32.7767
+        longitude: 263.203
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 5
+    title: 2023 Pacific Northwest
+    start_date: 2023-05-10 00:00:00
+    end_date: 2023-05-23 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 47.6062
+        longitude: 237.6679
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 6
+    title: 2022 Mid-Atlantic
+    start_date: 2022-05-17 00:00:00
+    end_date: 2022-05-24 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 39.2904
+        longitude: 283.38779999999997
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 7
+    title: 2023 Australia
+    start_date: 2023-11-18 00:00:00
+    end_date: 2023-11-28 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -31.9505
+        longitude: 115.8605
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 8
+    title: 2023 Ireland
+    start_date: 2023-09-02 00:00:00
+    end_date: 2023-09-13 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 53.1424
+        longitude: 352.3079
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 9
+    title: 2023 Italy
+    start_date: 2023-07-07 00:00:00
+    end_date: 2023-07-27 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 41.9028
+        longitude: 12.4964
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 10
+    title: 2023 SW Europe
+    start_date: 2023-08-17 00:00:00
+    end_date: 2023-08-28 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 40.4637
+        longitude: 356.2508
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 11
+    title: 2023 South America
+    start_date: 2023-07-29 00:00:00
+    end_date: 2023-08-04 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -34.6037
+        longitude: 301.6184
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 12
+    title: 2023 China (Shanghai)
+    start_date: 2023-05-24 00:00:00
+    end_date: 2023-06-01 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 31.2304
+        longitude: 121.4737
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 13
+    title: 2023 China (Yunnan Province)
+    start_date: 2023-04-14 00:00:00
+    end_date: 2023-04-23 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 25.0458
+        longitude: 102.71
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 14
+    title: 2023 Algeria
+    start_date: 2023-07-05 00:00:00
+    end_date: 2023-07-27 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 36.7372
+        longitude: 3.0869
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 15
+    title: 2023 Iberian Peninsula
+    start_date: 2023-04-22 00:00:00
+    end_date: 2023-05-01 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 41.1496
+        longitude: 352.389
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 16
+    title: 2023 Southeast Asia
+    start_date: 2023-04-16 00:00:00
+    end_date: 2023-04-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.0
+        latitude_max: 31.5
+        longitude_min: 61.5
+        longitude_max: 113.75
+    event_type: heat_wave
+  - case_id_number: 17
+    title: 2023 India
+    start_date: 2023-02-15 00:00:00
+    end_date: 2023-03-01 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 28.6139
+        longitude: 77.209
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 18
+    title: 2021 Western Russia
+    start_date: 2021-06-18 00:00:00
+    end_date: 2021-06-30 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 55.7558
+        longitude: 37.6173
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 19
+    title: 2022 Germany
+    start_date: 2022-12-23 00:00:00
+    end_date: 2022-12-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 52.52
+        longitude: 13.405
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 20
+    title: 2022 UK (August)
+    start_date: 2022-08-08 00:00:00
+    end_date: 2022-08-16 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 51.5074
+        longitude: 359.8722
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 21
+    title: 2022 UK (July)
+    start_date: 2022-07-15 00:00:00
+    end_date: 2022-07-23 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 51.5074
+        longitude: 359.8722
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 22
+    title: 2022 France
+    start_date: 2022-06-09 00:00:00
+    end_date: 2022-06-21 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 43.4832
+        longitude: 358.4414
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 23
+    title: 2022 Japan
+    start_date: 2022-06-20 00:00:00
+    end_date: 2022-07-05 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 35.6895
+        longitude: 139.6917
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 24
+    title: 2022 India
+    start_date: 2022-04-24 00:00:00
+    end_date: 2022-05-04 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 28.2769
+        longitude: 68.4376
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 25
+    title: 2022 East Antarctica
+    start_date: 2022-03-12 00:00:00
+    end_date: 2022-03-26 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -75.1
+        longitude: 123.35
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 26
+    title: 2022 West Australia
+    start_date: 2022-01-15 00:00:00
+    end_date: 2022-01-25 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -31.9505
+        longitude: 115.8605
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 27
+    title: 2021 Canada Plains
+    start_date: 2021-05-30 00:00:00
+    end_date: 2021-06-09 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 49.0
+        longitude: 262.43330000000003
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 28
+    title: 2021 New Zealand
+    start_date: 2021-01-12 18:00:00
+    end_date: 2021-01-18 18:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -43.8983
+        longitude: 171.731
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 29
+    title: 2020 Australia
+    start_date: 2020-11-25 00:00:00
+    end_date: 2020-12-01 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -33.8245
+        longitude: 150.9448
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 30
+    title: 2021 Texas
+    start_date: 2021-02-10 12:00:00
+    end_date: 2021-02-22 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 30.2672
+        longitude: 262.2569
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 31
+    title: 2022 Arkansas
+    start_date: 2022-02-17 18:00:00
+    end_date: 2022-03-01 06:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 34.7445
+        longitude: 267.7104
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 32
+    title: 2023 Germany
+    start_date: 2023-12-02 06:00:00
+    end_date: 2023-12-08 06:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 48.1351
+        longitude: 11.582
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 33
+    title: 2023 China
+    start_date: 2023-12-15 06:00:00
+    end_date: 2023-12-26 18:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 31.2304
+        longitude: 121.4737
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 34
+    title: 2023 Afghanistan
+    start_date: 2023-01-11 06:00:00
+    end_date: 2023-01-28 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 34.5553
+        longitude: 69.2075
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 35
+    title: 2022 Colorado
+    start_date: 2022-04-06 00:00:00
+    end_date: 2022-04-16 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 39.7392
+        longitude: 255.0097
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 36
+    title: July 2024 South Dakota
+    start_date: 2024-07-13 00:00:00
+    end_date: 2024-07-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 49.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 37
+    title: July 2024 Chicago
+    start_date: 2024-07-14 00:00:00
+    end_date: 2024-07-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 49.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 38
+    title: July 2024 New York
+    start_date: 2024-07-16 00:00:00
+    end_date: 2024-07-17 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 49.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 39
+    title: May 2024 Wisconsin
+    start_date: 2024-05-18 00:00:00
+    end_date: 2024-05-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 40
+    title: May 2024 Kansas
+    start_date: 2024-05-19 00:00:00
+    end_date: 2024-05-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 41
+    title: May 2024 Iowa + Nebraska
+    start_date: 2024-05-20 00:00:00
+    end_date: 2024-05-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 42
+    title: May 2024 Iowa + Wisconsin
+    start_date: 2024-05-21 00:00:00
+    end_date: 2024-05-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 43
+    title: May 2024 Texas
+    start_date: 2024-05-22 00:00:00
+    end_date: 2024-05-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 44
+    title: May 2024 Iowa + Nebraska 2
+    start_date: 2024-05-23 00:00:00
+    end_date: 2024-05-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 45
+    title: April 2024 Oklahoma
+    start_date: 2024-04-25 12:00:00
+    end_date: 2024-04-29 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 46
+    title: April 2024 Midwest
+    start_date: 2024-04-02 12:00:00
+    end_date: 2024-04-03 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 47
+    title: April 2024 Great Plains + Midwest
+    start_date: 2024-04-01 12:00:00
+    end_date: 2024-04-02 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 48
+    title: March 2024 Midwest
+    start_date: 2024-03-14 12:00:00
+    end_date: 2024-03-15 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 49
+    title: February 2024 Midwest
+    start_date: 2024-02-27 12:00:00
+    end_date: 2024-02-28 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 50
+    title: January 2024 Southeast
+    start_date: 2024-01-08 12:00:00
+    end_date: 2024-01-10 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 51
+    title: December 2023 South
+    start_date: 2023-12-09 12:00:00
+    end_date: 2023-12-10 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 52
+    title: August 2023 East Coast
+    start_date: 2023-08-07 12:00:00
+    end_date: 2023-08-08 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 53
+    title: August 2023 Minnesota
+    start_date: 2023-08-11 12:00:00
+    end_date: 2023-08-12 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 54
+    title: July 2023 Midwest
+    start_date: 2023-07-02 12:00:00
+    end_date: 2023-07-03 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 55
+    title: July 2023 Midwest 2
+    start_date: 2023-07-01 12:00:00
+    end_date: 2023-07-02 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 56
+    title: June 2023 Midwest
+    start_date: 2023-06-30 12:00:00
+    end_date: 2023-07-01 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 57
+    title: June 2023 Front Range
+    start_date: 2023-06-21 12:00:00
+    end_date: 2023-06-22 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 58
+    title: June 2023 Texas
+    start_date: 2023-06-21 12:00:00
+    end_date: 2023-06-22 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 59
+    title: June 2023 Great Plains
+    start_date: 2023-06-23 12:00:00
+    end_date: 2023-06-24 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 60
+    title: June 2023 Iowa + Minnesota
+    start_date: 2023-06-24 12:00:00
+    end_date: 2023-06-25 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 61
+    title: June 2023 South + Midwest
+    start_date: 2023-06-25 12:00:00
+    end_date: 2023-06-26 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 62
+    title: June 2023 East Coast
+    start_date: 2023-06-26 12:00:00
+    end_date: 2023-06-27 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 63
+    title: June 2023 Midwest + Great Plains
+    start_date: 2023-06-29 12:00:00
+    end_date: 2023-06-30 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 64
+    title: June 2023 Southeast
+    start_date: 2023-06-14 12:00:00
+    end_date: 2023-06-15 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 65
+    title: June 2023 OK + TX + South
+    start_date: 2023-06-15 12:00:00
+    end_date: 2023-06-16 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 66
+    title: June 2023 South
+    start_date: 2023-06-16 12:00:00
+    end_date: 2023-06-17 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 67
+    title: June 2023 Mid-Atlantic
+    start_date: 2023-06-16 12:00:00
+    end_date: 2023-06-17 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 68
+    title: June 2023 Great Plains + South
+    start_date: 2023-06-17 12:00:00
+    end_date: 2023-06-18 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 69
+    title: May 2023 Great Plains
+    start_date: 2023-05-10 12:00:00
+    end_date: 2023-05-11 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 70
+    title: May 2023 Great Plains + South
+    start_date: 2023-05-11 12:00:00
+    end_date: 2023-05-12 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 71
+    title: May 2023 Nebraska
+    start_date: 2023-05-12 12:00:00
+    end_date: 2023-05-13 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 54.0
+        longitude_min: 245.0
+        longitude_max: 295.0
+    event_type: severe_convection
+  - case_id_number: 72
+    title: May 2024 Texas
+    start_date: 2024-05-25 00:00:00
+    end_date: 2024-05-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 25.9017
+        longitude: 262.50260000000003
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 73
+    title: June 2024 Northeast US
+    start_date: 2024-06-17 00:00:00
+    end_date: 2024-06-23 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 41.8781
+        longitude: 286.771
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 74
+    title: July 2024 Southwest US
+    start_date: 2024-07-04 00:00:00
+    end_date: 2024-07-10 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 33.7701
+        longitude: 243.78539999999998
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 75
+    title: July 2024 Northeast US
+    start_date: 2024-07-07 00:00:00
+    end_date: 2024-07-13 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 40.7128
+        longitude: 285.994
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 76
+    title: July 2024 Mid-Atlantic US
+    start_date: 2024-07-15 00:00:00
+    end_date: 2024-07-21 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 39.9526
+        longitude: 284.8348
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 77
+    title: August 2024 Midwest US
+    start_date: 2024-08-25 00:00:00
+    end_date: 2024-08-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 40.1106
+        longitude: 271.79269999999997
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 78
+    title: July 2024 Antarctica
+    start_date: 2024-07-01 00:00:00
+    end_date: 2024-07-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -75.0
+        longitude: 15.0
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 79
+    title: August 2024 Canada
+    start_date: 2024-08-09 00:00:00
+    end_date: 2024-08-15 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 67.0
+        longitude: 248.0
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 80
+    title: August 2024 Australia
+    start_date: 2024-08-22 00:00:00
+    end_date: 2024-08-30 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -20.0
+        longitude: 120.0
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 81
+    title: July/August 2024 Japan
+    start_date: 2024-07-25 00:00:00
+    end_date: 2024-08-05 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 36.0
+        longitude: 138.0
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 82
+    title: June 2024 Saudi Arabia
+    start_date: 2024-06-16 00:00:00
+    end_date: 2024-06-22 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 24.0
+        longitude: 45.0
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 83
+    title: August 2024 Europe
+    start_date: 2024-08-10 00:00:00
+    end_date: 2024-08-16 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 48.3794
+        longitude: 10.8978
+        bounding_box_degrees: 10
+    event_type: heat_wave
+  - case_id_number: 84
+    title: July 2024 Ukraine
+    start_date: 2024-07-12 00:00:00
+    end_date: 2024-07-18 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 50.4501
+        longitude: 30.5234
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 85
+    title: June 2024 Europe
+    start_date: 2024-06-20 00:00:00
+    end_date: 2024-06-30 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 52.3676
+        longitude: 4.9041
+        bounding_box_degrees: 6
+    event_type: heat_wave
+  - case_id_number: 86
+    title: May 2024 Central Mexico
+    start_date: 2024-05-23 00:00:00
+    end_date: 2024-05-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 19.4326
+        longitude: 260.8668
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 87
+    title: May 2024 Pakistan/India
+    start_date: 2024-05-23 00:00:00
+    end_date: 2024-05-31 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 34.0
+        longitude: 76.0
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 88
+    title: August 2023 Chile
+    start_date: 2023-08-01 00:00:00
+    end_date: 2023-08-07 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: -33.4489
+        longitude: 289.3307
+        bounding_box_degrees: 5
+    event_type: heat_wave
+  - case_id_number: 89
+    title: January 2024 Pacific Northwest
+    start_date: 2024-01-11 12:00:00
+    end_date: 2024-01-20 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 47.6062
+        longitude: 237.6679
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 90
+    title: April 2022 Nevada
+    start_date: 2022-04-11 18:00:00
+    end_date: 2022-04-17 18:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 40.8324
+        longitude: 244.2369
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 91
+    title: February/March 2021 New England
+    start_date: 2021-03-04 18:00:00
+    end_date: 2021-03-10 18:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 42.8509
+        longitude: 287.4421
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 92
+    title: January 2024 Northern Europe
+    start_date: 2024-01-01 06:00:00
+    end_date: 2024-01-09 12:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 59.3293
+        longitude: 18.0686
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 93
+    title: December 2022 Europe
+    start_date: 2022-12-10 06:00:00
+    end_date: 2022-12-20 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 52.52
+        longitude: 13.405
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 94
+    title: April 2024 Europe
+    start_date: 2024-04-16 12:00:00
+    end_date: 2024-04-27 12:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 48.8566
+        longitude: 2.3522
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 95
+    title: January 2023 North China
+    start_date: 2024-01-20 00:00:00
+    end_date: 2024-02-04 18:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 42.5246
+        longitude: 122.3853
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 96
+    title: April 2024 Sweden
+    start_date: 2024-04-02 00:00:00
+    end_date: 2024-04-08 00:00:00
+    location:
+      type: centered_region
+      parameters:
+        latitude: 60.1282
+        longitude: 18.6435
+        bounding_box_degrees: 5
+    event_type: freeze
+  - case_id_number: 97
+    title: November 2024 West Coast US
+    start_date: 2024-11-20 00:00:00
+    end_date: 2024-11-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 35.0
+        latitude_max: 50.0
+        longitude_min: 230.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 98
+    title: October 2024 British Columbia
+    start_date: 2024-10-18 00:00:00
+    end_date: 2024-10-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 55.0
+        longitude_min: 225.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 99
+    title: September 2024 SW Alaska and British Columbia
+    start_date: 2024-09-22 00:00:00
+    end_date: 2024-09-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 45.0
+        latitude_max: 60.0
+        longitude_min: 220.0
+        longitude_max: 240.0
+    event_type: atmospheric_river
+  - case_id_number: 100
+    title: October 2024 Bosnia
+    start_date: 2024-10-03 00:00:00
+    end_date: 2024-10-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 42.0
+        latitude_max: 46.0
+        longitude_min: 16.0
+        longitude_max: 20.0
+    event_type: atmospheric_river
+  - case_id_number: 101
+    title: April 2024 Eastern Australia
+    start_date: 2024-04-05 00:00:00
+    end_date: 2024-04-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -38.0
+        latitude_max: -25.0
+        longitude_min: 140.0
+        longitude_max: 155.0
+    event_type: atmospheric_river
+  - case_id_number: 102
+    title: April 2024 Persian Gulf
+    start_date: 2024-04-14 00:00:00
+    end_date: 2024-04-18 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.0
+        latitude_max: 30.0
+        longitude_min: 48.0
+        longitude_max: 58.0
+    event_type: atmospheric_river
+  - case_id_number: 103
+    title: February 2024 Pacific Northwest
+    start_date: 2024-02-28 00:00:00
+    end_date: 2024-03-04 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 104
+    title: February 2024 California
+    start_date: 2024-02-18 00:00:00
+    end_date: 2024-02-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 105
+    title: February 2024 California
+    start_date: 2024-02-03 00:00:00
+    end_date: 2024-02-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 106
+    title: January 2024 Alaska to California
+    start_date: 2024-01-26 00:00:00
+    end_date: 2024-02-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 65.0
+        longitude_min: 210.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 107
+    title: January 2024 California and Arizona
+    start_date: 2024-01-22 00:00:00
+    end_date: 2024-01-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 38.0
+        longitude_min: 240.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 108
+    title: December 2023 East Coast Cyclone
+    start_date: 2023-12-17 00:00:00
+    end_date: 2023-12-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 25.0
+        latitude_max: 45.0
+        longitude_min: 275.0
+        longitude_max: 295.0
+    event_type: atmospheric_river
+  - case_id_number: 109
+    title: June 2023 Northwest Cloudband
+    start_date: 2023-06-25 00:00:00
+    end_date: 2023-06-28 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -28.0
+        latitude_max: -15.0
+        longitude_min: 120.0
+        longitude_max: 140.0
+    event_type: atmospheric_river
+  - case_id_number: 110
+    title: April 2023 Middle East
+    start_date: 2023-04-01 00:00:00
+    end_date: 2023-05-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 20.0
+        latitude_max: 40.0
+        longitude_min: 30.0
+        longitude_max: 60.0
+    event_type: atmospheric_river
+  - case_id_number: 111
+    title: March 2023 California and Arizona
+    start_date: 2023-03-09 00:00:00
+    end_date: 2023-03-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 38.0
+        longitude_min: 240.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 112
+    title: March 2023 California
+    start_date: 2023-03-09 00:00:00
+    end_date: 2023-03-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 113
+    title: February 2023 Pacific Northwest
+    start_date: 2023-02-17 00:00:00
+    end_date: 2023-02-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 114
+    title: December 2022 - January 2023 California
+    start_date: 2022-12-01 00:00:00
+    end_date: 2023-02-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 115
+    title: December 2022 California
+    start_date: 2022-12-26 00:00:00
+    end_date: 2022-12-28 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 116
+    title: December 2022 Oregon and California
+    start_date: 2022-12-09 00:00:00
+    end_date: 2022-12-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 45.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 117
+    title: November 2022 - December 2022 California
+    start_date: 2022-11-29 00:00:00
+    end_date: 2022-12-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 118
+    title: October 2022 Victoria
+    start_date: 2022-10-13 00:00:00
+    end_date: 2022-10-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -39.0
+        latitude_max: -34.0
+        longitude_min: 140.0
+        longitude_max: 150.0
+    event_type: atmospheric_river
+  - case_id_number: 119
+    title: October 2022 Victoria
+    start_date: 2022-10-30 00:00:00
+    end_date: 2022-10-31 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -39.0
+        latitude_max: -34.0
+        longitude_min: 140.0
+        longitude_max: 150.0
+    event_type: atmospheric_river
+  - case_id_number: 120
+    title: November 2022 California
+    start_date: 2022-11-07 00:00:00
+    end_date: 2022-11-09 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 121
+    title: November 2022 Pacific Northwest
+    start_date: 2022-11-03 00:00:00
+    end_date: 2022-11-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 122
+    title: August 2022 Japan
+    start_date: 2022-08-01 00:00:00
+    end_date: 2022-09-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 35.0
+        latitude_max: 45.0
+        longitude_min: 130.0
+        longitude_max: 145.0
+    event_type: atmospheric_river
+  - case_id_number: 123
+    title: June 2022 Pacific Northwest, Wyoming, and Montana
+    start_date: 2022-06-09 00:00:00
+    end_date: 2022-06-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 124
+    title: March 2022 East Antarctica
+    start_date: 2022-03-15 00:00:00
+    end_date: 2022-03-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -90.0
+        latitude_max: -70.0
+        longitude_min: 60.0
+        longitude_max: 160.0
+    event_type: atmospheric_river
+  - case_id_number: 125
+    title: February 2022 Southeast QLD / Northern NSW
+    start_date: 2022-02-26 00:00:00
+    end_date: 2022-03-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -30.0
+        latitude_max: -25.0
+        longitude_min: 150.0
+        longitude_max: 155.0
+    event_type: atmospheric_river
+  - case_id_number: 126
+    title: February 2022 Pacific Northwest
+    start_date: 2022-02-26 00:00:00
+    end_date: 2022-03-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 127
+    title: January 2022 Norway and Sweden
+    start_date: 2022-01-14 00:00:00
+    end_date: 2022-01-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 58.0
+        latitude_max: 65.0
+        longitude_min: 5.0
+        longitude_max: 20.0
+    event_type: atmospheric_river
+  - case_id_number: 128
+    title: January 2022 Colorado
+    start_date: 2022-01-04 00:00:00
+    end_date: 2022-01-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 37.0
+        latitude_max: 41.0
+        longitude_min: 251.0
+        longitude_max: 258.0
+    event_type: atmospheric_river
+  - case_id_number: 129
+    title: January 2022 Pacific Northwest
+    start_date: 2022-01-02 00:00:00
+    end_date: 2022-01-09 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 130
+    title: December 2021 - January 2022 Western US
+    start_date: 2021-12-22 00:00:00
+    end_date: 2022-01-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 131
+    title: December 2021 Pacific NW
+    start_date: 2021-12-10 00:00:00
+    end_date: 2021-12-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 132
+    title: November 2021 Pacific Northwest
+    start_date: 2021-11-10 00:00:00
+    end_date: 2021-11-17 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 133
+    title: October 2021 California
+    start_date: 2021-10-19 00:00:00
+    end_date: 2021-10-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 42.0
+        longitude_min: 235.0
+        longitude_max: 245.0
+    event_type: atmospheric_river
+  - case_id_number: 134
+    title: September 2021 Pacific Northwest
+    start_date: 2021-09-16 00:00:00
+    end_date: 2021-09-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 135
+    title: June 2021 Bloomington Indiana
+    start_date: 2021-06-18 00:00:00
+    end_date: 2021-06-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 39.0
+        latitude_max: 40.0
+        longitude_min: 273.0
+        longitude_max: 274.0
+    event_type: atmospheric_river
+  - case_id_number: 136
+    title: June 2021 Alaska Trans-Pacific
+    start_date: 2021-06-24 00:00:00
+    end_date: 2021-06-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 55.0
+        latitude_max: 70.0
+        longitude_min: 190.0
+        longitude_max: 230.0
+    event_type: atmospheric_river
+  - case_id_number: 137
+    title: March 2021 Sydney
+    start_date: 2021-03-17 00:00:00
+    end_date: 2021-03-25 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -34.0
+        latitude_max: -33.0
+        longitude_min: 150.0
+        longitude_max: 152.0
+    event_type: atmospheric_river
+  - case_id_number: 138
+    title: February 2021 Pacific Northwest
+    start_date: 2021-02-21 00:00:00
+    end_date: 2021-02-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 139
+    title: January 2021 Pacific NW
+    start_date: 2021-01-11 00:00:00
+    end_date: 2021-01-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 140
+    title: January 2021 Pacific Northwest
+    start_date: 2021-01-01 00:00:00
+    end_date: 2021-01-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 141
+    title: December 2020 Pacific Northwest
+    start_date: 2020-12-17 00:00:00
+    end_date: 2020-12-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 142
+    title: December 2020 Western US
+    start_date: 2020-12-11 00:00:00
+    end_date: 2020-12-18 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 143
+    title: December 2020 Alaska
+    start_date: 2020-12-01 00:00:00
+    end_date: 2020-12-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 55.0
+        latitude_max: 65.0
+        longitude_min: 200.0
+        longitude_max: 230.0
+    event_type: atmospheric_river
+  - case_id_number: 144
+    title: November 2020 Western US
+    start_date: 2020-11-16 00:00:00
+    end_date: 2020-11-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 145
+    title: October 2020 Western Alps
+    start_date: 2020-10-02 00:00:00
+    end_date: 2020-10-04 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 44.0
+        latitude_max: 47.0
+        longitude_min: 5.0
+        longitude_max: 9.0
+    event_type: atmospheric_river
+  - case_id_number: 146
+    title: September 2020 Pacific Northwest
+    start_date: 2020-09-23 00:00:00
+    end_date: 2020-09-28 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 147
+    title: September 2020 Pacific Northwest
+    start_date: 2020-09-14 00:00:00
+    end_date: 2020-09-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 148
+    title: May 2020 Western US
+    start_date: 2020-05-16 00:00:00
+    end_date: 2020-05-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 149
+    title: March 2020 Southwestern US
+    start_date: 2020-03-09 00:00:00
+    end_date: 2020-03-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 30.0
+        latitude_max: 40.0
+        longitude_min: 240.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 150
+    title: February 2020 Southwestern US
+    start_date: 2020-02-21 00:00:00
+    end_date: 2020-02-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 30.0
+        latitude_max: 40.0
+        longitude_min: 240.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 151
+    title: February 2020 Western US
+    start_date: 2020-02-04 00:00:00
+    end_date: 2020-02-09 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 255.0
+    event_type: atmospheric_river
+  - case_id_number: 152
+    title: January 2020 Pacific Northwest
+    start_date: 2020-01-26 00:00:00
+    end_date: 2020-02-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 50.0
+        longitude_min: 235.0
+        longitude_max: 250.0
+    event_type: atmospheric_river
+  - case_id_number: 153
+    title: Milton
+    start_date: 2024-10-02 00:00:00
+    end_date: 2024-10-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 18.6
+        latitude_max: 31.7
+        longitude_min: 262.1
+        longitude_max: 296.5
+    event_type: tropical_cyclone
+  - case_id_number: 154
+    title: Helene
+    start_date: 2024-09-21 00:00:00
+    end_date: 2024-09-30 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 15.0
+        latitude_max: 40.3
+        longitude_min: 269.5
+        longitude_max: 280.7
+    event_type: tropical_cyclone
+  - case_id_number: 155
+    title: Francine
+    start_date: 2024-09-06 00:00:00
+    end_date: 2024-09-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 19.2
+        latitude_max: 38.1
+        longitude_min: 261.4
+        longitude_max: 272.7
+    event_type: tropical_cyclone
+  - case_id_number: 156
+    title: Debby
+    start_date: 2024-07-31 00:00:00
+    end_date: 2024-08-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 18.2
+        latitude_max: 52.2
+        longitude_min: 273.2
+        longitude_max: 302.9
+    event_type: tropical_cyclone
+  - case_id_number: 157
+    title: Beryl
+    start_date: 2024-06-26 00:00:00
+    end_date: 2024-07-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 6.7
+        latitude_max: 45.3
+        longitude_min: 261.7
+        longitude_max: 322.7
+    event_type: tropical_cyclone
+  - case_id_number: 158
+    title: John
+    start_date: 2024-09-20 00:00:00
+    end_date: 2024-09-29 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.6
+        latitude_max: 20.5
+        longitude_min: 254.5
+        longitude_max: 263.9
+    event_type: tropical_cyclone
+  - case_id_number: 159
+    title: Hone
+    start_date: 2024-08-17 00:00:00
+    end_date: 2024-09-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.5
+        latitude_max: 28.3
+        longitude_min: 177.9
+        longitude_max: 231.5
+    event_type: tropical_cyclone
+  - case_id_number: 160
+    title: Trami
+    start_date: 2024-10-18 00:00:00
+    end_date: 2024-10-31 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.9
+        latitude_max: 19.9
+        longitude_min: 105.0
+        longitude_max: 139.8
+    event_type: tropical_cyclone
+  - case_id_number: 161
+    title: Prapiroon (Butchoy)
+    start_date: 2024-07-17 00:00:00
+    end_date: 2024-07-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.9
+        latitude_max: 24.0
+        longitude_min: 104.3
+        longitude_max: 120.4
+    event_type: tropical_cyclone
+  - case_id_number: 162
+    title: Gaemi (Carina)
+    start_date: 2024-07-17 00:00:00
+    end_date: 2024-07-30 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.4
+        latitude_max: 32.0
+        longitude_min: 110.6
+        longitude_max: 135.5
+    event_type: tropical_cyclone
+  - case_id_number: 163
+    title: Shanshan
+    start_date: 2024-08-19 00:00:00
+    end_date: 2024-09-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.8
+        latitude_max: 37.8
+        longitude_min: 127.7
+        longitude_max: 146.3
+    event_type: tropical_cyclone
+  - case_id_number: 164
+    title: Yagi (Enteng)
+    start_date: 2024-08-30 00:00:00
+    end_date: 2024-09-10 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.9
+        latitude_max: 23.8
+        longitude_min: 101.8
+        longitude_max: 128.7
+    event_type: tropical_cyclone
+  - case_id_number: 165
+    title: Bebinca (Ferdie)
+    start_date: 2024-09-07 00:00:00
+    end_date: 2024-09-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.9
+        latitude_max: 35.7
+        longitude_min: 112.4
+        longitude_max: 149.9
+    event_type: tropical_cyclone
+  - case_id_number: 166
+    title: Soulik (Gener)
+    start_date: 2024-09-13 00:00:00
+    end_date: 2024-09-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.3
+        latitude_max: 19.9
+        longitude_min: 102.2
+        longitude_max: 128.8
+    event_type: tropical_cyclone
+  - case_id_number: 167
+    title: Krathon
+    start_date: 2024-09-24 00:00:00
+    end_date: 2024-10-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 16.2
+        latitude_max: 25.0
+        longitude_min: 116.8
+        longitude_max: 129.8
+    event_type: tropical_cyclone
+  - case_id_number: 168
+    title: Asna
+    start_date: 2024-08-28 00:00:00
+    end_date: 2024-09-04 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 18.8
+        latitude_max: 26.1
+        longitude_min: 59.0
+        longitude_max: 70.7
+    event_type: tropical_cyclone
+  - case_id_number: 169
+    title: Kirrily
+    start_date: 2024-01-15 00:00:00
+    end_date: 2024-02-07 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -31.8
+        latitude_max: -11.3
+        longitude_min: 135.3
+        longitude_max: 159.0
+    event_type: tropical_cyclone
+  - case_id_number: 170
+    title: Belal
+    start_date: 2024-01-10 00:00:00
+    end_date: 2024-01-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -26.5
+        latitude_max: -11.1
+        longitude_min: 50.8
+        longitude_max: 68.1
+    event_type: tropical_cyclone
+  - case_id_number: 171
+    title: Alvaro
+    start_date: 2023-12-30 00:00:00
+    end_date: 2024-01-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -31.3
+        latitude_max: -18.5
+        longitude_min: 38.2
+        longitude_max: 59.9
+    event_type: tropical_cyclone
+  - case_id_number: 172
+    title: Franklin
+    start_date: 2023-08-17 00:00:00
+    end_date: 2023-09-11 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.6
+        latitude_max: 50.8
+        longitude_min: 286.3
+        longitude_max: 346.3
+    event_type: tropical_cyclone
+  - case_id_number: 173
+    title: Harold
+    start_date: 2023-08-19 00:00:00
+    end_date: 2023-08-25 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -37.2
+        latitude_max: -7.0
+        longitude_min: 152.2
+        longitude_max: 214.7
+    event_type: tropical_cyclone
+  - case_id_number: 174
+    title: Idalia
+    start_date: 2023-08-24 00:00:00
+    end_date: 2023-09-10 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 17.6
+        latitude_max: 47.4
+        longitude_min: 270.8
+        longitude_max: 304.9
+    event_type: tropical_cyclone
+  - case_id_number: 175
+    title: Lee
+    start_date: 2023-09-03 00:00:00
+    end_date: 2023-09-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.0
+        latitude_max: 55.2
+        longitude_min: 289.4
+        longitude_max: 322.7
+    event_type: tropical_cyclone
+  - case_id_number: 176
+    title: Ophelia
+    start_date: 2023-09-19 00:00:00
+    end_date: 2023-09-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 26.3
+        latitude_max: 41.1
+        longitude_min: 279.8
+        longitude_max: 287.5
+    event_type: tropical_cyclone
+  - case_id_number: 177
+    title: Tammy
+    start_date: 2023-10-16 00:00:00
+    end_date: 2023-11-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.7
+        latitude_max: 35.5
+        longitude_min: 293.7
+        longitude_max: 314.2
+    event_type: tropical_cyclone
+  - case_id_number: 178
+    title: Hilary
+    start_date: 2023-08-14 00:00:00
+    end_date: 2023-08-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.7
+        latitude_max: 33.6
+        longitude_min: 241.6
+        longitude_max: 261.5
+    event_type: tropical_cyclone
+  - case_id_number: 179
+    title: Lidia
+    start_date: 2023-10-01 00:00:00
+    end_date: 2023-10-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.0
+        latitude_max: 26.7
+        longitude_min: 244.9
+        longitude_max: 261.8
+    event_type: tropical_cyclone
+  - case_id_number: 180
+    title: Max
+    start_date: 2023-10-06 00:00:00
+    end_date: 2023-10-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.6
+        latitude_max: 20.1
+        longitude_min: 256.1
+        longitude_max: 262.4
+    event_type: tropical_cyclone
+  - case_id_number: 181
+    title: Norman
+    start_date: 2023-10-17 00:00:00
+    end_date: 2023-10-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.0
+        latitude_max: 25.0
+        longitude_min: 250.0
+        longitude_max: 265.0
+    event_type: tropical_cyclone
+  - case_id_number: 182
+    title: Otis
+    start_date: 2023-10-19 00:00:00
+    end_date: 2023-10-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.1
+        latitude_max: 20.8
+        longitude_min: 257.0
+        longitude_max: 266.5
+    event_type: tropical_cyclone
+  - case_id_number: 183
+    title: Mawar (Betty)
+    start_date: 2023-05-16 00:00:00
+    end_date: 2023-06-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 2.2
+        latitude_max: 36.3
+        longitude_min: 122.7
+        longitude_max: 153.2
+    event_type: tropical_cyclone
+  - case_id_number: 184
+    title: Talim (Dodong)
+    start_date: 2023-07-11 00:00:00
+    end_date: 2023-07-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.6
+        latitude_max: 25.6
+        longitude_min: 101.0
+        longitude_max: 125.1
+    event_type: tropical_cyclone
+  - case_id_number: 185
+    title: Doksuri (Egay)
+    start_date: 2023-07-18 00:00:00
+    end_date: 2023-08-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.5
+        latitude_max: 39.6
+        longitude_min: 110.5
+        longitude_max: 136.0
+    event_type: tropical_cyclone
+  - case_id_number: 186
+    title: Khanun (Falcon)
+    start_date: 2023-07-24 00:00:00
+    end_date: 2023-08-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 6.7
+        latitude_max: 41.3
+        longitude_min: 121.8
+        longitude_max: 143.6
+    event_type: tropical_cyclone
+  - case_id_number: 187
+    title: Lan
+    start_date: 2023-08-04 00:00:00
+    end_date: 2023-08-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 21.1
+        latitude_max: 50.0
+        longitude_min: 132.3
+        longitude_max: 152.0
+    event_type: tropical_cyclone
+  - case_id_number: 188
+    title: Saola (Goring)
+    start_date: 2023-08-20 00:00:00
+    end_date: 2023-09-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.8
+        latitude_max: 24.2
+        longitude_min: 106.8
+        longitude_max: 130.3
+    event_type: tropical_cyclone
+  - case_id_number: 189
+    title: Haikui
+    start_date: 2023-08-25 00:00:00
+    end_date: 2023-09-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 15.9
+        latitude_max: 25.9
+        longitude_min: 107.0
+        longitude_max: 146.8
+    event_type: tropical_cyclone
+  - case_id_number: 190
+    title: Koinu (Jenny)
+    start_date: 2023-09-25 00:00:00
+    end_date: 2023-10-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 12.0
+        latitude_max: 24.4
+        longitude_min: 109.0
+        longitude_max: 146.1
+    event_type: tropical_cyclone
+  - case_id_number: 191
+    title: Mocha
+    start_date: 2023-05-06 00:00:00
+    end_date: 2023-05-17 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 5.4
+        latitude_max: 27.3
+        longitude_min: 85.7
+        longitude_max: 100.1
+    event_type: tropical_cyclone
+  - case_id_number: 192
+    title: Biparjoy
+    start_date: 2023-06-03 00:00:00
+    end_date: 2023-06-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 8.1
+        latitude_max: 28.5
+        longitude_min: 63.6
+        longitude_max: 78.3
+    event_type: tropical_cyclone
+  - case_id_number: 193
+    title: Hamoon
+    start_date: 2023-10-18 00:00:00
+    end_date: 2023-10-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.2
+        latitude_max: 24.9
+        longitude_min: 83.5
+        longitude_max: 94.8
+    event_type: tropical_cyclone
+  - case_id_number: 194
+    title: Freddy
+    start_date: 2023-02-02 00:00:00
+    end_date: 2023-03-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -26.3
+        latitude_max: -8.9
+        longitude_min: 29.0
+        longitude_max: 121.6
+    event_type: tropical_cyclone
+  - case_id_number: 195
+    title: Jasper
+    start_date: 2023-11-30 00:00:00
+    end_date: 2023-12-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -20.0
+        latitude_max: -5.3
+        longitude_min: 139.0
+        longitude_max: 167.2
+    event_type: tropical_cyclone
+  - case_id_number: 196
+    title: Daniel - Europe
+    start_date: 2023-09-02 00:00:00
+    end_date: 2023-09-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 30.0
+        latitude_max: 45.0
+        longitude_min: 10.0
+        longitude_max: 30.0
+    event_type: tropical_cyclone
+  - case_id_number: 197
+    title: Alex
+    start_date: 2022-05-31 00:00:00
+    end_date: 2022-06-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 19.1
+        latitude_max: 36.9
+        longitude_min: 270.1
+        longitude_max: 300.2
+    event_type: tropical_cyclone
+  - case_id_number: 198
+    title: Fiona
+    start_date: 2022-09-12 00:00:00
+    end_date: 2022-09-29 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.5
+        latitude_max: 66.2
+        longitude_min: 285.9
+        longitude_max: 314.4
+    event_type: tropical_cyclone
+  - case_id_number: 199
+    title: Ian
+    start_date: 2022-09-20 00:00:00
+    end_date: 2022-10-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.1
+        latitude_max: 37.5
+        longitude_min: 274.0
+        longitude_max: 296.0
+    event_type: tropical_cyclone
+  - case_id_number: 200
+    title: Julia
+    start_date: 2022-10-04 00:00:00
+    end_date: 2022-10-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.2
+        latitude_max: 15.9
+        longitude_min: 267.8
+        longitude_max: 295.8
+    event_type: tropical_cyclone
+  - case_id_number: 201
+    title: Nicole
+    start_date: 2022-11-04 00:00:00
+    end_date: 2022-11-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 18.4
+        latitude_max: 37.6
+        longitude_min: 272.9
+        longitude_max: 295.7
+    event_type: tropical_cyclone
+  - case_id_number: 202
+    title: Agatha
+    start_date: 2022-05-25 00:00:00
+    end_date: 2022-06-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.6
+        latitude_max: 20.5
+        longitude_min: 258.6
+        longitude_max: 267.7
+    event_type: tropical_cyclone
+  - case_id_number: 203
+    title: Kay
+    start_date: 2022-09-02 00:00:00
+    end_date: 2022-09-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.9
+        latitude_max: 33.4
+        longitude_min: 235.8
+        longitude_max: 261.4
+    event_type: tropical_cyclone
+  - case_id_number: 204
+    title: Roslyn
+    start_date: 2022-10-18 00:00:00
+    end_date: 2022-10-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 12.9
+        latitude_max: 27.8
+        longitude_min: 251.0
+        longitude_max: 261.4
+    event_type: tropical_cyclone
+  - case_id_number: 205
+    title: Megi (Agaton)
+    start_date: 2022-04-06 00:00:00
+    end_date: 2022-04-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.7
+        latitude_max: 13.5
+        longitude_min: 122.4
+        longitude_max: 130.7
+    event_type: tropical_cyclone
+  - case_id_number: 206
+    title: Hinnamnor (Henry)
+    start_date: 2022-08-25 00:00:00
+    end_date: 2022-09-10 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 19.1
+        latitude_max: 62.0
+        longitude_min: 122.2
+        longitude_max: 153.4
+    event_type: tropical_cyclone
+  - case_id_number: 207
+    title: Muifa (Inday)
+    start_date: 2022-09-02 00:00:00
+    end_date: 2022-09-18 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.7
+        latitude_max: 45.6
+        longitude_min: 118.0
+        longitude_max: 147.7
+    event_type: tropical_cyclone
+  - case_id_number: 208
+    title: Nanmadol (Josie)
+    start_date: 2022-09-09 00:00:00
+    end_date: 2022-09-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 19.5
+        latitude_max: 41.1
+        longitude_min: 128.0
+        longitude_max: 149.7
+    event_type: tropical_cyclone
+  - case_id_number: 209
+    title: Noru (Karding)
+    start_date: 2022-09-19 00:00:00
+    end_date: 2022-10-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 12.8
+        latitude_max: 20.2
+        longitude_min: 101.0
+        longitude_max: 136.8
+    event_type: tropical_cyclone
+  - case_id_number: 210
+    title: Nalgae (Paeng)
+    start_date: 2022-10-24 00:00:00
+    end_date: 2022-11-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.0
+        latitude_max: 24.3
+        longitude_min: 111.0
+        longitude_max: 136.6
+    event_type: tropical_cyclone
+  - case_id_number: 211
+    title: Sitrang
+    start_date: 2022-10-19 00:00:00
+    end_date: 2022-10-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.4
+        latitude_max: 26.7
+        longitude_min: 85.8
+        longitude_max: 95.6
+    event_type: tropical_cyclone
+  - case_id_number: 212
+    title: Ana
+    start_date: 2022-01-18 00:00:00
+    end_date: 2022-01-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -32.5
+        latitude_max: -13.3
+        longitude_min: 168.8
+        longitude_max: 191.7
+    event_type: tropical_cyclone
+  - case_id_number: 213
+    title: Batsirai
+    start_date: 2022-01-22 00:00:00
+    end_date: 2022-02-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -41.7
+        latitude_max: -7.2
+        longitude_min: 38.5
+        longitude_max: 94.0
+    event_type: tropical_cyclone
+  - case_id_number: 214
+    title: Gombe
+    start_date: 2022-03-04 00:00:00
+    end_date: 2022-03-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -20.7
+        latitude_max: -12.7
+        longitude_min: 34.2
+        longitude_max: 57.6
+    event_type: tropical_cyclone
+  - case_id_number: 215
+    title: Seth
+    start_date: 2021-12-21 00:00:00
+    end_date: 2022-01-09 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -30.3
+        latitude_max: -6.5
+        longitude_min: 127.3
+        longitude_max: 161.5
+    event_type: tropical_cyclone
+  - case_id_number: 216
+    title: Blas
+    start_date: 2022-06-12 00:00:00
+    end_date: 2022-06-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.4
+        latitude_max: 21.5
+        longitude_min: 240.9
+        longitude_max: 260.3
+    event_type: tropical_cyclone
+  - case_id_number: 217
+    title: Apollo
+    start_date: 2021-10-23 00:00:00
+    end_date: 2021-11-03 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 30.0
+        latitude_max: 40.0
+        longitude_min: 10.0
+        longitude_max: 25.0
+    event_type: tropical_cyclone
+  - case_id_number: 218
+    title: Elsa
+    start_date: 2021-06-28 00:00:00
+    end_date: 2021-07-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.1
+        latitude_max: 49.0
+        longitude_min: 274.1
+        longitude_max: 319.5
+    event_type: tropical_cyclone
+  - case_id_number: 219
+    title: Fred
+    start_date: 2021-08-07 00:00:00
+    end_date: 2021-08-22 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.7
+        latitude_max: 44.9
+        longitude_min: 271.8
+        longitude_max: 303.6
+    event_type: tropical_cyclone
+  - case_id_number: 220
+    title: Grace
+    start_date: 2021-08-11 00:00:00
+    end_date: 2021-08-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 12.8
+        latitude_max: 23.0
+        longitude_min: 259.7
+        longitude_max: 315.6
+    event_type: tropical_cyclone
+  - case_id_number: 221
+    title: Henri
+    start_date: 2021-08-13 00:00:00
+    end_date: 2021-08-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 27.3
+        latitude_max: 44.5
+        longitude_min: 283.0
+        longitude_max: 299.9
+    event_type: tropical_cyclone
+  - case_id_number: 222
+    title: Ida
+    start_date: 2021-08-24 00:00:00
+    end_date: 2021-09-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.3
+        latitude_max: 51.0
+        longitude_min: 266.8
+        longitude_max: 299.9
+    event_type: tropical_cyclone
+  - case_id_number: 223
+    title: Larry
+    start_date: 2021-08-29 00:00:00
+    end_date: 2021-09-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.3
+        latitude_max: 57.5
+        longitude_min: 295.4
+        longitude_max: 341.7
+    event_type: tropical_cyclone
+  - case_id_number: 224
+    title: Nicholas
+    start_date: 2021-09-10 00:00:00
+    end_date: 2021-09-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 18.8
+        latitude_max: 33.0
+        longitude_min: 260.9
+        longitude_max: 270.8
+    event_type: tropical_cyclone
+  - case_id_number: 225
+    title: Claudette
+    start_date: 2021-06-15 00:00:00
+    end_date: 2021-06-25 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 20.3
+        latitude_max: 46.3
+        longitude_min: 265.4
+        longitude_max: 302.8
+    event_type: tropical_cyclone
+  - case_id_number: 226
+    title: Nora
+    start_date: 2021-08-22 00:00:00
+    end_date: 2021-09-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.0
+        latitude_max: 26.5
+        longitude_min: 250.3
+        longitude_max: 267.3
+    event_type: tropical_cyclone
+  - case_id_number: 227
+    title: Olaf
+    start_date: 2021-09-04 00:00:00
+    end_date: 2021-09-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.9
+        latitude_max: 26.9
+        longitude_min: 242.8
+        longitude_max: 256.6
+    event_type: tropical_cyclone
+  - case_id_number: 228
+    title: Pamela
+    start_date: 2021-10-08 00:00:00
+    end_date: 2021-10-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.9
+        latitude_max: 27.3
+        longitude_min: 248.4
+        longitude_max: 259.9
+    event_type: tropical_cyclone
+  - case_id_number: 229
+    title: Surigae (Bising)
+    start_date: 2021-04-09 00:00:00
+    end_date: 2021-05-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 3.3
+        latitude_max: 49.7
+        longitude_min: 122.5
+        longitude_max: 186.8
+    event_type: tropical_cyclone
+  - case_id_number: 230
+    title: In-fa (Fabian)
+    start_date: 2021-07-14 00:00:00
+    end_date: 2021-08-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.9
+        latitude_max: 42.4
+        longitude_min: 114.4
+        longitude_max: 137.6
+    event_type: tropical_cyclone
+  - case_id_number: 231
+    title: Kompasu (Maring)
+    start_date: 2021-10-05 00:00:00
+    end_date: 2021-10-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.8
+        latitude_max: 21.7
+        longitude_min: 103.4
+        longitude_max: 136.5
+    event_type: tropical_cyclone
+  - case_id_number: 232
+    title: Rai
+    start_date: 2021-12-09 00:00:00
+    end_date: 2021-12-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 3.1
+        latitude_max: 23.9
+        longitude_min: 108.3
+        longitude_max: 147.3
+    event_type: tropical_cyclone
+  - case_id_number: 233
+    title: Tauktae
+    start_date: 2021-05-11 00:00:00
+    end_date: 2021-05-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.8
+        latitude_max: 28.0
+        longitude_min: 68.6
+        longitude_max: 77.1
+    event_type: tropical_cyclone
+  - case_id_number: 234
+    title: Yaas
+    start_date: 2021-05-21 00:00:00
+    end_date: 2021-05-29 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.2
+        latitude_max: 26.9
+        longitude_min: 82.5
+        longitude_max: 92.3
+    event_type: tropical_cyclone
+  - case_id_number: 235
+    title: Gulab and Shaheen
+    start_date: 2021-09-21 00:00:00
+    end_date: 2021-10-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 15.9
+        latitude_max: 26.6
+        longitude_min: 53.7
+        longitude_max: 96.5
+    event_type: tropical_cyclone
+  - case_id_number: 236
+    title: Eloise
+    start_date: 2021-01-09 00:00:00
+    end_date: 2021-01-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -24.7
+        latitude_max: -9.3
+        longitude_min: 28.8
+        longitude_max: 88.1
+    event_type: tropical_cyclone
+  - case_id_number: 237
+    title: Amanda and Cristobal
+    start_date: 2020-05-28 00:00:00
+    end_date: 2020-06-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.0
+        latitude_max: 55.6
+        longitude_min: 265.0
+        longitude_max: 283.3
+    event_type: tropical_cyclone
+  - case_id_number: 238
+    title: Hanna
+    start_date: 2020-07-21 00:00:00
+    end_date: 2020-07-28 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 23.5
+        latitude_max: 29.4
+        longitude_min: 257.2
+        longitude_max: 274.2
+    event_type: tropical_cyclone
+  - case_id_number: 239
+    title: Isaias
+    start_date: 2020-07-26 00:00:00
+    end_date: 2020-08-07 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.3
+        latitude_max: 48.9
+        longitude_min: 277.7
+        longitude_max: 308.3
+    event_type: tropical_cyclone
+  - case_id_number: 240
+    title: Laura
+    start_date: 2020-08-18 00:00:00
+    end_date: 2020-08-31 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 12.2
+        latitude_max: 40.5
+        longitude_min: 264.3
+        longitude_max: 315.0
+    event_type: tropical_cyclone
+  - case_id_number: 241
+    title: Nana
+    start_date: 2020-08-30 00:00:00
+    end_date: 2020-09-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 13.6
+        latitude_max: 19.3
+        longitude_min: 266.3
+        longitude_max: 287.1
+    event_type: tropical_cyclone
+  - case_id_number: 242
+    title: Paulette
+    start_date: 2020-09-05 00:00:00
+    end_date: 2020-09-30 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.7
+        latitude_max: 49.3
+        longitude_min: 292.8
+        longitude_max: 345.7
+    event_type: tropical_cyclone
+  - case_id_number: 243
+    title: Sally
+    start_date: 2020-09-09 00:00:00
+    end_date: 2020-09-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 23.2
+        latitude_max: 36.3
+        longitude_min: 269.4
+        longitude_max: 283.9
+    event_type: tropical_cyclone
+  - case_id_number: 244
+    title: Teddy
+    start_date: 2020-09-10 00:00:00
+    end_date: 2020-09-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 8.8
+        latitude_max: 55.0
+        longitude_min: 293.4
+        longitude_max: 330.9
+    event_type: tropical_cyclone
+  - case_id_number: 245
+    title: Delta
+    start_date: 2020-10-02 00:00:00
+    end_date: 2020-10-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 14.2
+        latitude_max: 37.3
+        longitude_min: 263.9
+        longitude_max: 286.1
+    event_type: tropical_cyclone
+  - case_id_number: 246
+    title: Zeta
+    start_date: 2020-10-22 00:00:00
+    end_date: 2020-11-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 15.5
+        latitude_max: 41.7
+        longitude_min: 265.9
+        longitude_max: 290.7
+    event_type: tropical_cyclone
+  - case_id_number: 247
+    title: Eta
+    start_date: 2020-10-29 00:00:00
+    end_date: 2020-11-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 11.4
+        latitude_max: 37.9
+        longitude_min: 269.9
+        longitude_max: 293.1
+    event_type: tropical_cyclone
+  - case_id_number: 248
+    title: Iota
+    start_date: 2020-11-10 00:00:00
+    end_date: 2020-11-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.3
+        latitude_max: 17.7
+        longitude_min: 268.7
+        longitude_max: 291.4
+    event_type: tropical_cyclone
+  - case_id_number: 249
+    title: Genevieve
+    start_date: 2020-08-14 00:00:00
+    end_date: 2020-08-24 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 9.1
+        latitude_max: 29.2
+        longitude_min: 240.3
+        longitude_max: 265.8
+    event_type: tropical_cyclone
+  - case_id_number: 250
+    title: Hagupit (Dindo)
+    start_date: 2020-07-29 00:00:00
+    end_date: 2020-08-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 15.0
+        latitude_max: 54.5
+        longitude_min: 117.9
+        longitude_max: 182.5
+    event_type: tropical_cyclone
+  - case_id_number: 251
+    title: Maysak
+    start_date: 2020-08-24 00:00:00
+    end_date: 2020-09-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.6
+        latitude_max: 55.4
+        longitude_min: 120.7
+        longitude_max: 136.2
+    event_type: tropical_cyclone
+  - case_id_number: 252
+    title: Noul (Leon)
+    start_date: 2020-09-12 00:00:00
+    end_date: 2020-09-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 8.8
+        latitude_max: 18.7
+        longitude_min: 98.2
+        longitude_max: 129.6
+    event_type: tropical_cyclone
+  - case_id_number: 253
+    title: Linfa
+    start_date: 2020-10-05 00:00:00
+    end_date: 2020-10-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.3
+        latitude_max: 17.3
+        longitude_min: 104.6
+        longitude_max: 127.1
+    event_type: tropical_cyclone
+  - case_id_number: 254
+    title: Molave (Quinta)
+    start_date: 2020-10-19 00:00:00
+    end_date: 2020-10-31 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 6.5
+        latitude_max: 17.8
+        longitude_min: 101.8
+        longitude_max: 139.8
+    event_type: tropical_cyclone
+  - case_id_number: 255
+    title: Goni (Rolly)
+    start_date: 2020-10-23 00:00:00
+    end_date: 2020-11-08 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 8.4
+        latitude_max: 18.9
+        longitude_min: 105.6
+        longitude_max: 146.2
+    event_type: tropical_cyclone
+  - case_id_number: 256
+    title: Vamco (Ulysse)
+    start_date: 2020-11-06 00:00:00
+    end_date: 2020-11-18 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 5.8
+        latitude_max: 21.5
+        longitude_min: 101.3
+        longitude_max: 137.2
+    event_type: tropical_cyclone
+  - case_id_number: 257
+    title: Remal
+    start_date: 2024-05-23 00:00:00
+    end_date: 2024-05-29 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 16.6
+        latitude_max: 26.4
+        longitude_min: 86.0
+        longitude_max: 92.8
+    event_type: tropical_cyclone
+  - case_id_number: 258
+    title: Amphan
+    start_date: 2020-05-13 00:00:00
+    end_date: 2020-05-23 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 7.3
+        latitude_max: 27.6
+        longitude_min: 83.8
+        longitude_max: 92.4
+    event_type: tropical_cyclone
+  - case_id_number: 259
+    title: Nisarga
+    start_date: 2020-05-29 00:00:00
+    end_date: 2020-06-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 10.7
+        latitude_max: 24.4
+        longitude_min: 68.8
+        longitude_max: 79.9
+    event_type: tropical_cyclone
+  - case_id_number: 260
+    title: Damien
+    start_date: 2020-02-01 00:00:00
+    end_date: 2020-02-12 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -27.9
+        latitude_max: -13.8
+        longitude_min: 113.9
+        longitude_max: 131.8
+    event_type: tropical_cyclone
+  - case_id_number: 261
+    title: Harold
+    start_date: 2023-08-19 00:00:00
+    end_date: 2023-08-25 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -37.2
+        latitude_max: -7.0
+        longitude_min: 152.2
+        longitude_max: 214.7
+    event_type: tropical_cyclone
+  - case_id_number: 262
+    title: Ianos
+    start_date: 2020-09-16 00:00:00
+    end_date: 2020-09-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 30.0
+        latitude_max: 40.0
+        longitude_min: 15.0
+        longitude_max: 25.0
+    event_type: tropical_cyclone
+  - case_id_number: 263
+    title: January 2020 Australia
+    start_date: 2020-01-20 00:00:00
+    end_date: 2020-01-21 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 264
+    title: April 2020 Australia
+    start_date: 2020-04-03 00:00:00
+    end_date: 2020-04-04 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 265
+    title: May 2020 Australia
+    start_date: 2020-05-31 00:00:00
+    end_date: 2020-06-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 266
+    title: September 2020 Australia
+    start_date: 2020-09-05 00:00:00
+    end_date: 2020-09-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 267
+    title: October 2020 Australia
+    start_date: 2020-10-31 00:00:00
+    end_date: 2020-11-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 268
+    title: December 2020 Australia
+    start_date: 2020-12-05 00:00:00
+    end_date: 2020-12-06 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 269
+    title: September 2021 Australia
+    start_date: 2021-09-30 00:00:00
+    end_date: 2021-10-01 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 270
+    title: October 2021 Australia
+    start_date: 2021-10-14 00:00:00
+    end_date: 2021-10-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 271
+    title: October 2021 Australia
+    start_date: 2021-10-18 00:00:00
+    end_date: 2021-10-19 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 272
+    title: October 2021 Australia
+    start_date: 2021-10-19 00:00:00
+    end_date: 2021-10-20 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 273
+    title: October 2021 Australia
+    start_date: 2021-10-28 00:00:00
+    end_date: 2021-10-29 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 274
+    title: December 2021 Australia
+    start_date: 2021-12-03 00:00:00
+    end_date: 2021-12-04 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 275
+    title: December 2021 Australia
+    start_date: 2021-12-09 00:00:00
+    end_date: 2021-12-10 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 276
+    title: January 2022 Australia
+    start_date: 2022-01-15 00:00:00
+    end_date: 2022-01-16 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 277
+    title: March 2022 Australia
+    start_date: 2022-03-04 00:00:00
+    end_date: 2022-03-05 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 278
+    title: December 2022 Australia
+    start_date: 2022-12-08 00:00:00
+    end_date: 2022-12-09 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 279
+    title: February 2023 Australia
+    start_date: 2023-02-14 00:00:00
+    end_date: 2023-02-15 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 280
+    title: December 2023 Australia
+    start_date: 2023-12-12 00:00:00
+    end_date: 2023-12-13 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 281
+    title: December 2023 Australia
+    start_date: 2023-12-25 00:00:00
+    end_date: 2023-12-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 282
+    title: December 2023 Australia
+    start_date: 2023-12-26 00:00:00
+    end_date: 2023-12-27 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 283
+    title: August 2024 Australia
+    start_date: 2024-08-25 00:00:00
+    end_date: 2024-08-26 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 284
+    title: October 2024 Australia
+    start_date: 2024-10-09 00:00:00
+    end_date: 2024-10-10 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 285
+    title: October 2024 Australia
+    start_date: 2024-10-17 00:00:00
+    end_date: 2024-10-18 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 286
+    title: November 2024 Australia
+    start_date: 2024-11-01 00:00:00
+    end_date: 2024-11-02 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection
+  - case_id_number: 287
+    title: November 2024 Australia
+    start_date: 2024-11-13 00:00:00
+    end_date: 2024-11-14 00:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: -40.0
+        latitude_max: -10.0
+        longitude_min: 110.0
+        longitude_max: 155.0
+    event_type: severe_convection


### PR DESCRIPTION
# EWB Pull Request

## Description

A duplicate case occurs at case 16, which is the 2023 heatwave around the Iberian Peninsula. This PR swaps it for another case in 2023, the [mid-April South/Southeast Asian heatwave](https://www.theguardian.com/weather/2023/apr/19/severe-heatwave-asia-deaths-schools-close-india-china).