### PR TITLE
Add conditional chunking to zarr data

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -1021,7 +1021,9 @@ def zarr_target_subsetter(
     fully_subset_data = case_operator.case_metadata.location.mask(
         subset_time_variable_data, drop=drop
     )
-
+    # chunk the data if it doesn't have chunks, e.g. ARCO ERA5
+    if not fully_subset_data.chunks:
+        fully_subset_data = fully_subset_data.chunk()
     return fully_subset_data
 
 


### PR DESCRIPTION
# EWB Pull Request

## Description

In cases where the default data does not have chunking - how we're pulling the ARCO ERA5, as the primary example - chunking the data once it's subset helps with managing the asynchronous loading of the data in multithreaded/processing contexts. 

This PR adds a conditional to chunk the data with defaults for now as well as tests to confirm the functionality.