### PR TITLE
Variables in metric instances

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -285,7 +285,7 @@ def compute_case_operator(
             logger.warning(
                 "Metric %s instantiated with default parameters", metric.name
             )
-        if not isinstance(metric, metrics.BaseMetric):
+        if not isinstance(case_operator.metric_list[i], metrics.BaseMetric):
             raise TypeError(f"Metric must be a BaseMetric instance, got {type(metric)}")
 
     forecast_ds, target_ds = _build_datasets(case_operator, **kwargs)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1011,7 +1011,10 @@ class TestComputeCaseOperator:
             sample_forecast_dataset,
             sample_target_dataset,
         )
-        sample_case_operator.metric_list = [mock.Mock(spec=metrics.BaseMetric)]
+        mock_metric = mock.Mock(spec=metrics.BaseMetric)
+        mock_metric.forecast_variable = None
+        mock_metric.target_variable = None
+        sample_case_operator.metric_list = [mock_metric]
 
         with mock.patch(
             "extremeweatherbench.evaluate._compute_and_maybe_cache"
@@ -1049,7 +1052,11 @@ class TestComputeCaseOperator:
 
         # Create multiple metrics
         metric_1 = mock.Mock(spec=metrics.BaseMetric)
+        metric_1.forecast_variable = None
+        metric_1.target_variable = None
         metric_2 = mock.Mock(spec=metrics.BaseMetric)
+        metric_2.forecast_variable = None
+        metric_2.target_variable = None
         sample_case_operator.metric_list = [metric_1, metric_2]
 
         sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
@@ -3366,6 +3373,8 @@ class TestMetricVariableHandling:
 
         # Create a metric CLASS (not instance) with required methods
         class TestMetric(metrics.BaseMetric):
+            name = "TestMetric"
+
             def __init__(self):
                 super().__init__("TestMetric")
 


### PR DESCRIPTION
# EWB Pull Request

## Description

To help improve the API for EWB, the metrics now can have their own forecast and target variables declared in their instantiation.

Example: 

```python

...
# GHCN target
ghcn_target = inputs.GHCN(
    variables=["surface_air_temperature"],
)

# Define forecast (HRES)
hres_forecast = inputs.ZarrForecast(
    name="hres_forecast",
    source="gs://weatherbench2/datasets/hres/2016-2022-0012-1440x721.zarr",
    variables=["surface_air_temperature"],
    variable_mapping=inputs.HRES_metadata_variable_mapping,
)

metrics_list = [
    metrics.MaximumMAE(),
metrics.RMSE(forecast_variable='surface_eastward_wind',target_variable='surface_eastward_wind'),
    metrics.OnsetME(),
    metrics.DurationME(),
    metrics.MaxMinMAE(),
]
...
```

Where all of the metrics will evaluate the set of the variables in `ghcn_target` and `hres_forecast` (`surface_air_temperature`) except for `RMSE`, which will instead evaluate `surface_eastward_wind`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

New tests were set up to cover the core and edge cases of the variable permutations.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules