### PR TITLE
Handle metric edge cases with multiple valid timesteps

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -199,8 +199,13 @@ class MaximumMAE(AppliedMetric):
     ) -> Any:
         forecast = forecast.compute()
         target_spatial_mean = target.compute().mean(["latitude", "longitude"])
-        maximum_timestep = target_spatial_mean.idxmax("valid_time").values
+        maximum_timestep = target_spatial_mean.idxmax("valid_time")
         maximum_value = target_spatial_mean.sel(valid_time=maximum_timestep)
+
+        # Handle the case where there are >1 resulting target values
+        maximum_timestep = utils.maybe_get_closest_timestamp_to_center_of_valid_times(
+            maximum_timestep, target.valid_time
+        )
         forecast_spatial_mean = forecast.mean(["latitude", "longitude"])
         filtered_max_forecast = forecast_spatial_mean.where(
             (
@@ -234,9 +239,13 @@ class MinimumMAE(AppliedMetric):
     ) -> Any:
         forecast = forecast.compute()
         target_spatial_mean = target.compute().mean(["latitude", "longitude"])
-        minimum_timestep = target_spatial_mean.idxmin("valid_time").values
+        minimum_timestep = target_spatial_mean.idxmin("valid_time")
         minimum_value = target_spatial_mean.sel(valid_time=minimum_timestep)
         forecast_spatial_mean = forecast.mean(["latitude", "longitude"])
+        # Handle the case where there are >1 resulting target values
+        minimum_timestep = utils.maybe_get_closest_timestamp_to_center_of_valid_times(
+            minimum_timestep, target.valid_time
+        )
         filtered_min_forecast = forecast_spatial_mean.where(
             (
                 forecast_spatial_mean.valid_time
@@ -280,7 +289,14 @@ class MaxMinMAE(AppliedMetric):
         )
         max_min_target_datetime = target.where(
             target == max_min_target_value, drop=True
-        ).valid_time.values
+        ).valid_time
+
+        # Handle the case where there are >1 resulting target values
+        max_min_target_datetime = (
+            utils.maybe_get_closest_timestamp_to_center_of_valid_times(
+                max_min_target_datetime, target.valid_time
+            )
+        )
         max_min_target_value = target.sel(valid_time=max_min_target_datetime)
         subset_forecast = (
             forecast.where(

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -269,3 +269,19 @@ def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
         ],
         "lead_time",
     )
+
+
+def maybe_get_closest_timestamp_to_center_of_valid_times(
+    output_times: xr.DataArray,
+    valid_time_values: xr.DataArray,
+) -> xr.DataArray:
+    if output_times.size > 1:
+        # This is a temporary fix to handle the case where there are multiple
+        # max/min target values. It's assumed the target value closest to the center
+        # of the forecast valid time is the most relevant.
+        center_time = valid_time_values.values[valid_time_values.size // 2]
+        time_diffs = np.abs(output_times - center_time)
+        closest_idx = np.argmin(time_diffs.data)
+        output_times = output_times[closest_idx]
+    # Pass through the original output times and values if there is only one
+    return output_times


### PR DESCRIPTION
# EWB Pull Request

## Description

There are edge cases where a metric that is looking for a maximum or minimum value ends up with >1 output. For example, a MaximumMAE output might result in two timesteps reaching 35C (308K). Tests are included to handle 1, 2, 3, and 20 `valid_times` that validate to confirm functionality.

The fix for this (for now) is to take the result closest to the center of the `valid_time` range.

Future behavior could take the average result of the two (or more) identical values, depending on the metric type. 