### PR TITLE
Make `storage_options` optional except for KerchunkForecast

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -146,7 +146,7 @@ class InputBase(ABC):
         default_factory=list
     )
     variable_mapping: dict = dataclasses.field(default_factory=dict)
-    storage_options: dict = dataclasses.field(default_factory=dict)
+    storage_options: Optional[dict] = None
     preprocess: Callable = _default_preprocess
 
     def open_and_maybe_preprocess_data_from_source(
@@ -373,6 +373,7 @@ class KerchunkForecast(ForecastBase):
 
     name: str = "kerchunk_forecast"
     chunks: Optional[Union[dict, str]] = "auto"
+    storage_options: dict = dataclasses.field(default_factory=dict)
 
     def _open_data_from_source(self) -> IncomingDataInput:
         return open_kerchunk_reference(

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1628,6 +1628,7 @@ class TestInputsIntegration:
             source=temp_zarr_file,
             variables=["2m_temperature"],
             variable_mapping={},
+            storage_options=None,
         )
 
         # Test opening data


### PR DESCRIPTION
# EWB Pull Request

## Description

`storage_options` is not used when using `xr.open_zarr` in this case. The argument is only used when `xr.open_zarr` has an fsspec URI string for a store. 

The test, as a result (being a string to a local zarr from `conftest.py`) fails out. This changes the argument and the default to be `None`.

`KerchunkForecast` needs to have a `dict` as far as I am aware, to manage the remote_protocol (though I think this changes if we move to a Icechunk store for the CIRA forecasts). Therefore, it gets a required `dict`.