### PR TITLE
Update heat wave and freeze event case bounds

### DIFF
--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -4,165 +4,180 @@ cases:
     start_date: 2021-06-20 00:00:00
     end_date: 2021-07-03 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 47.6062
-        longitude: 237.6679
-        bounding_box_degrees: 5
+        latitude_min: 33.25
+        latitude_max: 68.0
+        longitude_min: 215.25
+        longitude_max: 256.0
     event_type: heat_wave
   - case_id_number: 2
     title: 2022 Upper Midwest
     start_date: 2022-05-07 00:00:00
     end_date: 2022-05-17 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 41.8781
-        longitude: 272.3702
-        bounding_box_degrees: 5
+        latitude_min: 19.5
+        latitude_max: 48.25
+        longitude_min: 252.0
+        longitude_max: 276.75
     event_type: heat_wave
   - case_id_number: 3
     title: 2022 California
     start_date: 2022-06-07 00:00:00
     end_date: 2022-06-15 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 34.0522
-        longitude: 241.7563
-        bounding_box_degrees: 5
+        latitude_min: 23.75
+        latitude_max: 44.5
+        longitude_min: 235.75
+        longitude_max: 266.25
     event_type: heat_wave
   - case_id_number: 4
     title: 2022 Texas
     start_date: 2022-06-30 00:00:00
     end_date: 2022-07-18 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 32.7767
-        longitude: 263.203
-        bounding_box_degrees: 5
+        latitude_min: 20.5
+        latitude_max: 43.25
+        longitude_min: 254.75
+        longitude_max: 275.5
     event_type: heat_wave
   - case_id_number: 5
     title: 2023 Pacific Northwest
     start_date: 2023-05-10 00:00:00
     end_date: 2023-05-23 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 47.6062
-        longitude: 237.6679
-        bounding_box_degrees: 5
+        latitude_min: 35.25
+        latitude_max: 72.0
+        longitude_min: 219.25
+        longitude_max: 262.0
     event_type: heat_wave
   - case_id_number: 6
     title: 2022 Mid-Atlantic
     start_date: 2022-05-17 00:00:00
     end_date: 2022-05-24 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 39.2904
-        longitude: 283.38779999999997
-        bounding_box_degrees: 5
+        latitude_min: 31.0
+        latitude_max: 42.25
+        longitude_min: 277.0
+        longitude_max: 287.75
     event_type: heat_wave
   - case_id_number: 7
     title: 2023 Australia
     start_date: 2023-11-18 00:00:00
     end_date: 2023-11-28 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -31.9505
-        longitude: 115.8605
-        bounding_box_degrees: 5
+        latitude_min: -35.0
+        latitude_max: -20.0
+        longitude_min: 113.5
+        longitude_max: 120.25
     event_type: heat_wave
   - case_id_number: 8
     title: 2023 Ireland
     start_date: 2023-09-02 00:00:00
     end_date: 2023-09-13 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 53.1424
-        longitude: 352.3079
-        bounding_box_degrees: 5
+        latitude_min: 40.75
+        latitude_max: 67.5
+        longitude_min: -9.75
+        longitude_max: 16.75
     event_type: heat_wave
   - case_id_number: 9
     title: 2023 Italy
     start_date: 2023-07-07 00:00:00
     end_date: 2023-07-27 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 41.9028
-        longitude: 12.4964
-        bounding_box_degrees: 5
+        latitude_min: 17.5
+        latitude_max: 52.25
+        longitude_min: -12.0
+        longitude_max: 32.75
     event_type: heat_wave
   - case_id_number: 10
     title: 2023 SW Europe
     start_date: 2023-08-17 00:00:00
     end_date: 2023-08-28 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 40.4637
-        longitude: 356.2508
-        bounding_box_degrees: 5
+        latitude_min: 36.0
+        latitude_max: 56.75
+        longitude_min: -9.25
+        longitude_max: 20.75
     event_type: heat_wave
   - case_id_number: 11
     title: 2023 South America
     start_date: 2023-07-29 00:00:00
     end_date: 2023-08-04 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -34.6037
-        longitude: 301.6184
-        bounding_box_degrees: 5
+        latitude_min: -44.25
+        latitude_max: -20.25
+        longitude_min: 285.75
+        longitude_max: 308.0
     event_type: heat_wave
   - case_id_number: 12
     title: 2023 China (Shanghai)
     start_date: 2023-05-24 00:00:00
     end_date: 2023-06-01 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 31.2304
-        longitude: 121.4737
-        bounding_box_degrees: 5
+        latitude_min: 16.75
+        latitude_max: 35.25
+        longitude_min: 99.0
+        longitude_max: 122.0
     event_type: heat_wave
   - case_id_number: 13
     title: 2023 China (Yunnan Province)
     start_date: 2023-04-14 00:00:00
     end_date: 2023-04-23 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 25.0458
