### PR TITLE
Remove `--explicit-package-bases` from pre-commit yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,7 @@ repos:
     rev: v1.5.1
     hooks:
       - id: mypy
-        args:
-          [
-            --enable-incomplete-feature=Unpack,
-            --ignore-missing-imports,
-            --explicit-package-bases,
-          ]
+        args: [--enable-incomplete-feature=Unpack, --ignore-missing-imports]
         additional_dependencies:
           [tqdm-stubs, types-requests, types-ujson, types-pyyaml]
   - repo: local


### PR DESCRIPTION
# EWB Pull Request

## Description

Given that EWB has code that should be linted and type checked outside of `src/extremeweatherbench`, `--explicit-package-bases` should not be included in the pre-commit manifest. Removing it will force a more robust codebase.