### PR TITLE
Add an extra check for an empty sizes dict

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -108,6 +108,11 @@ def compute_case_operator(case_operator: "cases.CaseOperator", **kwargs):
     # Check if any dimension has zero length
     if 0 in forecast_ds.sizes.values() or 0 in target_ds.sizes.values():
         return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+    # Or, check if there aren't any dimensions
+    elif len(forecast_ds.sizes) == 0 or len(target_ds.sizes) == 0:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
     # spatiotemporally align the target and forecast datasets dependent on the forecast
     aligned_forecast_ds, aligned_target_ds = (
         case_operator.target.maybe_align_forecast_to_target(forecast_ds, target_ds)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -497,7 +497,7 @@ class TestComputeCaseOperator:
                 assert len(result) == 2
 
     @patch("extremeweatherbench.evaluate._build_datasets")
-    def test_compute_case_operator_empty_forecast_dataset(
+    def test_compute_case_operator_zero_length_forecast_dataset(
         self, mock_build_datasets, sample_case_operator
     ):
         """Test compute_case_operator when _build_datasets returns empty forecast
@@ -518,13 +518,53 @@ class TestComputeCaseOperator:
         mock_build_datasets.assert_called_once_with(sample_case_operator)
 
     @patch("extremeweatherbench.evaluate._build_datasets")
-    def test_compute_case_operator_empty_target_dataset(
+    def test_compute_case_operator_zero_length_target_dataset(
         self, mock_build_datasets, sample_case_operator, sample_forecast_dataset
     ):
         """Test compute_case_operator when _build_datasets returns empty
         target dataset."""
         # Mock _build_datasets to return empty target dataset
         empty_target_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
+        mock_build_datasets.return_value = (sample_forecast_dataset, empty_target_ds)
+
+        result = evaluate.compute_case_operator(sample_case_operator)
+
+        # Should return empty DataFrame with correct columns
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+        assert list(result.columns) == OUTPUT_COLUMNS
+
+        mock_build_datasets.assert_called_once_with(sample_case_operator)
+
+    @patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_empty_forecast_dataset(
+        self, mock_build_datasets, sample_case_operator
+    ):
+        """Test compute_case_operator when _build_datasets returns empty forecast
+        dataset."""
+        # Mock _build_datasets to return empty datasets (simulating zero valid times)
+        empty_forecast_ds = xr.Dataset()
+        empty_target_ds = xr.Dataset()
+        mock_build_datasets.return_value = (empty_forecast_ds, empty_target_ds)
+
+        result = evaluate.compute_case_operator(sample_case_operator)
+
+        # Should return empty DataFrame with correct columns
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+        assert list(result.columns) == OUTPUT_COLUMNS
+
+        # _build_datasets should be called, but no further processing should occur
+        mock_build_datasets.assert_called_once_with(sample_case_operator)
+
+    @patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_empty_target_dataset(
+        self, mock_build_datasets, sample_case_operator, sample_forecast_dataset
+    ):
+        """Test compute_case_operator when _build_datasets returns empty
+        target dataset."""
+        # Mock _build_datasets to return empty target dataset
+        empty_target_ds = xr.Dataset()
         mock_build_datasets.return_value = (sample_forecast_dataset, empty_target_ds)
 
         result = evaluate.compute_case_operator(sample_case_operator)


### PR DESCRIPTION
# EWB Pull Request

## Description

In the case of a dataset with no data whatsoever, `forecast_ds.sizes` and `target_ds.sizes` should return an empty dictionary. This check and additional test covers this case.