-        longitude: 102.71
-        bounding_box_degrees: 5
+        latitude_min: 12.75
+        latitude_max: 43.5
+        longitude_min: 92.25
+        longitude_max: 121.0
     event_type: heat_wave
   - case_id_number: 14
     title: 2023 Algeria
     start_date: 2023-07-05 00:00:00
     end_date: 2023-07-27 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 36.7372
-        longitude: 3.0869
-        bounding_box_degrees: 5
+        latitude_min: 16.25
+        latitude_max: 51.0
+        longitude_min: -17.0
+        longitude_max: 27.5
     event_type: heat_wave
   - case_id_number: 15
     title: 2023 Iberian Peninsula
     start_date: 2023-04-22 00:00:00
     end_date: 2023-05-01 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 41.1496
-        longitude: 352.389
-        bounding_box_degrees: 5
+        latitude_min: 22.75
+        latitude_max: 46.75
+        longitude_min: -15.75
+        longitude_max: 8.75
     event_type: heat_wave
   - case_id_number: 16
     title: 2023 Southeast Asia
@@ -171,153 +186,166 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 9.0
-        latitude_max: 31.5
-        longitude_min: 61.5
-        longitude_max: 113.75
+        latitude_min: 6.0
+        latitude_max: 41.0
+        longitude_min: 84.0
+        longitude_max: 123.75
     event_type: heat_wave
   - case_id_number: 17
     title: 2023 India
     start_date: 2023-02-15 00:00:00
     end_date: 2023-03-01 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 28.6139
-        longitude: 77.209
-        bounding_box_degrees: 5
+        latitude_min: 22.25
+        latitude_max: 53.0
+        longitude_min: 56.75
+        longitude_max: 101.5
     event_type: heat_wave
   - case_id_number: 18
     title: 2021 Western Russia
     start_date: 2021-06-18 00:00:00
     end_date: 2021-06-30 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 55.7558
-        longitude: 37.6173
-        bounding_box_degrees: 5
+        latitude_min: 35.5
+        latitude_max: 65.75
+        longitude_min: 13.25
+        longitude_max: 60.0
     event_type: heat_wave
   - case_id_number: 19
     title: 2022 Germany
     start_date: 2022-12-23 00:00:00
     end_date: 2022-12-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 52.52
-        longitude: 13.405
-        bounding_box_degrees: 5
+        latitude_min: 36.25
+        latitude_max: 56.25
+        longitude_min: -3.0
+        longitude_max: 21.75
     event_type: heat_wave
   - case_id_number: 20
     title: 2022 UK (August)
     start_date: 2022-08-08 00:00:00
     end_date: 2022-08-16 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 51.5074
-        longitude: 359.8722
-        bounding_box_degrees: 5
+        latitude_min: 39.25
+        latitude_max: 56.0
+        longitude_min: -9.75
+        longitude_max: 8.25
     event_type: heat_wave
   - case_id_number: 21
     title: 2022 UK (July)
     start_date: 2022-07-15 00:00:00
     end_date: 2022-07-23 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 51.5074
-        longitude: 359.8722
-        bounding_box_degrees: 5
+        latitude_min: 37.25
+        latitude_max: 58.0
+        longitude_min: -9.75
+        longitude_max: 8.25
     event_type: heat_wave
   - case_id_number: 22
     title: 2022 France
     start_date: 2022-06-09 00:00:00
     end_date: 2022-06-21 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 43.4832
-        longitude: 358.4414
-        bounding_box_degrees: 5
+        latitude_min: 29.0
+        latitude_max: 51.75
+        longitude_min: -9.75
+        longitude_max: 12.75
     event_type: heat_wave
   - case_id_number: 23
     title: 2022 Japan
     start_date: 2022-06-20 00:00:00
     end_date: 2022-07-05 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 35.6895
-        longitude: 139.6917
-        bounding_box_degrees: 5
+        latitude_min: 31.25
+        latitude_max: 46.0
+        longitude_min: 125.25
+        longitude_max: 145.25
     event_type: heat_wave
   - case_id_number: 24
     title: 2022 India
     start_date: 2022-04-24 00:00:00
     end_date: 2022-05-04 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 28.2769
-        longitude: 68.4376
-        bounding_box_degrees: 5
+        latitude_min: 18.0
+        latitude_max: 52.75
+        longitude_min: 58.0
+        longitude_max: 78.75
     event_type: heat_wave
   - case_id_number: 25
     title: 2022 East Antarctica
     start_date: 2022-03-12 00:00:00
     end_date: 2022-03-26 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -75.1
