### PR TITLE
Add default attributes to era5, ghcn, pph, lsr, ibtracs

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -441,7 +441,9 @@ class ERA5(TargetBase):
     name: str = "ERA5"
     chunks: Optional[Union[dict, str]] = None
     source: str = ARCO_ERA5_FULL_URI
-    variable_mapping: dict = ERA5_metadata_variable_mapping
+    variable_mapping: dict = dataclasses.field(
+        default_factory=ERA5_metadata_variable_mapping
+    )
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         data = xr.open_zarr(

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -36,6 +36,52 @@ IBTRACS_URI = (
     "climate-stewardship-ibtracs/v04r01/access/csv/ibtracs.ALL.list.v04r01.csv"
 )
 
+# ERA5 metadata variable mapping
+ERA5_metadata_variable_mapping = {
+    "time": "valid_time",
+    "2m_temperature": "surface_air_temperature",
+    "2m_dewpoint_temperature": "surface_dewpoint_temperature",
+    "2m_relative_humidity": "surface_relative_humidity",
+    "2m_specific_humidity": "surface_specific_humidity",
+    "10m_u_component_of_wind": "surface_eastward_wind",
+    "10m_v_component_of_wind": "surface_northward_wind",
+    "u_component_of_wind": "eastward_wind",
+    "v_component_of_wind": "northward_wind",
+    "specific_humidity": "specific_humidity",
+    "mean_sea_level_pressure": "air_pressure_at_mean_sea_level",
+}
+
+# CIRA MLWP forecasts metadata variable mapping
+CIRA_metadata_variable_mapping = {
+    "time": "valid_time",
+    "t2": "surface_air_temperature",
+    "t": "air_temperature",
+    "q": "specific_humidity",
+    "u": "eastward_wind",
+    "v": "northward_wind",
+    "p": "air_pressure",
+    "z": "geopotential_height",
+    "q": "specific_humidity",
+    "r": "relative_humidity",
+    "u10": "surface_eastward_wind",
+    "v10": "surface_northward_wind",
+    "u100": "eastward_wind",
+    "v100": "northward_wind",
+}
+
+# HRES forecast (weatherbench2)metadata variable mapping
+HRES_metadata_variable_mapping = {
+    "2m_temperature": "surface_air_temperature",
+    "10m_u_component_of_wind": "surface_eastward_wind",
+    "10m_v_component_of_wind": "surface_northward_wind",
+    "u_component_of_wind": "eastward_wind",
+    "v_component_of_wind": "northward_wind",
+    "prediction_timedelta": "lead_time",
+    "time": "init_time",
+    "mean_sea_level_pressure": "air_pressure_at_mean_sea_level",
+    "10m_wind_speed": "surface_wind_speed",
+}
+
 IBTrACS_metadata_variable_mapping = {
     "ISO_TIME": "valid_time",
     "NAME": "tc_name",
@@ -390,6 +436,7 @@ class ERA5(TargetBase):
     name: str = "ERA5"
     chunks: Optional[Union[dict, str]] = None
     source: str = ARCO_ERA5_FULL_URI
+    variable_mapping: dict = ERA5_metadata_variable_mapping
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         data = xr.open_zarr(

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -63,7 +63,6 @@ CIRA_metadata_variable_mapping = {
     "v": "northward_wind",
     "p": "air_pressure",
     "z": "geopotential_height",
-    "q": "specific_humidity",
     "r": "relative_humidity",
     "u10": "surface_eastward_wind",
     "v10": "surface_northward_wind",

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -72,6 +72,7 @@ CIRA_metadata_variable_mapping = {
 # HRES forecast (weatherbench2)metadata variable mapping
 HRES_metadata_variable_mapping = {
     "2m_temperature": "surface_air_temperature",
+    "dewpoint": "dewpoint_temperature",
     "10m_u_component_of_wind": "surface_eastward_wind",
     "10m_v_component_of_wind": "surface_northward_wind",
     "u_component_of_wind": "eastward_wind",

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -41,6 +41,8 @@ ERA5_metadata_variable_mapping = {
     "time": "valid_time",
     "2m_temperature": "surface_air_temperature",
     "2m_dewpoint_temperature": "surface_dewpoint_temperature",
+    "temperature": "air_temperature",
+    "dewpoint": "dewpoint_temperature",
     "2m_relative_humidity": "surface_relative_humidity",
     "2m_specific_humidity": "surface_specific_humidity",
     "10m_u_component_of_wind": "surface_eastward_wind",
@@ -72,6 +74,8 @@ CIRA_metadata_variable_mapping = {
 # HRES forecast (weatherbench2)metadata variable mapping
 HRES_metadata_variable_mapping = {
     "2m_temperature": "surface_air_temperature",
+    "2m_dewpoint_temperature": "surface_dewpoint_temperature",
+    "temperature": "air_temperature",
     "dewpoint": "dewpoint_temperature",
     "10m_u_component_of_wind": "surface_eastward_wind",
     "10m_v_component_of_wind": "surface_northward_wind",

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -389,6 +389,7 @@ class ERA5(TargetBase):
 
     name: str = "ERA5"
     chunks: Optional[Union[dict, str]] = None
+    source: str = ARCO_ERA5_FULL_URI
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         data = xr.open_zarr(
@@ -438,6 +439,7 @@ class GHCN(TargetBase):
     """
 
     name: str = "GHCN"
+    source: str = DEFAULT_GHCN_URI
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         target_data: pl.LazyFrame = pl.scan_parquet(
@@ -541,6 +543,7 @@ class LSR(TargetBase):
     """
 
     name: str = "local_storm_reports"
+    source: str = LSR_URI
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         # force LSR to use anon token to prevent google reauth issues for users
@@ -669,6 +672,7 @@ class PPH(TargetBase):
     """Target class for practically perfect hindcast data."""
 
     name: str = "practically_perfect_hindcast"
+    source: str = PPH_URI
 
     def _open_data_from_source(
         self,
@@ -698,6 +702,7 @@ class IBTrACS(TargetBase):
     """Target class for IBTrACS data."""
 
     name: str = "IBTrACS"
+    source: str = IBTRACS_URI
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:
         # not using storage_options in this case due to NetCDF4Backend not

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -441,7 +441,7 @@ class ERA5(TargetBase):
     chunks: Optional[Union[dict, str]] = None
     source: str = ARCO_ERA5_FULL_URI
     variable_mapping: dict = dataclasses.field(
-        default_factory=ERA5_metadata_variable_mapping
+        default_factory=lambda: ERA5_metadata_variable_mapping.copy()
     )
 
     def _open_data_from_source(self) -> utils.IncomingDataInput:


### PR DESCRIPTION
# EWB Pull Request

## Description

Currently, users are required to include the source attribute when instantiating any of the builtin target classes. This shouldn't be necessary, as we are using an opinionated set of sources for our built in targets and forecasts. 

Similarly, variable mappings are currently not provided by default but are easily available. The only change to enable default variable mappings applies to ERA5. Therefore, the sources and mappings are added as defaults. Most default variable mappings are also included for CIRA MLWP model variables as well as HRES from Weatherbench2.

```python
...

era5 = inputs.ERA5(
    variables=["surface_air_temperature"],
    chunks=None
)

...
```

This pattern should handle most use cases now, simplifying the code overall. Users can still use their own attributes if desired with the same API, e.g.:

```python
...

era5 = inputs.ERA5(
    source=USER_SOURCE,
    variables=["surface_air_temperature"],
    variable_mapping={'2m_temperature':'surface_air_temperature'},
    chunks=None
)

...
```

But is not necessary unless there's a variable mapping not included that a user wants to process.