### PR TITLE
Update 100m wind mapping name

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -66,8 +66,8 @@ CIRA_metadata_variable_mapping = {
     "r": "relative_humidity",
     "u10": "surface_eastward_wind",
     "v10": "surface_northward_wind",
-    "u100": "eastward_wind",
-    "v100": "northward_wind",
+    "u100": "100m_eastward_wind",
+    "v100": "100m_northward_wind",
 }
 
 # HRES forecast (weatherbench2)metadata variable mapping


### PR DESCRIPTION
# EWB Pull Request

## Description

Duplicate naming for u100 and v100 in CIRA_metadata_variable_mapping is fixed here. Not ideal for CF conventions, but manages to handle it and maintain some consistency with surface_eastward_wind without being too verbose.