### PR TITLE
Update severe bounds, add Canada cases

### DIFF
--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -426,10 +426,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 49.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 38.25
+        latitude_max: 58.5
+        longitude_min: 240.86
+        longitude_max: 285.64
     event_type: severe_convection
   - case_id_number: 37
     title: July 2024 Chicago
@@ -438,10 +438,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 49.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 30.0
+        latitude_max: 57.75
+        longitude_min: 243.74
+        longitude_max: 289.69
     event_type: severe_convection
   - case_id_number: 38
     title: July 2024 New York
@@ -450,10 +450,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
+        latitude_min: 31.0
         latitude_max: 49.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        longitude_min: 274.31
+        longitude_max: 293.44
     event_type: severe_convection
   - case_id_number: 39
     title: May 2024 Wisconsin
@@ -462,10 +462,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 36.5
+        latitude_max: 55.5
+        longitude_min: 258.01
+        longitude_max: 277.99
     event_type: severe_convection
   - case_id_number: 40
     title: May 2024 Kansas
@@ -474,10 +474,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 30.0
+        latitude_max: 51.0
+        longitude_min: 250.79
+        longitude_max: 276.46
     event_type: severe_convection
   - case_id_number: 41
     title: May 2024 Iowa + Nebraska
@@ -486,10 +486,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 33.5
+        latitude_max: 49.25
+        longitude_min: 250.0
+        longitude_max: 282.75
     event_type: severe_convection
   - case_id_number: 42
     title: May 2024 Iowa + Wisconsin
@@ -498,10 +498,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.75
+        latitude_max: 55.75
+        longitude_min: 254.25
+        longitude_max: 278.25
     event_type: severe_convection
   - case_id_number: 43
     title: May 2024 Texas
@@ -510,10 +510,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.75
+        latitude_max: 50.0
+        longitude_min: 252.9
+        longitude_max: 291.35
     event_type: severe_convection
   - case_id_number: 44
     title: May 2024 Iowa + Nebraska 2
@@ -522,10 +522,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.75
+        latitude_max: 51.5
+        longitude_min: 251.62
+        longitude_max: 281.13
     event_type: severe_convection
   - case_id_number: 45
     title: April 2024 Oklahoma
@@ -534,10 +534,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.25
+        latitude_max: 50.75
+        longitude_min: 242.87
+        longitude_max: 282.12
     event_type: severe_convection
   - case_id_number: 46
     title: April 2024 Midwest
@@ -546,10 +546,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.0
+        latitude_max: 46.0
+        longitude_min: 262.72
+        longitude_max: 284.78
     event_type: severe_convection
   - case_id_number: 47
     title: April 2024 Great Plains + Midwest
@@ -558,10 +558,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.25
+        latitude_max: 45.5
+        longitude_min: 254.5
+        longitude_max: 281.0
     event_type: severe_convection
   - case_id_number: 48
     title: March 2024 Midwest
@@ -570,10 +570,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.75
+        latitude_max: 46.75
+        longitude_min: 254.69
+        longitude_max: 284.81
     event_type: severe_convection
   - case_id_number: 49
     title: February 2024 Midwest
@@ -582,10 +582,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 32.25
+        latitude_max: 48.75
+        longitude_min: 263.54
+        longitude_max: 285.21
     event_type: severe_convection
   - case_id_number: 50
     title: January 2024 Southeast
@@ -594,10 +594,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 23.25
+        latitude_max: 40.25
+        longitude_min: 257.62
+        longitude_max: 287.9
     event_type: severe_convection
   - case_id_number: 51
     title: December 2023 South
@@ -606,10 +606,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.0
+        latitude_max: 42.5
+        longitude_min: 259.79
+        longitude_max: 280.96
     event_type: severe_convection
   - case_id_number: 52
     title: August 2023 East Coast
@@ -618,10 +618,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 27.0
+        latitude_max: 47.75
+        longitude_min: 243.17
+        longitude_max: 269.83
     event_type: severe_convection
   - case_id_number: 53
     title: August 2023 Minnesota
@@ -630,10 +630,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 32.5
+        latitude_max: 51.75
+        longitude_min: 256.96
+        longitude_max: 281.79
     event_type: severe_convection
   - case_id_number: 54
     title: July 2023 Midwest
