### PR TITLE
Addressing forecaster's dilemma with yearlong cases

### DIFF
--- a/src/extremeweatherbench/data/long_events.yaml
+++ b/src/extremeweatherbench/data/long_events.yaml
@@ -1,6 +1,6 @@
 cases:
   - case_id_number: 1000
-    title: Yearlong Test
+    title: Yearlong Heat Wave Test
     start_date: 2024-01-01 00:00:00
     end_date: 2024-12-31 18:00:00
     location:
@@ -12,7 +12,7 @@ cases:
         longitude_max: 359.75
     event_type: heat_wave
   - case_id_number: 1001
-    title: Yearlong Test
+    title: Yearlong Freeze Test
     start_date: 2024-01-01 00:00:00
     end_date: 2024-12-31 18:00:00
     location:


### PR DESCRIPTION
# EWB Pull Request

## Description

One of the challenges of addressing extreme events is the [forecaster's dilemma](https://arxiv.org/abs/1512.09244), which is an issue that encourages forecasters to hedge on extreme forecasts over non-extreme forecasts. To partially address this in EWB and its companion paper, we introduce two yearlong cases for temperature-based events that are not restricted to pre-determined severe cases. 

Our other event types, atmospheric rivers, tropical cyclones, and severe convection are all (by their own definition) extreme events. We encourage and are interested in exploring methods in capturing remedies for the forecaster's dilemma, such as using "bust" cases where a forecast did not manifest in a validating extreme.