### PR TITLE
Update bounding coordinates for atmospheric rivers

### DIFF
--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -1356,9 +1356,9 @@ cases:
         longitude_max: 240.8
     event_type: atmospheric_river
   - case_id_number: 114
-    title: December 2022 - January 2023 California
-    start_date: 2022-12-01 00:00:00
-    end_date: 2023-02-01 00:00:00
+    title: January 2023 California
+    start_date: 2023-01-04 00:00:00
+    end_date: 2023-01-10 00:00:00
     location:
       type: bounded_region
       parameters:
@@ -1370,7 +1370,7 @@ cases:
   - case_id_number: 115
     title: December 2022 California
     start_date: 2022-12-26 00:00:00
-    end_date: 2022-12-28 00:00:00
+    end_date: 2023-01-02 00:00:00
     location:
       type: bounded_region
       parameters:


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR edits the bounding box coordinates for atmospheric rivers based on the following criteria:

* Using ERA5 as the reanalysis dataset
* An atmospheric river at time *t* must have at least 300 valid points on the 0.25 degree grid
* A Laplacian threshold of 2.5
* An IVT minimum threshold of 400 kg/m/s,
* An IVT Laplacian dilation radius of 8 gridpoints

The bounds are calculated using the composite mask of all atmospheric river gridpoints over land for the case timesteps. A 250km buffer is then extended for each edge.