@@ -642,10 +642,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 29.0
+        latitude_max: 46.75
+        longitude_min: 264.15
+        longitude_max: 289.85
     event_type: severe_convection
   - case_id_number: 55
     title: July 2023 Midwest 2
@@ -654,10 +654,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 39.25
+        latitude_max: 59.75
+        longitude_min: 239.53
+        longitude_max: 265.97
     event_type: severe_convection
   - case_id_number: 56
     title: June 2023 Midwest
@@ -666,10 +666,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 30.75
+        latitude_max: 45.0
+        longitude_min: 248.9
+        longitude_max: 279.6
     event_type: severe_convection
   - case_id_number: 57
     title: June 2023 Front Range
@@ -678,10 +678,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.5
+        latitude_max: 50.25
+        longitude_min: 248.4
+        longitude_max: 266.35
     event_type: severe_convection
   - case_id_number: 58
     title: June 2023 Texas
@@ -690,10 +690,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.5
+        latitude_max: 50.25
+        longitude_min: 248.4
+        longitude_max: 266.35
     event_type: severe_convection
   - case_id_number: 59
     title: June 2023 Great Plains
@@ -702,10 +702,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.5
+        latitude_max: 52.5
+        longitude_min: 242.12
+        longitude_max: 271.88
     event_type: severe_convection
   - case_id_number: 60
     title: June 2023 Iowa + Minnesota
@@ -714,10 +714,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 34.25
+        latitude_max: 53.0
+        longitude_min: 255.64
+        longitude_max: 275.11
     event_type: severe_convection
   - case_id_number: 61
     title: June 2023 South + Midwest
@@ -726,10 +726,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 27.25
+        latitude_max: 50.0
+        longitude_min: 259.62
+        longitude_max: 288.88
     event_type: severe_convection
   - case_id_number: 62
     title: June 2023 East Coast
@@ -738,10 +738,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 29.25
+        latitude_max: 49.5
+        longitude_min: 272.34
+        longitude_max: 292.91
     event_type: severe_convection
   - case_id_number: 63
     title: June 2023 Midwest + Great Plains
@@ -750,10 +750,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.5
+        latitude_max: 50.5
+        longitude_min: 248.64
+        longitude_max: 279.36
     event_type: severe_convection
   - case_id_number: 64
     title: June 2023 Southeast
@@ -762,10 +762,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.5
+        latitude_max: 41.75
+        longitude_min: 257.55
+        longitude_max: 283.7
     event_type: severe_convection
   - case_id_number: 65
     title: June 2023 OK + TX + South
@@ -774,10 +774,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.0
+        latitude_max: 48.0
+        longitude_min: 251.7
+        longitude_max: 284.55
     event_type: severe_convection
   - case_id_number: 66
     title: June 2023 South
@@ -786,10 +786,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.75
+        latitude_max: 45.25
+        longitude_min: 254.5
+        longitude_max: 290.5
     event_type: severe_convection
   - case_id_number: 67
     title: June 2023 Mid-Atlantic
@@ -798,10 +798,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.75
+        latitude_max: 45.25
+        longitude_min: 254.5
+        longitude_max: 290.5
     event_type: severe_convection
   - case_id_number: 68
     title: June 2023 Great Plains + South
@@ -810,10 +810,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.25
+        latitude_max: 46.5
+        longitude_min: 250.22
+        longitude_max: 279.78
     event_type: severe_convection
   - case_id_number: 69
     title: May 2023 Great Plains
@@ -822,10 +822,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.75
+        latitude_max: 55.5
+        longitude_min: 248.76
+        longitude_max: 275.74
     event_type: severe_convection
   - case_id_number: 70
     title: May 2023 Great Plains + South
@@ -834,10 +834,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 23.75
+        latitude_max: 47.25
+        longitude_min: 251.98
+        longitude_max: 283.77
     event_type: severe_convection
   - case_id_number: 71
     title: May 2023 Nebraska
@@ -846,10 +846,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.75
+        latitude_max: 47.75
+        longitude_min: 254.17
+        longitude_max: 270.58
     event_type: severe_convection
   - case_id_number: 72
     title: May 2024 Texas
@@ -3102,10 +3102,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -39.75
+        latitude_max: -29.5
+        longitude_min: 144.01
+        longitude_max: 155.74
     event_type: severe_convection
   - case_id_number: 260
     title: April 2020 Australia
@@ -3114,10 +3114,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -41.75
+        latitude_max: -26.5
+        longitude_min: 138.03
+        longitude_max: 153.47
     event_type: severe_convection
   - case_id_number: 261
     title: May 2020 Australia
@@ -3126,10 +3126,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -39.25
+        latitude_max: -28.75
+        longitude_min: 132.78
+        longitude_max: 143.72
     event_type: severe_convection
   - case_id_number: 262
     title: September 2020 Australia
@@ -3138,10 +3138,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -38.5
+        latitude_max: -29.5
+        longitude_min: 146.03
+        longitude_max: 155.97
     event_type: severe_convection
   - case_id_number: 263
     title: October 2020 Australia
@@ -3150,10 +3150,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -38.5
+        latitude_max: -23.25
+        longitude_min: 146.13
+        longitude_max: 157.87
     event_type: severe_convection
   - case_id_number: 264
     title: December 2020 Australia
@@ -3162,10 +3162,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -36.5
+        latitude_max: -26.75
+        longitude_min: 142.1
+        longitude_max: 152.9
     event_type: severe_convection
   - case_id_number: 265
     title: September 2021 Australia
@@ -3174,10 +3174,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -39.0
+        latitude_max: -25.5
+        longitude_min: 142.59
+        longitude_max: 156.16
     event_type: severe_convection
   - case_id_number: 266
     title: October 2021 Australia
@@ -3186,10 +3186,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -39.5
+        latitude_max: -25.5
+        longitude_min: 143.83
+        longitude_max: 156.67
     event_type: severe_convection
   - case_id_number: 267
     title: October 2021 Australia
@@ -3198,10 +3198,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -34.75
+        latitude_max: -16.25
+        longitude_min: 144.02
+        longitude_max: 157.86
     event_type: severe_convection
   - case_id_number: 268
     title: October 2021 Australia
@@ -3210,10 +3210,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -39.75
+        latitude_max: -29.25
+        longitude_min: 130.77
+        longitude_max: 144.23
     event_type: severe_convection
   - case_id_number: 269
     title: December 2021 Australia
@@ -3222,10 +3222,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -38.5
+        latitude_max: -28.75
+        longitude_min: 145.3
+        longitude_max: 155.95
     event_type: severe_convection
   - case_id_number: 270
     title: December 2021 Australia
@@ -3234,10 +3234,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -33.0
+        latitude_max: -23.0
+        longitude_min: 145.45
+        longitude_max: 156.8
     event_type: severe_convection
   - case_id_number: 271
     title: January 2022 Australia
@@ -3246,10 +3246,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -41.5
+        latitude_max: -29.25
+        longitude_min: 144.24
+        longitude_max: 155.76
     event_type: severe_convection
   - case_id_number: 272
     title: March 2022 Australia
@@ -3258,10 +3258,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -31.25
+        latitude_max: -22.25
+        longitude_min: 148.23
+        longitude_max: 157.77
     event_type: severe_convection
   - case_id_number: 273
     title: December 2022 Australia
@@ -3270,10 +3270,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -30.5
+        latitude_max: -21.5
+        longitude_min: 147.99
+        longitude_max: 157.51
     event_type: severe_convection
   - case_id_number: 274
     title: February 2023 Australia
@@ -3282,10 +3282,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -32.5
+        latitude_max: -22.0
+        longitude_min: 146.97
+        longitude_max: 158.28
     event_type: severe_convection
   - case_id_number: 275
     title: December 2023 Australia
@@ -3294,10 +3294,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -42.0
+        latitude_max: -33.0
+        longitude_min: 135.16
+        longitude_max: 145.34
     event_type: severe_convection
   - case_id_number: 276
     title: December 2023 Australia
@@ -3306,10 +3306,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -37.25
+        latitude_max: -22.5
+        longitude_min: 146.57
+        longitude_max: 158.29
     event_type: severe_convection
   - case_id_number: 277
     title: August 2024 Australia
@@ -3318,10 +3318,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -42.5
+        latitude_max: -30.75
+        longitude_min: 138.94
+        longitude_max: 152.56
     event_type: severe_convection
   - case_id_number: 278
     title: October 2024 Australia
