### PR TITLE
Swap subset order of operations in landfall metrics

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1743,12 +1743,12 @@ class LandfallDisplacement(LandfallMetric, BaseMetric):
         # Compute distance for each common init_time
         distances = []
         for init_time in common_init_times:
-            f_lat = forecast_landfall.coords["latitude"].sel(init_time=init_time).values
+            f_lat = forecast_landfall.sel(init_time=init_time).coords["latitude"].values
             f_lon = (
-                forecast_landfall.coords["longitude"].sel(init_time=init_time).values
+                forecast_landfall.sel(init_time=init_time).coords["longitude"].values
             )
-            t_lat = target_landfall.coords["latitude"].sel(init_time=init_time).values
-            t_lon = target_landfall.coords["longitude"].sel(init_time=init_time).values
+            t_lat = target_landfall.sel(init_time=init_time).coords["latitude"].values
+            t_lon = target_landfall.sel(init_time=init_time).coords["longitude"].values
 
             # Skip if any coordinates are NaN
             if (
@@ -1844,8 +1844,8 @@ class LandfallTimeMeanError(LandfallMetric, MeanError):
         # Calculate time difference for each common init_time
         time_diffs = []
         for init_time in common_init_times:
-            time1 = forecast_landfall.coords["valid_time"].sel(init_time=init_time)
-            time2 = target_landfall.coords["valid_time"].sel(init_time=init_time)
+            time1 = forecast_landfall.sel(init_time=init_time).coords["valid_time"]
+            time2 = target_landfall.sel(init_time=init_time).coords["valid_time"]
 
             # Calculate time difference in hours
             time_diff = (time1 - time2) / np.timedelta64(1, "h")


### PR DESCRIPTION
# EWB Pull Request

## Description

Certain cases in tropical cyclones fail when there's only one valid `init_time`. This pathology manifests when trying to select coords (e.g. `valid_time`) before subsetting by `init_time` using the `.sel()` method. 

Swapping the order in these lines fixes this issue.

This fix then creates a secondary issue, where the resulting `metric_result` is dimensionless. A secondary PR will follow to fix this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All unit tests pass and multiple checks were run to confirm functionality using the `applied_tc.py` script with different cases, including 196 and 220.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules