### PR TITLE
Swap from len() to .size for xarray objects

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -106,9 +106,7 @@ def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
     """
     forecast_ds, target_ds = _build_datasets(case_operator)
     # Check if any dimension has zero length
-    if any((forecast_ds[dim].size == 0 for dim in forecast_ds.dims)) or any(
-        (target_ds[dim].size == 0 for dim in target_ds.dims)
-    ):
+    if 0 in forecast_ds.sizes.values() or 0 in target_ds.sizes.values():
         return pd.DataFrame(columns=OUTPUT_COLUMNS)
     # spatiotemporally align the target and forecast datasets dependent on the forecast
     aligned_forecast_ds, aligned_target_ds = (

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -105,7 +105,10 @@ def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
         A concatenated dataframe of the results of the case operator.
     """
     forecast_ds, target_ds = _build_datasets(case_operator)
-    if len(forecast_ds) == 0 or len(target_ds) == 0:
+    # Check if any dimension has zero length
+    if any((forecast_ds[dim].size == 0 for dim in forecast_ds.dims)) or any(
+        (target_ds[dim].size == 0 for dim in target_ds.dims)
+    ):
         return pd.DataFrame(columns=OUTPUT_COLUMNS)
     # spatiotemporally align the target and forecast datasets dependent on the forecast
     aligned_forecast_ds, aligned_target_ds = (

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -330,8 +330,8 @@ class OnsetME(AppliedMetric):
                 utils.min_if_all_timesteps_present,
                 num_timesteps=utils.determine_timesteps_per_day_resolution(forecast),
             )
-            if len(min_daily_vals) >= 2:  # Check if we have at least 2 values
-                for i in range(len(min_daily_vals) - 1):
+            if min_daily_vals.size >= 2:  # Check if we have at least 2 values
+                for i in range(min_daily_vals.size - 1):
                     # TODO: CHANGE LOGIC; define forecast heatwave onset
                     if min_daily_vals[i] >= 288.15 and min_daily_vals[i + 1] >= 288.15:
                         return xr.DataArray(
@@ -379,13 +379,13 @@ class DurationME(AppliedMetric):
             )
             # need to determine logic for 2+ consecutive days to find the date
             # that the heatwave starts
-            if len(min_daily_vals) >= 2:  # Check if we have at least 2 values
-                for i in range(len(min_daily_vals) - 1):
+            if min_daily_vals.size >= 2:  # Check if we have at least 2 values
+                for i in range(min_daily_vals.size - 1):
                     if min_daily_vals[i] >= 288.15 and min_daily_vals[i + 1] >= 288.15:
                         consecutive_days = np.timedelta64(
                             2, "D"
                         )  # Start with 2 since we found first pair
-                        for j in range(i + 2, len(min_daily_vals)):
+                        for j in range(i + 2, min_daily_vals.size):
                             if min_daily_vals[j] >= 288.15:
                                 consecutive_days += np.timedelta64(1, "D")
                             else:

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -180,7 +180,7 @@ def min_if_all_timesteps_present(
         The minimum value of the DataArray if all timesteps are present,
         otherwise the original DataArray.
     """
-    if len(da.values) == num_timesteps:
+    if da.size == num_timesteps:
         return da.min()
     else:
         return xr.DataArray(np.nan)
@@ -199,12 +199,12 @@ def min_if_all_timesteps_present_forecast(
         The minimum value of the DataArray if all timesteps are present,
         otherwise the original DataArray.
     """
-    if len(da.valid_time) == num_timesteps:
+    if da.valid_time.size == num_timesteps:
         return da.min("valid_time")
     else:
         # Return an array with the same lead_time dimension but filled with NaNs
         return xr.DataArray(
-            np.full(len(da.lead_time), np.nan),
+            np.full(da.lead_time.size, np.nan),
             coords={"lead_time": da.lead_time},
             dims=["lead_time"],
         )

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -503,8 +503,8 @@ class TestComputeCaseOperator:
         """Test compute_case_operator when _build_datasets returns empty forecast
         dataset."""
         # Mock _build_datasets to return empty datasets (simulating zero valid times)
-        empty_forecast_ds = xr.Dataset()
-        empty_target_ds = xr.Dataset()
+        empty_forecast_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
+        empty_target_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
         mock_build_datasets.return_value = (empty_forecast_ds, empty_target_ds)
 
         result = evaluate.compute_case_operator(sample_case_operator)
@@ -524,7 +524,7 @@ class TestComputeCaseOperator:
         """Test compute_case_operator when _build_datasets returns empty
         target dataset."""
         # Mock _build_datasets to return empty target dataset
-        empty_target_ds = xr.Dataset()
+        empty_target_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
         mock_build_datasets.return_value = (sample_forecast_dataset, empty_target_ds)
 
         result = evaluate.compute_case_operator(sample_case_operator)


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR catches an issue where the length of a dataset is an incorrect output when the size of one of its dimensions are 0. To be consistent across the repo, any instance where a conditional uses len(xr.DataArray) is swapped to xr.DataArray.size.