-        longitude: 123.35
-        bounding_box_degrees: 5
+        latitude_min: -85.5
+        latitude_max: -65.5
+        longitude_min: 99.0
+        longitude_max: 147.75
     event_type: heat_wave
   - case_id_number: 26
     title: 2022 West Australia
     start_date: 2022-01-15 00:00:00
     end_date: 2022-01-25 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -31.9505
-        longitude: 115.8605
-        bounding_box_degrees: 5
+        latitude_min: -35.0
+        latitude_max: -27.5
+        longitude_min: 114.25
+        longitude_max: 119.75
     event_type: heat_wave
   - case_id_number: 27
     title: 2021 Canada Plains
     start_date: 2021-05-30 00:00:00
     end_date: 2021-06-09 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 49.0
-        longitude: 262.43330000000003
-        bounding_box_degrees: 5
+        latitude_min: 38.5
+        latitude_max: 59.5
+        longitude_min: 238.0
+        longitude_max: 272.75
     event_type: heat_wave
   - case_id_number: 28
     title: 2021 New Zealand
     start_date: 2021-01-12 18:00:00
     end_date: 2021-01-18 18:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -43.8983
-        longitude: 171.731
-        bounding_box_degrees: 5
+        latitude_min: -46.5
+        latitude_max: -40.75
+        longitude_min: 167.5
+        longitude_max: 175.25
     event_type: heat_wave
   - case_id_number: 29
     title: 2020 Australia
     start_date: 2020-11-25 00:00:00
     end_date: 2020-12-01 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -33.8245
-        longitude: 150.9448
-        bounding_box_degrees: 5
+        latitude_min: -36.75
+        latitude_max: -17.5
+        longitude_min: 126.5
+        longitude_max: 152.5
     event_type: heat_wave
   - case_id_number: 30
     title: 2021 Texas
@@ -822,187 +850,204 @@ cases:
     start_date: 2024-05-25 00:00:00
     end_date: 2024-05-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 25.9017
-        longitude: 262.50260000000003
-        bounding_box_degrees: 5
+        latitude_min: 9.75
+        latitude_max: 32.25
+        longitude_min: 254.25
+        longitude_max: 277.0
     event_type: heat_wave
   - case_id_number: 73
     title: June 2024 Northeast US
     start_date: 2024-06-17 00:00:00
     end_date: 2024-06-23 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 41.8781
-        longitude: 286.771
-        bounding_box_degrees: 6
+        latitude_min: 37.0
+        latitude_max: 50.75
+        longitude_min: 272.0
+        longitude_max: 307.25
     event_type: heat_wave
   - case_id_number: 74
     title: July 2024 Southwest US
     start_date: 2024-07-04 00:00:00
     end_date: 2024-07-10 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 33.7701
-        longitude: 243.78539999999998
-        bounding_box_degrees: 6
+        latitude_min: 30.0
+        latitude_max: 42.75
+        longitude_min: 235.5
+        longitude_max: 248.75
     event_type: heat_wave
   - case_id_number: 75
     title: July 2024 Northeast US
     start_date: 2024-07-07 00:00:00
     end_date: 2024-07-13 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 40.7128
-        longitude: 285.994
-        bounding_box_degrees: 6
+        latitude_min: 35.75
+        latitude_max: 47.5
+        longitude_min: 281.0
+        longitude_max: 300.0
     event_type: heat_wave
   - case_id_number: 76
     title: July 2024 Mid-Atlantic US
     start_date: 2024-07-15 00:00:00
     end_date: 2024-07-21 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 39.9526
-        longitude: 284.8348
-        bounding_box_degrees: 6
+        latitude_min: 35.25
+        latitude_max: 44.75
+        longitude_min: 280.0
+        longitude_max: 292.75
     event_type: heat_wave
   - case_id_number: 77
     title: August 2024 Midwest US
     start_date: 2024-08-25 00:00:00
     end_date: 2024-08-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 40.1106
-        longitude: 271.79269999999997
-        bounding_box_degrees: 5
+        latitude_min: 36.0
+        latitude_max: 46.25
+        longitude_min: 265.5
+        longitude_max: 278.25
     event_type: heat_wave
   - case_id_number: 78
     title: July 2024 Antarctica
     start_date: 2024-07-01 00:00:00
     end_date: 2024-07-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -75.0
-        longitude: 15.0
-        bounding_box_degrees: 5
+        latitude_min: -90.0
+        latitude_max: -68.75
+        longitude_min: -9.5
+        longitude_max: 39.5
     event_type: heat_wave
   - case_id_number: 79
     title: August 2024 Canada
     start_date: 2024-08-09 00:00:00
     end_date: 2024-08-15 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 67.0