@@ -3330,10 +3330,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -31.75
+        latitude_max: -21.25
+        longitude_min: 143.73
+        longitude_max: 157.77
     event_type: severe_convection
   - case_id_number: 279
     title: October 2024 Australia
@@ -3342,10 +3342,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -42.0
+        latitude_max: -32.0
+        longitude_min: 136.18
+        longitude_max: 147.32
     event_type: severe_convection
   - case_id_number: 280
     title: November 2024 Australia
@@ -3354,10 +3354,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -32.5
+        latitude_max: -20.75
+        longitude_min: 147.73
+        longitude_max: 158.27
     event_type: severe_convection
   - case_id_number: 281
     title: November 2024 Australia
@@ -3366,10 +3366,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: -40.0
-        latitude_max: -10.0
-        longitude_min: 110.0
-        longitude_max: 155.0
+        latitude_min: -37.75
+        latitude_max: -23.5
+        longitude_min: 143.38
+        longitude_max: 158.37
     event_type: severe_convection
   - case_id_number: 282
     title: April 2023 Midwest
@@ -3378,10 +3378,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 22.75
+        latitude_max: 44.75
+        longitude_min: 256.04
+        longitude_max: 282.71
     event_type: severe_convection
   - case_id_number: 283
     title: March 2023 Midwest + Southeast
@@ -3390,10 +3390,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.5
+        latitude_max: 49.0
+        longitude_min: 259.15
+        longitude_max: 284.1
     event_type: severe_convection
   - case_id_number: 284
     title: March 2023 North America
@@ -3402,10 +3402,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.5
+        latitude_max: 41.5
+        longitude_min: 254.81
+        longitude_max: 273.19
     event_type: severe_convection
   - case_id_number: 285
     title: February 2023 North America
@@ -3414,10 +3414,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 28.5
+        latitude_max: 43.0
+        longitude_min: 252.97
+        longitude_max: 271.78
     event_type: severe_convection
   - case_id_number: 286
     title: July 2022 Great Plains
@@ -3426,10 +3426,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.25
+        latitude_max: 54.25
+        longitude_min: 251.57
+        longitude_max: 280.43
     event_type: severe_convection
   - case_id_number: 287
     title: June 2022 Southwest
@@ -3438,10 +3438,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 30.25
+        latitude_max: 49.5
+        longitude_min: 249.57
+        longitude_max: 272.68
     event_type: severe_convection
   - case_id_number: 288
     title: May 2022 Midwest
@@ -3450,10 +3450,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 31.75
+        latitude_max: 52.75
+        longitude_min: 250.71
+        longitude_max: 277.79
     event_type: severe_convection
   - case_id_number: 289
     title: April 2022 Great Plains
@@ -3462,10 +3462,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 24.5
+        latitude_max: 50.5
+        longitude_min: 255.41
+        longitude_max: 278.09
     event_type: severe_convection
   - case_id_number: 290
     title: April 2022 South
@@ -3474,10 +3474,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.75
+        latitude_max: 45.0
+        longitude_min: 260.49
+        longitude_max: 285.51
     event_type: severe_convection
   - case_id_number: 291
     title: December 2021 Midwest
@@ -3486,10 +3486,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 32.5
+        latitude_max: 49.75
+        longitude_min: 255.01
+        longitude_max: 274.74
     event_type: severe_convection
   - case_id_number: 292
     title: December 2021 Great Plains
@@ -3498,10 +3498,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 28.25
+        latitude_max: 46.0
+        longitude_min: 258.43
+        longitude_max: 281.32
     event_type: severe_convection
   - case_id_number: 293
     title: June 2021 Great Plains
@@ -3510,10 +3510,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.0
+        latitude_max: 52.0
+        longitude_min: 258.87
+        longitude_max: 281.88
     event_type: severe_convection
   - case_id_number: 294
     title: May 2021 Great Plains
@@ -3523,9 +3523,9 @@ cases:
       type: bounded_region
       parameters:
         latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_max: 45.75
+        longitude_min: 250.26
+        longitude_max: 288.49
     event_type: severe_convection
   - case_id_number: 295
     title: March 2021 South
@@ -3534,10 +3534,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.5
+        latitude_max: 45.25
+        longitude_min: 259.22
+        longitude_max: 288.03
     event_type: severe_convection
   - case_id_number: 296
     title: March 2021 South
