### PR TITLE
Fix exception when target data has more than one time resolution

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -269,11 +269,12 @@ class MaxMinMAE(AppliedMetric):
     ) -> Any:
         forecast = forecast.compute().mean(["latitude", "longitude"])
         target = target.compute().mean(["latitude", "longitude"])
+        time_resolution_hours = utils.determine_temporal_resolution(target)
         max_min_target_value = (
             target.groupby("valid_time.dayofyear")
             .map(
                 utils.min_if_all_timesteps_present,
-                time_resolution_hours=utils.determine_temporal_resolution(target),
+                time_resolution_hours=time_resolution_hours,
             )
             .max()
         )

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -273,8 +273,7 @@ class MaxMinMAE(AppliedMetric):
             target.groupby("valid_time.dayofyear")
             .map(
                 utils.min_if_all_timesteps_present,
-                # TODO: calculate num timesteps per day dynamically
-                num_timesteps=utils.determine_timesteps_per_day_resolution(target),
+                time_resolution_hours=utils.determine_temporal_resolution(target),
             )
             .max()
         )
@@ -303,7 +302,7 @@ class MaxMinMAE(AppliedMetric):
             .groupby("valid_time.dayofyear")
             .map(
                 utils.min_if_all_timesteps_present_forecast,
-                num_timesteps=utils.determine_timesteps_per_day_resolution(forecast),
+                time_resolution_hours=utils.determine_temporal_resolution(forecast),
             )
             .min("dayofyear")
         )
@@ -328,7 +327,7 @@ class OnsetME(AppliedMetric):
         ) >= 48:
             min_daily_vals = forecast.groupby("valid_time.dayofyear").map(
                 utils.min_if_all_timesteps_present,
-                num_timesteps=utils.determine_timesteps_per_day_resolution(forecast),
+                time_resolution_hours=utils.determine_temporal_resolution(forecast),
             )
             if len(min_daily_vals) >= 2:  # Check if we have at least 2 values
                 for i in range(len(min_daily_vals) - 1):
