### PR TITLE
Move inputs import

### DIFF
--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -3,8 +3,6 @@ from typing import Literal, Sequence, Union
 import numpy as np
 import xarray as xr
 
-from extremeweatherbench import inputs
-
 
 def convert_from_cartesian_to_latlon(
     input_point: Union[np.ndarray, tuple[float, float]], ds_mapping: xr.Dataset
@@ -103,9 +101,13 @@ def orography(ds: xr.Dataset) -> xr.DataArray:
     Returns:
         The orography as an xarray DataArray.
     """
+
     if "geopotential_at_surface" in ds.variables:
         return ds["geopotential_at_surface"].isel(time=0) / 9.80665
     else:
+        # Import inputs here to avoid circular import
+        from extremeweatherbench import inputs
+
         era5 = xr.open_zarr(
             inputs.ARCO_ERA5_FULL_URI,
             chunks=None,


### PR DESCRIPTION
# EWB Pull Request

## Description

The import of `inputs` is moved within the function to minimize the risk of a circular import. The only location `inputs` is used in calc.py is in `orography()`, minimizing any duplicated import issues. If `inputs` needs to be called elsewhere in the future, this will be modified accordingly.