-        longitude: 248.0
-        bounding_box_degrees: 5
+        latitude_min: 54.5
+        latitude_max: 73.5
+        longitude_min: 231.5
+        longitude_max: 272.5
     event_type: heat_wave
   - case_id_number: 80
     title: August 2024 Australia
     start_date: 2024-08-22 00:00:00
     end_date: 2024-08-30 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -20.0
-        longitude: 120.0
-        bounding_box_degrees: 5
+        latitude_min: -32.5
+        latitude_max: -9.5
+        longitude_min: 116.25
+        longitude_max: 144.5
     event_type: heat_wave
   - case_id_number: 81
     title: July/August 2024 Japan
     start_date: 2024-07-25 00:00:00
     end_date: 2024-08-05 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 36.0
-        longitude: 138.0
-        bounding_box_degrees: 6
+        latitude_min: 31.25
+        latitude_max: 43.0
+        longitude_min: 123.0
+        longitude_max: 142.75
     event_type: heat_wave
   - case_id_number: 82
     title: June 2024 Saudi Arabia
     start_date: 2024-06-16 00:00:00
     end_date: 2024-06-22 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 24.0
-        longitude: 45.0
-        bounding_box_degrees: 6
+        latitude_min: 19.0
+        latitude_max: 35.0
+        longitude_min: 30.0
+        longitude_max: 54.0
     event_type: heat_wave
   - case_id_number: 83
     title: August 2024 Europe
     start_date: 2024-08-10 00:00:00
     end_date: 2024-08-16 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 48.3794
-        longitude: 10.8978
-        bounding_box_degrees: 10
+        latitude_min: 35.5
+        latitude_max: 55.25
+        longitude_min: 0.0
+        longitude_max: 25.75
     event_type: heat_wave
   - case_id_number: 84
     title: July 2024 Ukraine
     start_date: 2024-07-12 00:00:00
     end_date: 2024-07-18 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 50.4501
-        longitude: 30.5234
-        bounding_box_degrees: 5
+        latitude_min: 40.0
+        latitude_max: 56.75
+        longitude_min: 14.25
+        longitude_max: 45.0
     event_type: heat_wave
   - case_id_number: 85
     title: June 2024 Europe
     start_date: 2024-06-20 00:00:00
     end_date: 2024-06-30 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 52.3676
-        longitude: 4.9041
-        bounding_box_degrees: 6
+        latitude_min: 45.5
+        latitude_max: 63.25
+        longitude_min: -4.0
+        longitude_max: 25.75
     event_type: heat_wave
   - case_id_number: 86
     title: May 2024 Central Mexico
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 19.4326
-        longitude: 260.8668
-        bounding_box_degrees: 5
+        latitude_min: 7.25
+        latitude_max: 29.75
+        longitude_min: 252.5
+        longitude_max: 283.25
     event_type: heat_wave
   - case_id_number: 87
     title: May 2024 Pakistan/India
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: 34.0
-        longitude: 76.0
-        bounding_box_degrees: 5
+        latitude_min: 23.5
+        latitude_max: 42.5
+        longitude_min: 71.5
+        longitude_max: 98.5
     event_type: heat_wave
   - case_id_number: 88
     title: August 2023 Chile
     start_date: 2023-08-01 00:00:00
     end_date: 2023-08-07 00:00:00
     location:
-      type: centered_region
+      type: bounded_region
       parameters:
-        latitude: -33.4489
-        longitude: 289.3307
-        bounding_box_degrees: 5
+        latitude_min: -37.25
+        latitude_max: -19.0
+        longitude_min: 288.5
+        longitude_max: 305.75
     event_type: heat_wave
   - case_id_number: 89
     title: January 2024 Pacific Northwest


### PR DESCRIPTION
# EWB Pull Request

## Description

The current heat and cold cases use a central point and bounding box radius in degrees that was determined based upon reports of heat waves. This new set of bounds uses a more robust method to identify the bounding corners:

- All data for determining bounds are calculated using ERA5.
- An initial bound and timeframe was determined based on news reports and aggregated information online, with a central point + bounding box size in degrees (minimum of 5 degrees latitude and longitude to start).
- A valid heat wave is defined per gridpoint having at least 3 consecutive days, or 12 6-hourly timesteps, of temperatures above (below) the 85th (15th) percentile for that gridpoint, day, and hour of day. 
    - 85th (15th) percentile values are calculated by gridpoint, day of year, and hour 
    - Values are smoothed with a 21 day linear weighted window
- Bounds are then iteratively widened if an edge has at least 50% of its gridpoints satisfying the aforementioned heat wave criteria. This repeats for up to 10 iterations, or until all edges have less than 50% of validating heatwave points (whichever comes first). Each edge is enlarged by 2 degrees at a time.

These new bounds more accurately reflect the spatial scale of the temperature events and should produce more robust results when evaluating a model's outputs.