@@ -3546,10 +3546,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.5
+        latitude_max: 44.5
+        longitude_min: 264.48
+        longitude_max: 284.27
     event_type: severe_convection
   - case_id_number: 297
     title: April 2020 South
@@ -3558,10 +3558,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.0
+        latitude_max: 41.75
+        longitude_min: 256.05
+        longitude_max: 277.2
     event_type: severe_convection
   - case_id_number: 298
     title: April 2020 Southeast
@@ -3570,10 +3570,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 25.5
+        latitude_max: 40.75
+        longitude_min: 257.06
+        longitude_max: 285.94
     event_type: severe_convection
   - case_id_number: 299
     title: April 2020 Midwest
@@ -3582,10 +3582,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 26.25
+        latitude_max: 46.5
+        longitude_min: 262.2
+        longitude_max: 288.8
     event_type: severe_convection
   - case_id_number: 300
     title: March 2020 South
@@ -3594,10 +3594,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 27.25
+        latitude_max: 48.25
+        longitude_min: 257.9
+        longitude_max: 286.35
     event_type: severe_convection
   - case_id_number: 301
     title: March 2020 Southeast
@@ -3606,10 +3606,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 30.25
+        latitude_max: 43.5
+        longitude_min: 261.93
+        longitude_max: 280.82
     event_type: severe_convection
   - case_id_number: 302
     title: February 2020 East
@@ -3618,10 +3618,10 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
-        latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        latitude_min: 23.25
+        latitude_max: 41.25
+        longitude_min: 260.81
+        longitude_max: 288.16
     event_type: severe_convection
   - case_id_number: 303
     title: January 2020 South
@@ -3630,8 +3630,440 @@ cases:
     location:
       type: bounded_region
       parameters:
-        latitude_min: 24.0
+        latitude_min: 24.5
+        latitude_max: 44.5
+        longitude_min: 255.04
+        longitude_max: 281.51
+    event_type: severe_convection
+  - case_id_number: 304
+    title: June 2020 Canada
+    start_date: 2020-06-10 12:00:00
+    end_date: 2020-06-11 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 34.0
+        latitude_max: 50.25
+        longitude_min: 265.96
+        longitude_max: 288.54
+    event_type: severe_convection
+  - case_id_number: 305
+    title: June 2020 Canada
+    start_date: 2020-06-12 12:00:00
+    end_date: 2020-06-13 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 41.25
+        latitude_max: 56.25
+        longitude_min: 236.83
+        longitude_max: 253.92
+    event_type: severe_convection
+  - case_id_number: 306
+    title: June 2020 Canada
+    start_date: 2020-06-28 12:00:00
+    end_date: 2020-06-29 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 38.5
+        latitude_max: 56.0
+        longitude_min: 243.43
+        longitude_max: 274.07
+    event_type: severe_convection
+  - case_id_number: 307
+    title: July 2020 Canada
+    start_date: 2020-07-04 12:00:00
+    end_date: 2020-07-05 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 31.0
+        latitude_max: 58.5
+        longitude_min: 241.83
+        longitude_max: 275.92
+    event_type: severe_convection
+  - case_id_number: 308
+    title: July 2020 Canada
+    start_date: 2020-07-12 12:00:00
+    end_date: 2020-07-13 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 33.0
+        latitude_max: 57.75
+        longitude_min: 239.04
+        longitude_max: 265.46
+    event_type: severe_convection
+  - case_id_number: 309
+    title: July 2020 Canada
+    start_date: 2020-07-19 12:00:00
+    end_date: 2020-07-20 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 37.75
         latitude_max: 54.0
