### PR TITLE
Remove logging setlevels from modules

### DIFF
--- a/src/extremeweatherbench/cases.py
+++ b/src/extremeweatherbench/cases.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from extremeweatherbench import inputs, metrics
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 @dataclasses.dataclass

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -4,7 +4,6 @@ from typing import List, Type, Union
 
 import xarray as xr
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from extremeweatherbench import metrics
 
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from extremeweatherbench import metrics
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 #: Storage/access options for gridded target datasets.
 ARCO_ERA5_FULL_URI = (

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -10,7 +10,6 @@ from scores.continuous import mae, mean_error, rmse  # type: ignore[import-untyp
 from extremeweatherbench import utils
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class BaseMetric(ABC):

--- a/src/extremeweatherbench/regions.py
+++ b/src/extremeweatherbench/regions.py
@@ -16,7 +16,6 @@ from shapely import MultiPolygon, Polygon  # type: ignore[import-untyped]
 from extremeweatherbench import utils
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class Region(ABC):

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -16,7 +16,6 @@ import xarray as xr
 import yaml  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 IncomingDataInput: TypeAlias = xr.Dataset | xr.DataArray | pl.LazyFrame | pd.DataFrame
 


### PR DESCRIPTION
# EWB Pull Request

## Description

A vestige of older code was that the modules had defined setlevels for logging predetermined. Users should be able to set their own logging contexts at runtime and the code should stick with established best practices for logging.