### PR TITLE
Change `cases` to `case_metadata` in EWB instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cases = utils.load_events_yaml()
 
 # Create the evaluation class, with cases and evaluation objects declared
 ewb_instance = evaluate.ExtremeWeatherBench(
-    cases=cases,
+    case_metadata=cases,
     evaluation_objects=heatwave_evaluation_list,
 )
 

--- a/docs/examples/applied_freeze.py
+++ b/docs/examples/applied_freeze.py
@@ -95,7 +95,7 @@ freeze_evaluation_object = [
 
 # Initialize ExtremeWeatherBench runner instance
 ewb = evaluate.ExtremeWeatherBench(
-    cases=case_yaml,
+    case_metadata=case_yaml,
     evaluation_objects=freeze_evaluation_object,
 )
 

--- a/docs/examples/applied_heatwave.py
+++ b/docs/examples/applied_heatwave.py
@@ -56,7 +56,7 @@ heatwave_evaluation_object = [
 
 # Initialize ExtremeWeatherBench
 ewb = evaluate.ExtremeWeatherBench(
-    cases=case_yaml,
+    case_metadata=case_yaml,
     evaluation_objects=heatwave_evaluation_object,
 )
 

--- a/scripts/brightband_evaluation.py
+++ b/scripts/brightband_evaluation.py
@@ -27,7 +27,7 @@ case_yaml = cases.load_ewb_events_yaml_into_case_collection()
 
 # Initialize ExtremeWeatherBench
 ewb = evaluate.ExtremeWeatherBench(
-    cases=case_yaml,
+    case_metadata=case_yaml,
     evaluation_objects=defaults.get_brightband_evaluation_objects(),
 )
 # Get the number of available CPUs for determining n_processes and divide by 4 threads

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -139,7 +139,7 @@ def cli_runner(
 
     # Initialize ExtremeWeatherBench
     ewb = ExtremeWeatherBench(
-        cases=cases_dict,
+        case_metadata=cases_dict,
         evaluation_objects=evaluation_objects,
         cache_dir=cache_dir if cache_dir else None,
     )


### PR DESCRIPTION
# EWB Pull Request

## Description

In the examples, 

`ExtremeWeatherBench(cases=<>...` 

is incorrect and was replaced with 

`ExtremeWeatherBench(case_metadata=<>...` 

to differentiate from the module `cases.py`. This changes all instances to ensure proper functionality.