-        longitude_min: 245.0
-        longitude_max: 295.0
+        longitude_min: 272.02
+        longitude_max: 292.73
+    event_type: severe_convection
+  - case_id_number: 310
+    title: July 2020 Canada
+    start_date: 2020-07-23 12:00:00
+    end_date: 2020-07-24 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.0
+        latitude_max: 58.5
+        longitude_min: 238.8
+        longitude_max: 268.2
+    event_type: severe_convection
+  - case_id_number: 311
+    title: August 2020 Canada
+    start_date: 2020-08-27 12:00:00
+    end_date: 2020-08-28 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 38.75
+        latitude_max: 56.5
+        longitude_min: 249.41
+        longitude_max: 268.84
+    event_type: severe_convection
+  - case_id_number: 312
+    title: June 2021 Canada
+    start_date: 2021-06-05 12:00:00
+    end_date: 2021-06-06 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 42.5
+        latitude_max: 57.5
+        longitude_min: 239.25
+        longitude_max: 274.0
+    event_type: severe_convection
+  - case_id_number: 313
+    title: June 2021 Canada
+    start_date: 2021-06-14 12:00:00
+    end_date: 2021-06-15 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 37.5
+        latitude_max: 58.75
+        longitude_min: 235.63
+        longitude_max: 263.62
+    event_type: severe_convection
+  - case_id_number: 314
+    title: July 2021 Canada
+    start_date: 2021-07-15 12:00:00
+    end_date: 2021-07-16 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 35.25
+        latitude_max: 52.75
+        longitude_min: 265.37
+        longitude_max: 289.38
+    event_type: severe_convection
+  - case_id_number: 315
+    title: July 2021 Canada
+    start_date: 2021-07-22 12:00:00
+    end_date: 2021-07-23 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 45.0
+        latitude_max: 60.25
+        longitude_min: 238.54
+        longitude_max: 263.46
+    event_type: severe_convection
+  - case_id_number: 316
+    title: August 2021 Canada
+    start_date: 2021-08-23 12:00:00
+    end_date: 2021-08-24 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 38.75
+        latitude_max: 57.0
+        longitude_min: 244.39
+        longitude_max: 272.11
+    event_type: severe_convection
+  - case_id_number: 317
+    title: August 2021 Canada
+    start_date: 2021-08-31 12:00:00
+    end_date: 2021-09-01 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 44.75
+        latitude_max: 59.75
+        longitude_min: 239.32
+        longitude_max: 261.93
+    event_type: severe_convection
+  - case_id_number: 318
+    title: June 2022 Canada
+    start_date: 2022-06-23 12:00:00
+    end_date: 2022-06-24 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 31.5
+        latitude_max: 56.5
+        longitude_min: 247.12
+        longitude_max: 273.88
+    event_type: severe_convection
+  - case_id_number: 319
+    title: June 2022 Canada
+    start_date: 2022-06-29 12:00:00
+    end_date: 2022-06-30 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.5
+        latitude_max: 57.5
+        longitude_min: 241.57
+        longitude_max: 274.18
+    event_type: severe_convection
+  - case_id_number: 320
+    title: July 2022 Canada
+    start_date: 2022-07-05 12:00:00
+    end_date: 2022-07-06 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 31.25
+        latitude_max: 58.0
+        longitude_min: 241.09
+        longitude_max: 289.41
+    event_type: severe_convection
+  - case_id_number: 321
+    title: July 2022 Canada
+    start_date: 2022-07-07 12:00:00
+    end_date: 2022-07-08 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 38.25
+        latitude_max: 57.5
+        longitude_min: 238.14
+        longitude_max: 266.86
+    event_type: severe_convection
+  - case_id_number: 322
+    title: July 2022 Canada
+    start_date: 2022-07-08 12:00:00
+    end_date: 2022-07-09 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 31.0
+        latitude_max: 58.0
+        longitude_min: 238.59
+        longitude_max: 267.66
+    event_type: severe_convection
+  - case_id_number: 323
+    title: July 2022 Canada
+    start_date: 2022-07-17 12:00:00
+    end_date: 2022-07-18 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 43.5
+        latitude_max: 57.0
+        longitude_min: 245.23
+        longitude_max: 271.27
+    event_type: severe_convection
+  - case_id_number: 324
+    title: July 2022 Canada
+    start_date: 2022-07-19 12:00:00
+    end_date: 2022-07-20 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 46.5
+        latitude_max: 58.25
+        longitude_min: 239.06
+        longitude_max: 255.19
+    event_type: severe_convection
+  - case_id_number: 325
+    title: July 2022 Canada
+    start_date: 2022-07-31 12:00:00
+    end_date: 2022-08-01 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 45.5
+        latitude_max: 58.5
+        longitude_min: 236.34
+        longitude_max: 258.41
+    event_type: severe_convection
+  - case_id_number: 326
+    title: May 2023 Canada
+    start_date: 2023-05-31 12:00:00
+    end_date: 2023-06-01 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 28.25
+        latitude_max: 48.25
+        longitude_min: 248.38
+        longitude_max: 261.87
+    event_type: severe_convection
+  - case_id_number: 327
+    title: June 2023 Canada
+    start_date: 2023-06-28 12:00:00
+    end_date: 2023-06-29 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 33.0
+        latitude_max: 56.25
+        longitude_min: 248.09
+        longitude_max: 278.91
+    event_type: severe_convection
+  - case_id_number: 328
+    title: July 2023 Canada
+    start_date: 2023-07-13 12:00:00
+    end_date: 2023-07-14 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 29.25
+        latitude_max: 54.5
+        longitude_min: 249.48
+        longitude_max: 294.02
+    event_type: severe_convection
+  - case_id_number: 329
+    title: July 2023 Canada
+    start_date: 2023-07-20 12:00:00
+    end_date: 2023-07-21 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 29.75
+        latitude_max: 49.0
+        longitude_min: 265.84
+        longitude_max: 287.16
+    event_type: severe_convection
+  - case_id_number: 330
+    title: July 2023 Canada
+    start_date: 2023-07-22 12:00:00
+    end_date: 2023-07-23 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 26.0
+        latitude_max: 55.5
+        longitude_min: 246.28
+        longitude_max: 279.97
+    event_type: severe_convection
+  - case_id_number: 331
+    title: July 2023 Canada
+    start_date: 2023-07-26 12:00:00
+    end_date: 2023-07-27 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 34.75
+        latitude_max: 56.5
+        longitude_min: 250.03
+        longitude_max: 284.47
+    event_type: severe_convection
+  - case_id_number: 332
+    title: August 2023 Canada
+    start_date: 2023-08-03 12:00:00
+    end_date: 2023-08-04 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 38.25
+        latitude_max: 52.5
+        longitude_min: 266.29
+        longitude_max: 292.71
+    event_type: severe_convection
+  - case_id_number: 333
+    title: June 2024 Canada
+    start_date: 2024-06-12 12:00:00
+    end_date: 2024-06-13 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 36.0
+        latitude_max: 57.0
+        longitude_min: 248.23
+        longitude_max: 274.52
+    event_type: severe_convection
+  - case_id_number: 334
+    title: June 2024 Canada
+    start_date: 2024-06-22 12:00:00
+    end_date: 2024-06-23 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 36.0
+        latitude_max: 57.5
+        longitude_min: 247.71
+        longitude_max: 293.54
+    event_type: severe_convection
+  - case_id_number: 335
+    title: June 2024 Canada
+    start_date: 2024-06-23 12:00:00
+    end_date: 2024-06-24 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 41.25
+        latitude_max: 58.25
+        longitude_min: 240.26
+        longitude_max: 274.24
+    event_type: severe_convection
+  - case_id_number: 336
+    title: July 2024 Canada
+    start_date: 2024-07-11 12:00:00
+    end_date: 2024-07-12 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 32.5
+        latitude_max: 50.25
+        longitude_min: 251.25
+        longitude_max: 272.5
+    event_type: severe_convection
+  - case_id_number: 337
+    title: July 2024 Canada
+    start_date: 2024-07-24 12:00:00
+    end_date: 2024-07-25 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 40.75
+        latitude_max: 58.75
+        longitude_min: 236.26
+        longitude_max: 252.74
+    event_type: severe_convection
+  - case_id_number: 338
+    title: August 2024 Canada
+    start_date: 2024-08-05 12:00:00
+    end_date: 2024-08-06 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 37.0
+        latitude_max: 49.5
+        longitude_min: 259.41
+        longitude_max: 293.84
+    event_type: severe_convection
+  - case_id_number: 339
+    title: August 2024 Canada
+    start_date: 2024-08-21 12:00:00
+    end_date: 2024-08-22 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 37.25
+        latitude_max: 58.25
+        longitude_min: 243.9
+        longitude_max: 265.35
     event_type: severe_convection


### PR DESCRIPTION
# EWB Pull Request

## Description

As is in the description. Criteria for bounds changes:

1. Identify peak PPH location
2. Determine if any PPH >0.01 is within 1000km of peak
3. If so, include it and its "blob" until the blob ends; if not, only include the "blob" the peak is in
4. Add 250km buffer around the new bounding box

Code to determine and generate these bounds will be in the severe event type branch, to be merged into `new-event-types`, which is v1.0.