@@ -374,8 +373,7 @@ class DurationME(AppliedMetric):
         ) >= 48:
             min_daily_vals = forecast.groupby("valid_time.dayofyear").map(
                 utils.min_if_all_timesteps_present,
-                # TODO: calculate num timesteps per day dynamically
-                num_timesteps=4,
+                time_resolution_hours=utils.determine_temporal_resolution(forecast),
             )
             # need to determine logic for 2+ consecutive days to find the date
             # that the heatwave starts

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -229,8 +229,7 @@ def determine_temporal_resolution(
     if len(num_timesteps) > 1:
         logger.warning(
             "Multiple time resolutions found in dataset, data may be missing in "
-            " forecast or target datasets, "
-            f"({pd.to_datetime(data['init_time'].values[0]).strftime('%Y-%m-%d%H:%M')})"
+            "forecast or target datasets. Returning the highest time resolution."
         )
     # likely missing any data for valid time
     if len(num_timesteps) == 0:

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -169,7 +169,7 @@ def filter_kwargs_for_callable(kwargs: dict, callable_obj: Callable) -> dict:
 
 def min_if_all_timesteps_present(
     da: xr.DataArray,
-    num_timesteps: int,
+    time_resolution_hours: float,
 ) -> xr.DataArray:
     """Return the minimum value of a DataArray if all timesteps of a day are present.
 
@@ -180,14 +180,15 @@ def min_if_all_timesteps_present(
         The minimum value of the DataArray if all timesteps are present,
         otherwise the original DataArray.
     """
-    if len(da.values) == num_timesteps:
+    timesteps_per_day = 24 / time_resolution_hours
+    if len(da.values) == timesteps_per_day:
         return da.min()
     else:
         return xr.DataArray(np.nan)
 
 
 def min_if_all_timesteps_present_forecast(
-    da: xr.DataArray, num_timesteps
+    da: xr.DataArray, time_resolution_hours: float
 ) -> xr.DataArray:
     """Return the minimum value of a DataArray if all timesteps of a day are present
     given a dataset with lead_time and valid_time dimensions.
@@ -199,7 +200,8 @@ def min_if_all_timesteps_present_forecast(
         The minimum value of the DataArray if all timesteps are present,
         otherwise the original DataArray.
     """
-    if len(da.valid_time) == num_timesteps:
+    timesteps_per_day = 24 / time_resolution_hours
+    if len(da.valid_time) == timesteps_per_day:
         return da.min("valid_time")
     else:
         # Return an array with the same lead_time dimension but filled with NaNs
@@ -216,7 +218,7 @@ def determine_temporal_resolution(
     """Determine the temporal resolution of the data.
 
     Args:
-        ds: The input dataset with a valid_time dimension or coordinate.
+        data: The input dataset with a valid_time dimension or coordinate.
 
     Returns:
         The temporal resolution of the data as a float in hours.
@@ -234,10 +236,10 @@ def determine_temporal_resolution(
     if len(num_timesteps) == 0:
         return None
 
-    # return the maximum number of timesteps per day present
+    # return the minimum (highest time resolution) in hours
     # this is the most likely to be correct if there are multiple resolutions
     # present, likely due to missing data
-    return np.max(num_timesteps).astype(float)
+    return np.min(num_timesteps).astype(float)
 
 
 def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -199,16 +199,16 @@ def test_min_if_all_timesteps_present_forecast():
 
 def test_determine_temporal_resolution():
     """Test determining time resolution in hours."""
-    # Create dataset with 6-hourly data (6 hour gaps)
-    times = pd.date_range("2020-01-01", "2020-01-02", freq="6h")[:-1]  # 4 timesteps
+    # Create dataset with 6-hourly resolution
+    times = pd.date_range("2020-01-01", "2020-01-02", freq="6h")[:-1]  # 4 timesteps/day
     ds = xr.Dataset(
         data_vars={"temp": (["valid_time"], [1, 2, 3, 4])}, coords={"valid_time": times}
     )
 
     result = utils.determine_temporal_resolution(ds)
-    assert result == 6  # 6-hour gaps
+    assert result == 6  # 6-hour resolution
 
-    # Test with hourly data (1 hour gaps)
+    # Test with hourly resolution
     times_hourly = pd.date_range("2020-01-01", "2020-01-02", freq="1h")[:-1]
     ds_hourly = xr.Dataset(
         data_vars={"temp": (["valid_time"], range(24))},
@@ -216,7 +216,7 @@ def test_determine_temporal_resolution():
     )
 
     result_hourly = utils.determine_temporal_resolution(ds_hourly)
-    assert result_hourly == 1  # 1-hour gaps
+    assert result_hourly == 1  # 1-hour resolution
 
 
 def test_determine_temporal_resolution_multiple_resolutions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -197,26 +197,55 @@ def test_min_if_all_timesteps_present_forecast():
     assert np.all(np.isnan(result_incomplete.values))
 
 
-def test_determine_timesteps_per_day_resolution():
-    """Test determining timesteps per day resolution."""
-    # Create dataset with 6-hourly data (4 timesteps per day)
+def test_determine_temporal_resolution():
+    """Test determining time resolution in hours."""
+    # Create dataset with 6-hourly data (6 hour gaps)
     times = pd.date_range("2020-01-01", "2020-01-02", freq="6h")[:-1]  # 4 timesteps
     ds = xr.Dataset(
         data_vars={"temp": (["valid_time"], [1, 2, 3, 4])}, coords={"valid_time": times}
     )
 
-    result = utils.determine_timesteps_per_day_resolution(ds)
-    assert result == 4
+    result = utils.determine_temporal_resolution(ds)
+    assert result == 6  # 6-hour gaps
 
-    # Test with hourly data (24 timesteps per day)
+    # Test with hourly data (1 hour gaps)
     times_hourly = pd.date_range("2020-01-01", "2020-01-02", freq="1h")[:-1]
     ds_hourly = xr.Dataset(
         data_vars={"temp": (["valid_time"], range(24))},
         coords={"valid_time": times_hourly},
     )
 
-    result_hourly = utils.determine_timesteps_per_day_resolution(ds_hourly)
-    assert result_hourly == 24
+    result_hourly = utils.determine_temporal_resolution(ds_hourly)
+    assert result_hourly == 1  # 1-hour gaps
+
+
+def test_determine_temporal_resolution_multiple_resolutions():
+    """Test that max resolution is returned when multiple resolutions exist."""
+    # Create dataset with mixed time resolutions - some 1h gaps, some 6h gaps
+    # This simulates missing data where some timesteps are present at 1h
+    # resolution but others have 6h gaps
+    times_mixed = pd.to_datetime(
+        [
+            "2020-01-01 00:00",  # Start
+            "2020-01-01 01:00",  # 1h gap
+            "2020-01-01 02:00",  # 1h gap
+            "2020-01-01 08:00",  # 6h gap (missing 03:00-07:00)
+            "2020-01-01 09:00",  # 1h gap
+            "2020-01-01 15:00",  # 6h gap (missing 10:00-14:00)
+        ]
+    )
+
+    ds_mixed = xr.Dataset(
+        data_vars={"temp": (["valid_time"], [1, 2, 3, 4, 5, 6])},
+        coords={"valid_time": times_mixed, "init_time": [pd.Timestamp("2020-01-01")]},
+    )
+
+    result = utils.determine_temporal_resolution(ds_mixed)
+
+    # Should return 6 (maximum time gap in hours) when multiple resolutions
+    # are present, even though some gaps are only 1 hour
+    # This confirms the function takes the maximum gap, not the minimum
+    assert result == 6
 
 
 def test_convert_init_time_to_valid_time():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,14 +157,14 @@ def test_min_if_all_timesteps_present():
     """Test returning minimum if all timesteps are present."""
     # Test with complete timesteps
     da_complete = xr.DataArray([1, 2, 3, 4], dims=["time"])
-    result_complete = utils.min_if_all_timesteps_present(da_complete, 4)
+    result_complete = utils.min_if_all_timesteps_present(da_complete, 6)
 
     # Should return minimum value
     assert result_complete.values == 1
 
     # Test with incomplete timesteps
     da_incomplete = xr.DataArray([1, 2, 3], dims=["time"])
-    result_incomplete = utils.min_if_all_timesteps_present(da_incomplete, 4)
+    result_incomplete = utils.min_if_all_timesteps_present(da_incomplete, 6)
 
     # Should return NaN
     assert np.isnan(result_incomplete.values)
@@ -178,7 +178,7 @@ def test_min_if_all_timesteps_present_forecast():
         dims=["lead_time", "valid_time"],
         coords={"lead_time": [0, 6], "valid_time": [0, 1, 2]},
     )
-    result_complete = utils.min_if_all_timesteps_present_forecast(da_complete, 3)
+    result_complete = utils.min_if_all_timesteps_present_forecast(da_complete, 8)
 
     # Should return minimum along valid_time dimension
     expected = xr.DataArray([1, 4], dims=["lead_time"], coords={"lead_time": [0, 6]})
@@ -190,7 +190,7 @@ def test_min_if_all_timesteps_present_forecast():
         dims=["lead_time", "valid_time"],
         coords={"lead_time": [0, 6], "valid_time": [0, 1]},
     )
-    result_incomplete = utils.min_if_all_timesteps_present_forecast(da_incomplete, 3)
+    result_incomplete = utils.min_if_all_timesteps_present_forecast(da_incomplete, 8)
 
     # Should return NaN array with same lead_time dimension
     assert len(result_incomplete.lead_time) == 2
@@ -242,10 +242,10 @@ def test_determine_temporal_resolution_multiple_resolutions():
 
     result = utils.determine_temporal_resolution(ds_mixed)
 
-    # Should return 6 (maximum time gap in hours) when multiple resolutions
-    # are present, even though some gaps are only 1 hour
-    # This confirms the function takes the maximum gap, not the minimum
-    assert result == 6
+    # Should return 1 (minimum time gap in hours) when multiple resolutions
+    # are present, even though some gaps are 6 hours
+    # This confirms the function takes the minimum gap, not the maximum
+    assert result == 1
 
 
 def test_convert_init_time_to_valid_time():


### PR DESCRIPTION
# EWB Pull Request

## Description

The current behavior of EWB raises an exception when there are disparate (multiple) time resolutions in the data. Although originally intended to ensure forecast data is consistent, this causes issues with imperfect target data that is aligned to forecast data. 

For example, when coming a 6-hour resolution forecast with GHCNh data that has one missing timestep at 12Z (resulting in a 12 hour gap between 06Z and 18Z), the evaluation will break.

This PR:

1. Stops this from occurring by calculating the resolution - the difference between each `valid_time`.

2. Throws a warning instead of an exception if there are multiple values returned from 1, taking the minimum of all returned values. 

The minimum approach **should** work for almost all cases, as there are upstream filters that align and trim the data. An edge case like a series of erroneous values at :55 after the hour should be handled before it gets to this point.

The time-dependent metrics in the code (`MaximumMAE`, `MaxMinMAE`, `OnsetME`, `DurationME`) are all cleaned up with this new method. These methods need a full day's worth of data to compute the outputs. If there is any missing data, the metric will return a `NaN`.

The outputs are typed as a float in the eventual situation of sub-hourly evaluations in EWB.