### PR TITLE
Remove duplicate severe cases, renumber cases

### DIFF
--- a/src/extremeweatherbench/data/events.yaml
+++ b/src/extremeweatherbench/data/events.yaml
@@ -672,7 +672,7 @@ cases:
         longitude_max: 279.6
     event_type: severe_convection
   - case_id_number: 57
-    title: June 2023 Front Range
+    title: June 2023 Front Range & Texas
     start_date: 2023-06-21 12:00:00
     end_date: 2023-06-22 12:00:00
     location:
@@ -684,18 +684,6 @@ cases:
         longitude_max: 266.35
     event_type: severe_convection
   - case_id_number: 58
-    title: June 2023 Texas
-    start_date: 2023-06-21 12:00:00
-    end_date: 2023-06-22 12:00:00
-    location:
-      type: bounded_region
-      parameters:
-        latitude_min: 25.5
-        latitude_max: 50.25
-        longitude_min: 248.4
-        longitude_max: 266.35
-    event_type: severe_convection
-  - case_id_number: 59
     title: June 2023 Great Plains
     start_date: 2023-06-23 12:00:00
     end_date: 2023-06-24 12:00:00
@@ -707,7 +695,7 @@ cases:
         longitude_min: 242.12
         longitude_max: 271.88
     event_type: severe_convection
-  - case_id_number: 60
+  - case_id_number: 59
     title: June 2023 Iowa + Minnesota
     start_date: 2023-06-24 12:00:00
     end_date: 2023-06-25 12:00:00
@@ -719,7 +707,7 @@ cases:
         longitude_min: 255.64
         longitude_max: 275.11
     event_type: severe_convection
-  - case_id_number: 61
+  - case_id_number: 60
     title: June 2023 South + Midwest
     start_date: 2023-06-25 12:00:00
     end_date: 2023-06-26 12:00:00
@@ -731,7 +719,7 @@ cases:
         longitude_min: 259.62
         longitude_max: 288.88
     event_type: severe_convection
-  - case_id_number: 62
+  - case_id_number: 61
     title: June 2023 East Coast
     start_date: 2023-06-26 12:00:00
     end_date: 2023-06-27 12:00:00
@@ -743,7 +731,7 @@ cases:
         longitude_min: 272.34
         longitude_max: 292.91
     event_type: severe_convection
-  - case_id_number: 63
+  - case_id_number: 62
     title: June 2023 Midwest + Great Plains
     start_date: 2023-06-29 12:00:00
     end_date: 2023-06-30 12:00:00
@@ -755,7 +743,7 @@ cases:
         longitude_min: 248.64
         longitude_max: 279.36
     event_type: severe_convection
-  - case_id_number: 64
+  - case_id_number: 63
     title: June 2023 Southeast
     start_date: 2023-06-14 12:00:00
     end_date: 2023-06-15 12:00:00
@@ -767,7 +755,7 @@ cases:
         longitude_min: 257.55
         longitude_max: 283.7
     event_type: severe_convection
-  - case_id_number: 65
+  - case_id_number: 64
     title: June 2023 OK + TX + South
     start_date: 2023-06-15 12:00:00
     end_date: 2023-06-16 12:00:00
@@ -779,31 +767,19 @@ cases:
         longitude_min: 251.7
         longitude_max: 284.55
     event_type: severe_convection
+  - case_id_number: 65
+    title: June 2023 South & Mid-Atlantic
+    start_date: 2023-06-16 12:00:00
+    end_date: 2023-06-17 12:00:00
+    location:
+      type: bounded_region
+      parameters:
+        latitude_min: 24.75
+        latitude_max: 45.25
+        longitude_min: 254.5
+        longitude_max: 290.5
+    event_type: severe_convection
   - case_id_number: 66
-    title: June 2023 South
-    start_date: 2023-06-16 12:00:00
-    end_date: 2023-06-17 12:00:00
-    location:
-      type: bounded_region
-      parameters:
-        latitude_min: 24.75
-        latitude_max: 45.25
-        longitude_min: 254.5
-        longitude_max: 290.5
-    event_type: severe_convection
-  - case_id_number: 67
-    title: June 2023 Mid-Atlantic
-    start_date: 2023-06-16 12:00:00
-    end_date: 2023-06-17 12:00:00
-    location:
-      type: bounded_region
-      parameters:
-        latitude_min: 24.75
-        latitude_max: 45.25
-        longitude_min: 254.5
-        longitude_max: 290.5
-    event_type: severe_convection
-  - case_id_number: 68
     title: June 2023 Great Plains + South
     start_date: 2023-06-17 12:00:00
     end_date: 2023-06-18 12:00:00
@@ -815,7 +791,7 @@ cases:
         longitude_min: 250.22
         longitude_max: 279.78
     event_type: severe_convection
-  - case_id_number: 69
+  - case_id_number: 67
     title: May 2023 Great Plains
     start_date: 2023-05-10 12:00:00
     end_date: 2023-05-11 12:00:00
@@ -827,7 +803,7 @@ cases:
         longitude_min: 248.76
         longitude_max: 275.74
     event_type: severe_convection
-  - case_id_number: 70
+  - case_id_number: 68
     title: May 2023 Great Plains + South
     start_date: 2023-05-11 12:00:00
     end_date: 2023-05-12 12:00:00
@@ -839,7 +815,7 @@ cases:
         longitude_min: 251.98
         longitude_max: 283.77
     event_type: severe_convection
-  - case_id_number: 71
+  - case_id_number: 69
     title: May 2023 Nebraska
     start_date: 2023-05-12 12:00:00
     end_date: 2023-05-13 12:00:00
@@ -851,7 +827,7 @@ cases:
         longitude_min: 254.17
         longitude_max: 270.58
     event_type: severe_convection
-  - case_id_number: 72
+  - case_id_number: 70
     title: May 2024 Texas
     start_date: 2024-05-25 00:00:00
     end_date: 2024-05-31 00:00:00
@@ -863,7 +839,7 @@ cases:
         longitude_min: 254.25
         longitude_max: 277.0
     event_type: heat_wave
-  - case_id_number: 73
+  - case_id_number: 71
     title: June 2024 Northeast US
     start_date: 2024-06-17 00:00:00
     end_date: 2024-06-23 00:00:00
@@ -875,7 +851,7 @@ cases:
         longitude_min: 272.0
         longitude_max: 307.25
     event_type: heat_wave
-  - case_id_number: 74
+  - case_id_number: 72
     title: July 2024 Southwest US
     start_date: 2024-07-04 00:00:00
     end_date: 2024-07-10 00:00:00
@@ -887,7 +863,7 @@ cases:
         longitude_min: 235.5
         longitude_max: 248.75
     event_type: heat_wave
-  - case_id_number: 75
+  - case_id_number: 73
     title: July 2024 Northeast US
     start_date: 2024-07-07 00:00:00
     end_date: 2024-07-13 00:00:00
@@ -899,7 +875,7 @@ cases:
         longitude_min: 281.0
         longitude_max: 300.0
     event_type: heat_wave
-  - case_id_number: 76
+  - case_id_number: 74
     title: July 2024 Mid-Atlantic US
     start_date: 2024-07-15 00:00:00
     end_date: 2024-07-21 00:00:00
@@ -911,7 +887,7 @@ cases:
         longitude_min: 280.0
         longitude_max: 292.75
     event_type: heat_wave
-  - case_id_number: 77
+  - case_id_number: 75
     title: August 2024 Midwest US
     start_date: 2024-08-25 00:00:00
     end_date: 2024-08-31 00:00:00
@@ -923,7 +899,7 @@ cases:
         longitude_min: 265.5
         longitude_max: 278.25
     event_type: heat_wave
-  - case_id_number: 78
+  - case_id_number: 76
     title: July 2024 Antarctica
     start_date: 2024-07-01 00:00:00
     end_date: 2024-07-31 00:00:00
@@ -935,7 +911,7 @@ cases:
         longitude_min: -9.5
         longitude_max: 39.5
     event_type: heat_wave
-  - case_id_number: 79
+  - case_id_number: 77
     title: August 2024 Canada
     start_date: 2024-08-09 00:00:00
     end_date: 2024-08-15 00:00:00
@@ -947,7 +923,7 @@ cases:
         longitude_min: 231.5
         longitude_max: 272.5
     event_type: heat_wave
-  - case_id_number: 80
+  - case_id_number: 78
     title: August 2024 Australia
     start_date: 2024-08-22 00:00:00
     end_date: 2024-08-30 00:00:00
@@ -959,7 +935,7 @@ cases:
         longitude_min: 116.25
         longitude_max: 144.5
     event_type: heat_wave
-  - case_id_number: 81
+  - case_id_number: 79
     title: July/August 2024 Japan
     start_date: 2024-07-25 00:00:00
     end_date: 2024-08-05 00:00:00
@@ -971,7 +947,7 @@ cases:
         longitude_min: 123.0
         longitude_max: 142.75
     event_type: heat_wave
-  - case_id_number: 82
+  - case_id_number: 80
     title: June 2024 Saudi Arabia
     start_date: 2024-06-16 00:00:00
     end_date: 2024-06-22 00:00:00
@@ -983,7 +959,7 @@ cases:
         longitude_min: 30.0
         longitude_max: 54.0
     event_type: heat_wave
-  - case_id_number: 83
+  - case_id_number: 81
     title: August 2024 Europe
     start_date: 2024-08-10 00:00:00
     end_date: 2024-08-16 00:00:00
@@ -995,7 +971,7 @@ cases:
         longitude_min: 0.0
         longitude_max: 25.75
     event_type: heat_wave
-  - case_id_number: 84
+  - case_id_number: 82
     title: July 2024 Ukraine
     start_date: 2024-07-12 00:00:00
     end_date: 2024-07-18 00:00:00
@@ -1007,7 +983,7 @@ cases:
         longitude_min: 14.25
         longitude_max: 45.0
     event_type: heat_wave
-  - case_id_number: 85
+  - case_id_number: 83
     title: June 2024 Europe
     start_date: 2024-06-20 00:00:00
     end_date: 2024-06-30 00:00:00
@@ -1019,7 +995,7 @@ cases:
         longitude_min: -4.0
         longitude_max: 25.75
     event_type: heat_wave
-  - case_id_number: 86
+  - case_id_number: 84
     title: May 2024 Central Mexico
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
@@ -1031,7 +1007,7 @@ cases:
         longitude_min: 252.5
         longitude_max: 283.25
     event_type: heat_wave
-  - case_id_number: 87
+  - case_id_number: 85
     title: May 2024 Pakistan/India
     start_date: 2024-05-23 00:00:00
     end_date: 2024-05-31 00:00:00
@@ -1043,7 +1019,7 @@ cases:
         longitude_min: 71.5
         longitude_max: 98.5
     event_type: heat_wave
-  - case_id_number: 88
+  - case_id_number: 86
     title: August 2023 Chile
     start_date: 2023-08-01 00:00:00
     end_date: 2023-08-07 00:00:00
@@ -1055,7 +1031,7 @@ cases:
         longitude_min: 288.5
         longitude_max: 305.75
     event_type: heat_wave
-  - case_id_number: 89
+  - case_id_number: 87
     title: January 2024 Pacific Northwest
     start_date: 2024-01-11 12:00:00
     end_date: 2024-01-20 00:00:00
@@ -1067,7 +1043,7 @@ cases:
         longitude_min: 221.25
         longitude_max: 262.0
     event_type: freeze
-  - case_id_number: 90
+  - case_id_number: 88
     title: April 2022 Nevada
     start_date: 2022-04-11 18:00:00
     end_date: 2022-04-17 18:00:00
@@ -1079,7 +1055,7 @@ cases:
         longitude_min: 225.75
         longitude_max: 268.5
     event_type: freeze
-  - case_id_number: 91
+  - case_id_number: 89
     title: February/March 2021 New England
     start_date: 2021-03-04 18:00:00
     end_date: 2021-03-10 18:00:00
@@ -1091,7 +1067,7 @@ cases:
         longitude_min: 283.25
         longitude_max: 291.5
     event_type: freeze
-  - case_id_number: 92
+  - case_id_number: 90
     title: January 2024 Northern Europe
     start_date: 2024-01-01 06:00:00
     end_date: 2024-01-09 12:00:00
@@ -1103,7 +1079,7 @@ cases:
         longitude_min: 5.25
         longitude_max: 42.5
     event_type: freeze
-  - case_id_number: 93
+  - case_id_number: 91
     title: December 2022 Europe
     start_date: 2022-12-10 06:00:00
     end_date: 2022-12-20 00:00:00
@@ -1115,7 +1091,7 @@ cases:
         longitude_min: -9.75
         longitude_max: 25.75
     event_type: freeze
-  - case_id_number: 94
+  - case_id_number: 92
     title: April 2024 Europe
     start_date: 2024-04-16 12:00:00
     end_date: 2024-04-27 12:00:00
@@ -1127,7 +1103,7 @@ cases:
         longitude_min: -4.0
         longitude_max: 26.75
     event_type: freeze
-  - case_id_number: 95
+  - case_id_number: 93
     title: January 2023 North China
     start_date: 2024-01-20 00:00:00
     end_date: 2024-02-04 18:00:00
@@ -1139,7 +1115,7 @@ cases:
         longitude_min: 118.0
         longitude_max: 130.75
     event_type: freeze
-  - case_id_number: 96
+  - case_id_number: 94
     title: April 2024 Sweden
     start_date: 2024-04-02 00:00:00
     end_date: 2024-04-08 00:00:00
@@ -1151,7 +1127,7 @@ cases:
         longitude_min: 8.25
         longitude_max: 31.0
     event_type: freeze
-  - case_id_number: 97
+  - case_id_number: 95
     title: November 2024 West Coast US
     start_date: 2024-11-20 00:00:00
     end_date: 2024-11-22 00:00:00
@@ -1163,7 +1139,7 @@ cases:
         longitude_min: 222.4
         longitude_max: 245.3
     event_type: atmospheric_river
-  - case_id_number: 98
+  - case_id_number: 96
     title: October 2024 British Columbia
     start_date: 2024-10-18 00:00:00
     end_date: 2024-10-20 00:00:00
@@ -1175,7 +1151,7 @@ cases:
         longitude_min: 217.3
         longitude_max: 247.0
     event_type: atmospheric_river
-  - case_id_number: 99
+  - case_id_number: 97
     title: September 2024 SW Alaska and British Columbia
     start_date: 2024-09-22 00:00:00
     end_date: 2024-09-24 00:00:00
@@ -1187,7 +1163,7 @@ cases:
         longitude_min: 212.1
         longitude_max: 247.9
     event_type: atmospheric_river
-  - case_id_number: 100
+  - case_id_number: 98
     title: October 2024 Bosnia
     start_date: 2024-10-03 00:00:00
     end_date: 2024-10-05 00:00:00
@@ -1199,7 +1175,7 @@ cases:
         longitude_min: 8.2
         longitude_max: 27.8
     event_type: atmospheric_river
-  - case_id_number: 101
+  - case_id_number: 99
     title: April 2024 Eastern Australia
     start_date: 2024-04-05 00:00:00
     end_date: 2024-04-06 00:00:00
@@ -1211,7 +1187,7 @@ cases:
         longitude_min: 139.7
         longitude_max: 163.1
     event_type: atmospheric_river
-  - case_id_number: 102
+  - case_id_number: 100
     title: April 2024 Persian Gulf
     start_date: 2024-04-14 00:00:00
     end_date: 2024-04-18 00:00:00
@@ -1223,7 +1199,7 @@ cases:
         longitude_min: 45.6
         longitude_max: 65.4
     event_type: atmospheric_river
-  - case_id_number: 103
+  - case_id_number: 101
     title: February 2024 Pacific Northwest
     start_date: 2024-02-28 00:00:00
     end_date: 2024-03-04 00:00:00
@@ -1235,7 +1211,7 @@ cases:
         longitude_min: 227.1
         longitude_max: 240.9
     event_type: atmospheric_river
-  - case_id_number: 104
+  - case_id_number: 102
     title: February 2024 California
     start_date: 2024-02-18 00:00:00
     end_date: 2024-02-21 00:00:00
@@ -1247,7 +1223,7 @@ cases:
         longitude_min: 227.5
         longitude_max: 243.3
     event_type: atmospheric_river
-  - case_id_number: 105
+  - case_id_number: 103
     title: February 2024 California
     start_date: 2024-02-03 00:00:00
     end_date: 2024-02-06 00:00:00
@@ -1259,7 +1235,7 @@ cases:
         longitude_min: 227.5
         longitude_max: 252.5
     event_type: atmospheric_river
-  - case_id_number: 106
+  - case_id_number: 104
     title: January 2024 Alaska to California
     start_date: 2024-01-26 00:00:00
     end_date: 2024-02-03 00:00:00
@@ -1271,7 +1247,7 @@ cases:
         longitude_min: 202.5
         longitude_max: 249.3
     event_type: atmospheric_river
-  - case_id_number: 107
+  - case_id_number: 105
     title: January 2024 California and Arizona
     start_date: 2024-01-22 00:00:00
     end_date: 2024-01-23 00:00:00
@@ -1283,7 +1259,7 @@ cases:
         longitude_min: 232.5
         longitude_max: 249.5
     event_type: atmospheric_river
-  - case_id_number: 108
+  - case_id_number: 106
     title: December 2023 East Coast Cyclone
     start_date: 2023-12-17 00:00:00
     end_date: 2023-12-19 00:00:00
@@ -1295,7 +1271,7 @@ cases:
         longitude_min: 267.6
         longitude_max: 302.4
     event_type: atmospheric_river
-  - case_id_number: 109
+  - case_id_number: 107
     title: June 2023 Northwest Cloudband
     start_date: 2023-06-25 00:00:00
     end_date: 2023-06-28 00:00:00
@@ -1307,7 +1283,7 @@ cases:
         longitude_min: 113.6
         longitude_max: 147.7
     event_type: atmospheric_river
-  - case_id_number: 110
+  - case_id_number: 108
     title: April 2023 Middle East
     start_date: 2023-04-01 00:00:00
     end_date: 2023-05-01 00:00:00
@@ -1319,7 +1295,7 @@ cases:
         longitude_min: 22.6
         longitude_max: 55.1
     event_type: atmospheric_river
-  - case_id_number: 111
+  - case_id_number: 109
     title: March 2023 California and Arizona
     start_date: 2023-03-09 00:00:00
     end_date: 2023-03-15 00:00:00
@@ -1331,7 +1307,7 @@ cases:
         longitude_min: 232.5
         longitude_max: 252.5
     event_type: atmospheric_river
-  - case_id_number: 112
+  - case_id_number: 110
     title: March 2023 California
     start_date: 2023-03-09 00:00:00
     end_date: 2023-03-16 00:00:00
@@ -1343,7 +1319,7 @@ cases:
         longitude_min: 227.5
         longitude_max: 252.5
     event_type: atmospheric_river
-  - case_id_number: 113
+  - case_id_number: 111
     title: February 2023 Pacific Northwest
     start_date: 2023-02-17 00:00:00
     end_date: 2023-02-20 00:00:00
@@ -1355,7 +1331,7 @@ cases:
         longitude_min: 226.9
         longitude_max: 240.8
     event_type: atmospheric_river
-  - case_id_number: 114
+  - case_id_number: 112
     title: January 2023 California
     start_date: 2023-01-04 00:00:00
     end_date: 2023-01-10 00:00:00
@@ -1367,7 +1343,7 @@ cases:
         longitude_min: 227.5
         longitude_max: 252.5
     event_type: atmospheric_river
-  - case_id_number: 115
+  - case_id_number: 113
     title: December 2022 California
     start_date: 2022-12-26 00:00:00
     end_date: 2023-01-02 00:00:00
@@ -1379,7 +1355,7 @@ cases:
         longitude_min: 220.0
         longitude_max: 252.8
     event_type: atmospheric_river
-  - case_id_number: 116
+  - case_id_number: 114
     title: December 2022 Oregon and California
     start_date: 2022-12-09 00:00:00
     end_date: 2022-12-13 00:00:00
@@ -1391,7 +1367,7 @@ cases:
         longitude_min: 227.4
         longitude_max: 243.6
     event_type: atmospheric_river
-  - case_id_number: 117
+  - case_id_number: 115
     title: November 2022 - December 2022 California
     start_date: 2022-11-29 00:00:00
     end_date: 2022-12-06 00:00:00
@@ -1403,7 +1379,7 @@ cases:
         longitude_min: 227.4
         longitude_max: 243.3
     event_type: atmospheric_river
-  - case_id_number: 118
+  - case_id_number: 116
     title: October 2022 Victoria
     start_date: 2022-10-13 00:00:00
     end_date: 2022-10-14 00:00:00
@@ -1415,7 +1391,7 @@ cases:
         longitude_min: 116.4
         longitude_max: 166.6
     event_type: atmospheric_river
-  - case_id_number: 119
+  - case_id_number: 117
     title: October 2022 Victoria
     start_date: 2022-10-30 00:00:00
     end_date: 2022-10-31 00:00:00
@@ -1427,7 +1403,7 @@ cases:
         longitude_min: 116.4
         longitude_max: 166.6
     event_type: atmospheric_river
-  - case_id_number: 120
+  - case_id_number: 118
     title: November 2022 California
     start_date: 2022-11-07 00:00:00
     end_date: 2022-11-09 00:00:00
@@ -1439,7 +1415,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 247.8
     event_type: atmospheric_river
-  - case_id_number: 121
+  - case_id_number: 119
     title: November 2022 Pacific Northwest
     start_date: 2022-11-03 00:00:00
     end_date: 2022-11-06 00:00:00
@@ -1451,7 +1427,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 247.8
     event_type: atmospheric_river
-  - case_id_number: 122
+  - case_id_number: 120
     title: August 2022 Japan
     start_date: 2022-08-01 00:00:00
     end_date: 2022-09-01 00:00:00
@@ -1463,7 +1439,7 @@ cases:
         longitude_min: 122.4
         longitude_max: 152.6
     event_type: atmospheric_river
-  - case_id_number: 123
+  - case_id_number: 121
     title: June 2022 Pacific Northwest, Wyoming, and Montana
     start_date: 2022-06-09 00:00:00
     end_date: 2022-06-13 00:00:00
@@ -1475,7 +1451,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 262.7
     event_type: atmospheric_river
-  - case_id_number: 124
+  - case_id_number: 122
     title: March 2022 East Antarctica
     start_date: 2022-03-15 00:00:00
     end_date: 2022-03-20 00:00:00
@@ -1487,7 +1463,7 @@ cases:
         longitude_min: 101.3
         longitude_max: 146.9
     event_type: atmospheric_river
-  - case_id_number: 125
+  - case_id_number: 123
     title: February 2022 Southeast QLD / Northern NSW
     start_date: 2022-02-26 00:00:00
     end_date: 2022-03-01 00:00:00
@@ -1499,7 +1475,7 @@ cases:
         longitude_min: 142.3
         longitude_max: 162.7
     event_type: atmospheric_river
-  - case_id_number: 126
+  - case_id_number: 124
     title: February 2022 Pacific Northwest
     start_date: 2022-02-26 00:00:00
     end_date: 2022-03-03 00:00:00
@@ -1511,7 +1487,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 247.3
     event_type: atmospheric_river
-  - case_id_number: 127
+  - case_id_number: 125
     title: January 2022 Norway and Sweden
     start_date: 2022-01-14 00:00:00
     end_date: 2022-01-15 00:00:00
@@ -1523,7 +1499,7 @@ cases:
         longitude_min: 356.3
         longitude_max: 28.7
     event_type: atmospheric_river
-  - case_id_number: 128
+  - case_id_number: 126
     title: January 2022 Colorado
     start_date: 2022-01-04 00:00:00
     end_date: 2022-01-08 00:00:00
@@ -1535,7 +1511,7 @@ cases:
         longitude_min: 251.3
         longitude_max: 265.7
     event_type: atmospheric_river
-  - case_id_number: 129
+  - case_id_number: 127
     title: January 2022 Pacific Northwest
     start_date: 2022-01-02 00:00:00
     end_date: 2022-01-09 00:00:00
@@ -1547,7 +1523,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 245.7
     event_type: atmospheric_river
-  - case_id_number: 130
+  - case_id_number: 128
     title: December 2021 - January 2022 Western US
     start_date: 2021-12-22 00:00:00
     end_date: 2022-01-02 00:00:00
@@ -1559,7 +1535,7 @@ cases:
         longitude_min: 227.5
         longitude_max: 262.5
     event_type: atmospheric_river
-  - case_id_number: 131
+  - case_id_number: 129
     title: December 2021 Pacific NW
     start_date: 2021-12-10 00:00:00
     end_date: 2021-12-15 00:00:00
@@ -1571,7 +1547,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 243.7
     event_type: atmospheric_river
-  - case_id_number: 132
+  - case_id_number: 130
     title: November 2021 Pacific Northwest
     start_date: 2021-11-10 00:00:00
     end_date: 2021-11-17 00:00:00
@@ -1583,7 +1559,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 257.7
     event_type: atmospheric_river
-  - case_id_number: 133
+  - case_id_number: 131
     title: October 2021 California
     start_date: 2021-10-19 00:00:00
     end_date: 2021-10-27 00:00:00
@@ -1595,7 +1571,7 @@ cases:
         longitude_min: 227.4
         longitude_max: 251.1
     event_type: atmospheric_river
-  - case_id_number: 134
+  - case_id_number: 132
     title: September 2021 Pacific Northwest
     start_date: 2021-09-16 00:00:00
     end_date: 2021-09-20 00:00:00
@@ -1607,7 +1583,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 257.8
     event_type: atmospheric_river
-  - case_id_number: 135
+  - case_id_number: 133
     title: June 2021 Bloomington Indiana
     start_date: 2021-06-18 00:00:00
     end_date: 2021-06-20 00:00:00
@@ -1619,7 +1595,7 @@ cases:
         longitude_min: 265.3
         longitude_max: 281.7
     event_type: atmospheric_river
-  - case_id_number: 136
+  - case_id_number: 134
     title: June 2021 Alaska Trans-Pacific
     start_date: 2021-06-24 00:00:00
     end_date: 2021-06-27 00:00:00
@@ -1631,7 +1607,7 @@ cases:
         longitude_min: 181.5
         longitude_max: 238.5
     event_type: atmospheric_river
-  - case_id_number: 137
+  - case_id_number: 135
     title: March 2021 Sydney
     start_date: 2021-03-17 00:00:00
     end_date: 2021-03-25 00:00:00
@@ -1643,7 +1619,7 @@ cases:
         longitude_min: 142.1
         longitude_max: 159.9
     event_type: atmospheric_river
-  - case_id_number: 138
+  - case_id_number: 136
     title: February 2021 Pacific Northwest
     start_date: 2021-02-21 00:00:00
     end_date: 2021-02-24 00:00:00
@@ -1655,7 +1631,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 241.3
     event_type: atmospheric_river
-  - case_id_number: 139
+  - case_id_number: 137
     title: January 2021 Pacific NW
     start_date: 2021-01-11 00:00:00
     end_date: 2021-01-14 00:00:00
@@ -1667,7 +1643,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 252.0
     event_type: atmospheric_river
-  - case_id_number: 140
+  - case_id_number: 138
     title: January 2021 Pacific Northwest
     start_date: 2021-01-01 00:00:00
     end_date: 2021-01-08 00:00:00
@@ -1679,7 +1655,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 241.7
     event_type: atmospheric_river
-  - case_id_number: 141
+  - case_id_number: 139
     title: December 2020 Pacific Northwest
     start_date: 2020-12-17 00:00:00
     end_date: 2020-12-23 00:00:00
@@ -1691,7 +1667,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 247.0
     event_type: atmospheric_river
-  - case_id_number: 142
+  - case_id_number: 140
     title: December 2020 Western US
     start_date: 2020-12-11 00:00:00
     end_date: 2020-12-18 00:00:00
@@ -1703,7 +1679,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 246.9
     event_type: atmospheric_river
-  - case_id_number: 143
+  - case_id_number: 141
     title: December 2020 Alaska
     start_date: 2020-12-01 00:00:00
     end_date: 2020-12-05 00:00:00
@@ -1715,7 +1691,7 @@ cases:
         longitude_min: 191.5
         longitude_max: 238.5
     event_type: atmospheric_river
-  - case_id_number: 144
+  - case_id_number: 142
     title: November 2020 Western US
     start_date: 2020-11-16 00:00:00
     end_date: 2020-11-19 00:00:00
@@ -1727,7 +1703,7 @@ cases:
         longitude_min: 227.4
         longitude_max: 243.9
     event_type: atmospheric_river
-  - case_id_number: 145
+  - case_id_number: 143
     title: October 2020 Western Alps
     start_date: 2020-10-02 00:00:00
     end_date: 2020-10-04 00:00:00
@@ -1739,7 +1715,7 @@ cases:
         longitude_min: 357.1
         longitude_max: 16.9
     event_type: atmospheric_river
-  - case_id_number: 146
+  - case_id_number: 144
     title: September 2020 Pacific Northwest
     start_date: 2020-09-23 00:00:00
     end_date: 2020-09-28 00:00:00
@@ -1751,7 +1727,7 @@ cases:
         longitude_min: 227.2
         longitude_max: 257.8
     event_type: atmospheric_river
-  - case_id_number: 147
+  - case_id_number: 145
     title: September 2020 Pacific Northwest
     start_date: 2020-09-14 00:00:00
     end_date: 2020-09-19 00:00:00
@@ -1763,7 +1739,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 240.5
     event_type: atmospheric_river
-  - case_id_number: 148
+  - case_id_number: 146
     title: May 2020 Western US
     start_date: 2020-05-16 00:00:00
     end_date: 2020-05-20 00:00:00
@@ -1775,7 +1751,7 @@ cases:
         longitude_min: 227.4
         longitude_max: 241.6
     event_type: atmospheric_river
-  - case_id_number: 149
+  - case_id_number: 147
     title: March 2020 Southwestern US
     start_date: 2020-03-09 00:00:00
     end_date: 2020-03-14 00:00:00
@@ -1787,7 +1763,7 @@ cases:
         longitude_min: 232.5
         longitude_max: 262.5
     event_type: atmospheric_river
-  - case_id_number: 150
+  - case_id_number: 148
     title: February 2020 Southwestern US
     start_date: 2020-02-21 00:00:00
     end_date: 2020-02-24 00:00:00
@@ -1799,7 +1775,7 @@ cases:
         longitude_min: 235.8
         longitude_max: 262.5
     event_type: atmospheric_river
-  - case_id_number: 151
+  - case_id_number: 149
     title: February 2020 Western US
     start_date: 2020-02-04 00:00:00
     end_date: 2020-02-09 00:00:00
@@ -1811,7 +1787,7 @@ cases:
         longitude_min: 227.0
         longitude_max: 250.7
     event_type: atmospheric_river
-  - case_id_number: 152
+  - case_id_number: 150
     title: January 2020 Pacific Northwest
     start_date: 2020-01-26 00:00:00
     end_date: 2020-02-03 00:00:00
@@ -1823,7 +1799,7 @@ cases:
         longitude_min: 227.3
         longitude_max: 250.5
     event_type: atmospheric_river
-  - case_id_number: 153
+  - case_id_number: 151
     title: Milton
     start_date: 2024-10-02 18:00:00
     end_date: 2024-10-13 18:00:00
@@ -1835,7 +1811,7 @@ cases:
         longitude_min: 262.1
         longitude_max: 296.5
     event_type: tropical_cyclone
-  - case_id_number: 154
+  - case_id_number: 152
     title: Helene
     start_date: 2024-09-21 12:00:00
     end_date: 2024-09-30 18:00:00
@@ -1847,7 +1823,7 @@ cases:
         longitude_min: 269.5
         longitude_max: 280.7
     event_type: tropical_cyclone
-  - case_id_number: 155
+  - case_id_number: 153
     title: Francine
     start_date: 2024-09-06 18:00:00
     end_date: 2024-09-16 00:00:00
@@ -1859,7 +1835,7 @@ cases:
         longitude_min: 261.4
         longitude_max: 272.7
     event_type: tropical_cyclone
-  - case_id_number: 156
+  - case_id_number: 154
     title: Debby
     start_date: 2024-07-31 12:00:00
     end_date: 2024-08-12 18:00:00
@@ -1871,7 +1847,7 @@ cases:
         longitude_min: 273.2
         longitude_max: 302.9
     event_type: tropical_cyclone
-  - case_id_number: 157
+  - case_id_number: 155
     title: Beryl
     start_date: 2024-06-26 12:00:00
     end_date: 2024-07-13 12:00:00
@@ -1883,7 +1859,7 @@ cases:
         longitude_min: 261.7
         longitude_max: 322.7
     event_type: tropical_cyclone
-  - case_id_number: 158
+  - case_id_number: 156
     title: John
     start_date: 2024-09-20 12:00:00
     end_date: 2024-09-29 18:00:00
@@ -1895,7 +1871,7 @@ cases:
         longitude_min: 254.5
         longitude_max: 263.9
     event_type: tropical_cyclone
-  - case_id_number: 159
+  - case_id_number: 157
     title: Hone
     start_date: 2024-08-17 12:00:00
     end_date: 2024-09-03 18:00:00
@@ -1907,7 +1883,7 @@ cases:
         longitude_min: 177.9
         longitude_max: 231.5
     event_type: tropical_cyclone
-  - case_id_number: 160
+  - case_id_number: 158
     title: Trami
     start_date: 2024-10-18 00:00:00
     end_date: 2024-10-31 12:00:00
@@ -1919,7 +1895,7 @@ cases:
         longitude_min: 105.0
         longitude_max: 139.8
     event_type: tropical_cyclone
-  - case_id_number: 161
+  - case_id_number: 159
     title: Prapiroon (Butchoy)
     start_date: 2024-07-17 06:00:00
     end_date: 2024-07-27 06:00:00
@@ -1931,7 +1907,7 @@ cases:
         longitude_min: 104.3
         longitude_max: 120.2
     event_type: tropical_cyclone
-  - case_id_number: 162
+  - case_id_number: 160
     title: Gaemi (Carina)
     start_date: 2024-07-17 00:00:00
     end_date: 2024-07-30 00:00:00
@@ -1943,7 +1919,7 @@ cases:
         longitude_min: 110.6
         longitude_max: 135.5
     event_type: tropical_cyclone
-  - case_id_number: 163
+  - case_id_number: 161
     title: Shanshan
     start_date: 2024-08-19 00:00:00
     end_date: 2024-09-03 18:00:00
@@ -1955,7 +1931,7 @@ cases:
         longitude_min: 127.7
         longitude_max: 146.3
     event_type: tropical_cyclone
-  - case_id_number: 164
+  - case_id_number: 162
     title: Yagi (Enteng)
     start_date: 2024-08-30 00:00:00
     end_date: 2024-09-10 12:00:00
@@ -1967,7 +1943,7 @@ cases:
         longitude_min: 101.8
         longitude_max: 128.7
     event_type: tropical_cyclone
-  - case_id_number: 165
+  - case_id_number: 163
     title: Bebinca (Ferdie)
     start_date: 2024-09-07 12:00:00
     end_date: 2024-09-20 12:00:00
@@ -1979,7 +1955,7 @@ cases:
         longitude_min: 112.4
         longitude_max: 149.9
     event_type: tropical_cyclone
-  - case_id_number: 166
+  - case_id_number: 164
     title: Soulik (Gener)
     start_date: 2024-09-13 06:00:00
     end_date: 2024-09-22 06:00:00
@@ -1991,7 +1967,7 @@ cases:
         longitude_min: 102.2
         longitude_max: 128.8
     event_type: tropical_cyclone
-  - case_id_number: 167
+  - case_id_number: 165
     title: Krathon
     start_date: 2024-09-24 12:00:00
     end_date: 2024-10-05 18:00:00
@@ -2003,7 +1979,7 @@ cases:
         longitude_min: 116.8
         longitude_max: 129.9
     event_type: tropical_cyclone
-  - case_id_number: 168
+  - case_id_number: 166
     title: Asna
     start_date: 2024-08-28 00:00:00
     end_date: 2024-09-04 00:00:00
@@ -2015,7 +1991,7 @@ cases:
         longitude_min: 59.0
         longitude_max: 70.7
     event_type: tropical_cyclone
-  - case_id_number: 169
+  - case_id_number: 167
     title: Kirrily
     start_date: 2024-01-15 00:00:00
     end_date: 2024-02-07 06:00:00
@@ -2027,7 +2003,7 @@ cases:
         longitude_min: 135.3
         longitude_max: 159.0
     event_type: tropical_cyclone
-  - case_id_number: 170
+  - case_id_number: 168
     title: Belal
     start_date: 2024-01-10 12:00:00
     end_date: 2024-01-21 12:00:00
@@ -2039,7 +2015,7 @@ cases:
         longitude_min: 50.8
         longitude_max: 68.1
     event_type: tropical_cyclone
-  - case_id_number: 171
+  - case_id_number: 169
     title: Alvaro
     start_date: 2023-12-30 00:00:00
     end_date: 2024-01-06 12:00:00
@@ -2051,7 +2027,7 @@ cases:
         longitude_min: 38.2
         longitude_max: 59.9
     event_type: tropical_cyclone
-  - case_id_number: 172
+  - case_id_number: 170
     title: Franklin
     start_date: 2023-08-17 18:00:00
     end_date: 2023-09-11 18:00:00
@@ -2063,7 +2039,7 @@ cases:
         longitude_min: 286.3
         longitude_max: 346.3
     event_type: tropical_cyclone
-  - case_id_number: 173
+  - case_id_number: 171
     title: Harold
     start_date: 2020-03-30 00:00:00
     end_date: 2020-04-13 00:00:00
@@ -2075,7 +2051,7 @@ cases:
         longitude_min: 152.2
         longitude_max: 214.7
     event_type: tropical_cyclone
-  - case_id_number: 174
+  - case_id_number: 172
     title: Idalia
     start_date: 2023-08-24 12:00:00
     end_date: 2023-09-10 06:00:00
@@ -2087,7 +2063,7 @@ cases:
         longitude_min: 270.8
         longitude_max: 304.9
     event_type: tropical_cyclone
-  - case_id_number: 175
+  - case_id_number: 173
     title: Lee
     start_date: 2023-09-03 12:00:00
     end_date: 2023-09-20 18:00:00
@@ -2099,7 +2075,7 @@ cases:
         longitude_min: 289.4
         longitude_max: 322.7
     event_type: tropical_cyclone
-  - case_id_number: 176
+  - case_id_number: 174
     title: Ophelia
     start_date: 2023-09-19 12:00:00
     end_date: 2023-09-26 18:00:00
@@ -2111,7 +2087,7 @@ cases:
         longitude_min: 279.8
         longitude_max: 287.5
     event_type: tropical_cyclone
-  - case_id_number: 177
+  - case_id_number: 175
     title: Tammy
     start_date: 2023-10-16 18:00:00
     end_date: 2023-11-02 18:00:00
@@ -2123,7 +2099,7 @@ cases:
         longitude_min: 293.7
         longitude_max: 314.2
     event_type: tropical_cyclone
-  - case_id_number: 178
+  - case_id_number: 176
     title: Hilary
     start_date: 2023-08-14 06:00:00
     end_date: 2023-08-22 21:00:00
@@ -2135,7 +2111,7 @@ cases:
         longitude_min: 241.6
         longitude_max: 261.5
     event_type: tropical_cyclone
-  - case_id_number: 179
+  - case_id_number: 177
     title: Lidia
     start_date: 2023-10-01 00:00:00
     end_date: 2023-10-13 12:00:00
@@ -2147,7 +2123,7 @@ cases:
         longitude_min: 244.9
         longitude_max: 261.8
     event_type: tropical_cyclone
-  - case_id_number: 180
+  - case_id_number: 178
     title: Max
     start_date: 2023-10-06 00:00:00
     end_date: 2023-10-12 00:00:00
@@ -2159,7 +2135,7 @@ cases:
         longitude_min: 256.1
         longitude_max: 262.4
     event_type: tropical_cyclone
-  - case_id_number: 181
+  - case_id_number: 179
     title: Norma
     start_date: 2023-10-15 06:00:00
     end_date: 2023-10-25 12:00:00
@@ -2171,7 +2147,7 @@ cases:
         longitude_min: 247.4
         longitude_max: 257.9
     event_type: tropical_cyclone
-  - case_id_number: 182
+  - case_id_number: 180
     title: Otis
     start_date: 2023-10-19 00:00:00
     end_date: 2023-10-27 18:00:00
@@ -2183,7 +2159,7 @@ cases:
         longitude_min: 257.0
         longitude_max: 266.5
     event_type: tropical_cyclone
-  - case_id_number: 183
+  - case_id_number: 181
     title: Mawar (Betty)
     start_date: 2023-05-16 00:00:00
     end_date: 2023-06-05 12:00:00
@@ -2195,7 +2171,7 @@ cases:
         longitude_min: 122.7
         longitude_max: 153.2
     event_type: tropical_cyclone
-  - case_id_number: 184
+  - case_id_number: 182
     title: Talim (Dodong)
     start_date: 2023-07-11 06:00:00
     end_date: 2023-07-21 06:00:00
@@ -2207,7 +2183,7 @@ cases:
         longitude_min: 101.0
         longitude_max: 125.1
     event_type: tropical_cyclone
-  - case_id_number: 185
+  - case_id_number: 183
     title: Doksuri (Egay)
     start_date: 2023-07-18 06:00:00
     end_date: 2023-08-02 00:00:00
@@ -2219,7 +2195,7 @@ cases:
         longitude_min: 110.5
         longitude_max: 136.0
     event_type: tropical_cyclone
-  - case_id_number: 186
+  - case_id_number: 184
     title: Khanun (Falcon)
     start_date: 2023-07-24 06:00:00
     end_date: 2023-08-13 12:00:00
@@ -2231,7 +2207,7 @@ cases:
         longitude_min: 121.8
         longitude_max: 143.6
     event_type: tropical_cyclone
-  - case_id_number: 187
+  - case_id_number: 185
     title: Lan
     start_date: 2023-08-04 00:00:00
     end_date: 2023-08-20 00:00:00
@@ -2243,7 +2219,7 @@ cases:
         longitude_min: 132.3
         longitude_max: 152.0
     event_type: tropical_cyclone
-  - case_id_number: 188
+  - case_id_number: 186
     title: Saola (Goring)
     start_date: 2023-08-20 00:00:00
     end_date: 2023-09-06 00:00:00
@@ -2255,7 +2231,7 @@ cases:
         longitude_min: 106.8
         longitude_max: 130.3
     event_type: tropical_cyclone
-  - case_id_number: 189
+  - case_id_number: 187
     title: Haikui
     start_date: 2023-08-25 00:00:00
     end_date: 2023-09-12 12:00:00
@@ -2267,7 +2243,7 @@ cases:
         longitude_min: 107.0
         longitude_max: 146.8
     event_type: tropical_cyclone
-  - case_id_number: 190
+  - case_id_number: 188
     title: Koinu (Jenny)
     start_date: 2023-09-25 12:00:00
     end_date: 2023-10-12 00:00:00
@@ -2279,7 +2255,7 @@ cases:
         longitude_min: 109.0
         longitude_max: 146.1
     event_type: tropical_cyclone
-  - case_id_number: 191
+  - case_id_number: 189
     title: Mocha
     start_date: 2023-05-06 18:00:00
     end_date: 2023-05-17 00:00:00
@@ -2291,7 +2267,7 @@ cases:
         longitude_min: 85.7
         longitude_max: 100.1
     event_type: tropical_cyclone
-  - case_id_number: 192
+  - case_id_number: 190
     title: Biparjoy
     start_date: 2023-06-03 00:00:00
     end_date: 2023-06-21 00:00:00
@@ -2303,7 +2279,7 @@ cases:
         longitude_min: 63.6
         longitude_max: 78.3
     event_type: tropical_cyclone
-  - case_id_number: 193
+  - case_id_number: 191
     title: Hamoon
     start_date: 2023-10-18 06:00:00
     end_date: 2023-10-27 06:00:00
@@ -2315,7 +2291,7 @@ cases:
         longitude_min: 83.5
         longitude_max: 94.8
     event_type: tropical_cyclone
-  - case_id_number: 194
+  - case_id_number: 192
     title: Freddy
     start_date: 2023-02-02 12:00:00
     end_date: 2023-03-15 18:00:00
@@ -2327,7 +2303,7 @@ cases:
         longitude_min: 29.0
         longitude_max: 121.6
     event_type: tropical_cyclone
-  - case_id_number: 195
+  - case_id_number: 193
     title: Jasper
     start_date: 2023-11-30 12:00:00
     end_date: 2023-12-19 00:00:00
@@ -2339,7 +2315,7 @@ cases:
         longitude_min: 139.0
         longitude_max: 167.2
     event_type: tropical_cyclone
-  - case_id_number: 196
+  - case_id_number: 194
     title: Alex
     start_date: 2022-05-31 18:00:00
     end_date: 2022-06-08 18:00:00
@@ -2351,7 +2327,7 @@ cases:
         longitude_min: 270.1
         longitude_max: 300.2
     event_type: tropical_cyclone
-  - case_id_number: 197
+  - case_id_number: 195
     title: Fiona
     start_date: 2022-09-12 06:00:00
     end_date: 2022-09-29 18:00:00
@@ -2363,7 +2339,7 @@ cases:
         longitude_min: 285.9
         longitude_max: 314.4
     event_type: tropical_cyclone
-  - case_id_number: 198
+  - case_id_number: 196
     title: Ian
     start_date: 2022-09-20 18:00:00
     end_date: 2022-10-03 06:00:00
@@ -2375,7 +2351,7 @@ cases:
         longitude_min: 274.0
         longitude_max: 296.0
     event_type: tropical_cyclone
-  - case_id_number: 199
+  - case_id_number: 197
     title: Julia
     start_date: 2022-10-04 12:00:00
     end_date: 2022-10-12 12:00:00
@@ -2387,7 +2363,7 @@ cases:
         longitude_min: 267.8
         longitude_max: 295.8
     event_type: tropical_cyclone
-  - case_id_number: 200
+  - case_id_number: 198
     title: Nicole
     start_date: 2022-11-04 12:00:00
     end_date: 2022-11-13 18:00:00
@@ -2399,7 +2375,7 @@ cases:
         longitude_min: 272.9
         longitude_max: 295.7
     event_type: tropical_cyclone
-  - case_id_number: 201
+  - case_id_number: 199
     title: Agatha
     start_date: 2022-05-25 18:00:00
     end_date: 2022-06-03 06:00:00
@@ -2411,7 +2387,7 @@ cases:
         longitude_min: 258.6
         longitude_max: 267.7
     event_type: tropical_cyclone
-  - case_id_number: 202
+  - case_id_number: 200
     title: Kay
     start_date: 2022-09-02 12:00:00
     end_date: 2022-09-15 00:00:00
@@ -2423,7 +2399,7 @@ cases:
         longitude_min: 235.8
         longitude_max: 261.4
     event_type: tropical_cyclone
-  - case_id_number: 203
+  - case_id_number: 201
     title: Roslyn
     start_date: 2022-10-18 00:00:00
     end_date: 2022-10-26 00:00:00
@@ -2435,7 +2411,7 @@ cases:
         longitude_min: 251.0
         longitude_max: 261.4
     event_type: tropical_cyclone
-  - case_id_number: 204
+  - case_id_number: 202
     title: Megi (Agaton)
     start_date: 2022-04-06 12:00:00
     end_date: 2022-04-15 06:00:00
@@ -2447,7 +2423,7 @@ cases:
         longitude_min: 122.4
         longitude_max: 130.7
     event_type: tropical_cyclone
-  - case_id_number: 205
+  - case_id_number: 203
     title: Hinnamnor (Henry)
     start_date: 2022-08-25 00:00:00
     end_date: 2022-09-10 18:00:00
@@ -2459,7 +2435,7 @@ cases:
         longitude_min: 122.2
         longitude_max: 153.4
     event_type: tropical_cyclone
-  - case_id_number: 206
+  - case_id_number: 204
     title: Muifa (Inday)
     start_date: 2022-09-02 06:00:00
     end_date: 2022-09-18 21:00:00
@@ -2471,7 +2447,7 @@ cases:
         longitude_min: 118.0
         longitude_max: 147.7
     event_type: tropical_cyclone
-  - case_id_number: 207
+  - case_id_number: 205
     title: Nanmadol (Josie)
     start_date: 2022-09-09 06:00:00
     end_date: 2022-09-22 06:00:00
@@ -2483,7 +2459,7 @@ cases:
         longitude_min: 128.0
         longitude_max: 149.7
     event_type: tropical_cyclone
-  - case_id_number: 208
+  - case_id_number: 206
     title: Noru (Karding)
     start_date: 2022-09-19 00:00:00
     end_date: 2022-10-01 06:00:00
@@ -2495,7 +2471,7 @@ cases:
         longitude_min: 101.0
         longitude_max: 136.8
     event_type: tropical_cyclone
-  - case_id_number: 209
+  - case_id_number: 207
     title: Nalgae (Paeng)
     start_date: 2022-10-24 00:00:00
     end_date: 2022-11-05 00:00:00
@@ -2507,7 +2483,7 @@ cases:
         longitude_min: 111.0
         longitude_max: 136.6
     event_type: tropical_cyclone
-  - case_id_number: 210
+  - case_id_number: 208
     title: Sitrang
     start_date: 2022-10-19 18:00:00
     end_date: 2022-10-27 00:00:00
@@ -2519,7 +2495,7 @@ cases:
         longitude_min: 85.8
         longitude_max: 95.6
     event_type: tropical_cyclone
-  - case_id_number: 211
+  - case_id_number: 209
     title: Ana
     start_date: 2021-01-26 12:00:00
     end_date: 2021-02-05 06:00:00
@@ -2531,7 +2507,7 @@ cases:
         longitude_min: 168.8
         longitude_max: 191.7
     event_type: tropical_cyclone
-  - case_id_number: 212
+  - case_id_number: 210
     title: Batsirai
     start_date: 2022-01-22 00:00:00
     end_date: 2022-02-12 12:00:00
@@ -2543,7 +2519,7 @@ cases:
         longitude_min: 38.5
         longitude_max: 94.0
     event_type: tropical_cyclone
-  - case_id_number: 213
+  - case_id_number: 211
     title: Gombe
     start_date: 2022-03-04 00:00:00
     end_date: 2022-03-19 06:00:00
@@ -2555,7 +2531,7 @@ cases:
         longitude_min: 34.2
         longitude_max: 57.6
     event_type: tropical_cyclone
-  - case_id_number: 214
+  - case_id_number: 212
     title: Seth
     start_date: 2021-12-21 12:00:00
     end_date: 2022-01-09 06:00:00
@@ -2567,7 +2543,7 @@ cases:
         longitude_min: 127.3
         longitude_max: 161.5
     event_type: tropical_cyclone
-  - case_id_number: 215
+  - case_id_number: 213
     title: Blas
     start_date: 2022-06-12 06:00:00
     end_date: 2022-06-24 18:00:00
@@ -2579,7 +2555,7 @@ cases:
         longitude_min: 240.9
         longitude_max: 260.3
     event_type: tropical_cyclone
-  - case_id_number: 216
+  - case_id_number: 214
     title: Elsa
     start_date: 2021-06-28 18:00:00
     end_date: 2021-07-12 06:00:00
@@ -2591,7 +2567,7 @@ cases:
         longitude_min: 274.1
         longitude_max: 319.5
     event_type: tropical_cyclone
-  - case_id_number: 217
+  - case_id_number: 215
     title: Fred
     start_date: 2021-08-07 18:00:00
     end_date: 2021-08-22 06:00:00
@@ -2603,7 +2579,7 @@ cases:
         longitude_min: 271.8
         longitude_max: 303.6
     event_type: tropical_cyclone
-  - case_id_number: 218
+  - case_id_number: 216
     title: Grace
     start_date: 2021-08-11 06:00:00
     end_date: 2021-08-23 12:00:00
@@ -2615,7 +2591,7 @@ cases:
         longitude_min: 259.7
         longitude_max: 315.6
     event_type: tropical_cyclone
-  - case_id_number: 219
+  - case_id_number: 217
     title: Henri
     start_date: 2021-08-13 00:00:00
     end_date: 2021-08-26 18:00:00
@@ -2627,7 +2603,7 @@ cases:
         longitude_min: 283.0
         longitude_max: 299.9
     event_type: tropical_cyclone
-  - case_id_number: 220
+  - case_id_number: 218
     title: Ida
     start_date: 2021-08-24 12:00:00
     end_date: 2021-09-06 18:00:00
@@ -2639,7 +2615,7 @@ cases:
         longitude_min: 266.8
         longitude_max: 299.9
     event_type: tropical_cyclone
-  - case_id_number: 221
+  - case_id_number: 219
     title: Larry
     start_date: 2021-08-29 18:00:00
     end_date: 2021-09-13 18:00:00
@@ -2651,7 +2627,7 @@ cases:
         longitude_min: 295.4
         longitude_max: 341.7
     event_type: tropical_cyclone
-  - case_id_number: 222
+  - case_id_number: 220
     title: Nicholas
     start_date: 2021-09-10 12:00:00
     end_date: 2021-09-19 06:00:00
@@ -2663,7 +2639,7 @@ cases:
         longitude_min: 260.9
         longitude_max: 270.8
     event_type: tropical_cyclone
-  - case_id_number: 223
+  - case_id_number: 221
     title: Claudette
     start_date: 2021-06-15 18:00:00
     end_date: 2021-06-25 00:00:00
@@ -2675,7 +2651,7 @@ cases:
         longitude_min: 265.4
         longitude_max: 302.8
     event_type: tropical_cyclone
-  - case_id_number: 224
+  - case_id_number: 222
     title: Nora
     start_date: 2021-08-22 06:00:00
     end_date: 2021-09-01 12:00:00
@@ -2687,7 +2663,7 @@ cases:
         longitude_min: 250.3
         longitude_max: 267.3
     event_type: tropical_cyclone
-  - case_id_number: 225
+  - case_id_number: 223
     title: Olaf
     start_date: 2021-09-04 18:00:00
     end_date: 2021-09-14 00:00:00
@@ -2699,7 +2675,7 @@ cases:
         longitude_min: 242.8
         longitude_max: 256.6
     event_type: tropical_cyclone
-  - case_id_number: 226
+  - case_id_number: 224
     title: Pamela
     start_date: 2021-10-08 06:00:00
     end_date: 2021-10-15 18:00:00
@@ -2711,7 +2687,7 @@ cases:
         longitude_min: 248.4
         longitude_max: 259.9
     event_type: tropical_cyclone
-  - case_id_number: 227
+  - case_id_number: 225
     title: Surigae (Bising)
     start_date: 2021-04-09 12:00:00
     end_date: 2021-05-02 18:00:00
@@ -2723,7 +2699,7 @@ cases:
         longitude_min: 122.5
         longitude_max: 186.8
     event_type: tropical_cyclone
-  - case_id_number: 228
+  - case_id_number: 226
     title: In-fa (Fabian)
     start_date: 2021-07-14 00:00:00
     end_date: 2021-08-02 00:00:00
@@ -2735,7 +2711,7 @@ cases:
         longitude_min: 114.4
         longitude_max: 137.6
     event_type: tropical_cyclone
-  - case_id_number: 229
+  - case_id_number: 227
     title: Kompasu (Maring)
     start_date: 2021-10-05 18:00:00
     end_date: 2021-10-16 12:00:00
@@ -2747,7 +2723,7 @@ cases:
         longitude_min: 103.4
         longitude_max: 136.5
     event_type: tropical_cyclone
-  - case_id_number: 230
+  - case_id_number: 228
     title: Rai
     start_date: 2021-12-09 12:00:00
     end_date: 2021-12-23 12:00:00
@@ -2759,7 +2735,7 @@ cases:
         longitude_min: 108.3
         longitude_max: 147.3
     event_type: tropical_cyclone
-  - case_id_number: 231
+  - case_id_number: 229
     title: Tauktae
     start_date: 2021-05-11 06:00:00
     end_date: 2021-05-21 06:00:00
@@ -2771,7 +2747,7 @@ cases:
         longitude_min: 68.6
         longitude_max: 77.1
     event_type: tropical_cyclone
-  - case_id_number: 232
+  - case_id_number: 230
     title: Yaas
     start_date: 2021-05-21 00:00:00
     end_date: 2021-05-29 18:00:00
@@ -2783,7 +2759,7 @@ cases:
         longitude_min: 82.5
         longitude_max: 92.3
     event_type: tropical_cyclone
-  - case_id_number: 233
+  - case_id_number: 231
     title: Gulab and Shaheen
     start_date: 2021-09-21 18:00:00
     end_date: 2021-10-06 06:00:00
@@ -2795,7 +2771,7 @@ cases:
         longitude_min: 53.7
         longitude_max: 96.5
     event_type: tropical_cyclone
-  - case_id_number: 234
+  - case_id_number: 232
     title: Eloise
     start_date: 2021-01-09 18:00:00
     end_date: 2021-01-26 00:00:00
@@ -2807,7 +2783,7 @@ cases:
         longitude_min: 28.8
         longitude_max: 88.1
     event_type: tropical_cyclone
-  - case_id_number: 235
+  - case_id_number: 233
     title: Amanda and Cristobal
     start_date: 2020-05-28 18:00:00
     end_date: 2020-06-02 12:00:00
@@ -2819,7 +2795,7 @@ cases:
         longitude_min: 265.0
         longitude_max: 283.3
     event_type: tropical_cyclone
-  - case_id_number: 236
+  - case_id_number: 234
     title: Hanna
     start_date: 2020-07-21 00:00:00
     end_date: 2020-07-28 18:00:00
@@ -2831,7 +2807,7 @@ cases:
         longitude_min: 257.2
         longitude_max: 274.2
     event_type: tropical_cyclone
-  - case_id_number: 237
+  - case_id_number: 235
     title: Isaias
     start_date: 2020-07-26 12:00:00
     end_date: 2020-08-07 06:00:00
@@ -2843,7 +2819,7 @@ cases:
         longitude_min: 277.7
         longitude_max: 308.3
     event_type: tropical_cyclone
-  - case_id_number: 238
+  - case_id_number: 236
     title: Laura
     start_date: 2020-08-18 00:00:00
     end_date: 2020-08-31 06:00:00
@@ -2855,7 +2831,7 @@ cases:
         longitude_min: 264.3
         longitude_max: 315.0
     event_type: tropical_cyclone
-  - case_id_number: 239
+  - case_id_number: 237
     title: Nana
     start_date: 2020-08-30 06:00:00
     end_date: 2020-09-06 00:00:00
@@ -2867,7 +2843,7 @@ cases:
         longitude_min: 266.3
         longitude_max: 287.1
     event_type: tropical_cyclone
-  - case_id_number: 240
+  - case_id_number: 238
     title: Paulette
     start_date: 2020-09-05 00:00:00
     end_date: 2020-09-30 12:00:00
@@ -2879,7 +2855,7 @@ cases:
         longitude_min: 292.8
         longitude_max: 345.7
     event_type: tropical_cyclone
-  - case_id_number: 241
+  - case_id_number: 239
     title: Sally
     start_date: 2020-09-09 18:00:00
     end_date: 2020-09-20 06:00:00
@@ -2891,7 +2867,7 @@ cases:
         longitude_min: 269.4
         longitude_max: 283.9
     event_type: tropical_cyclone
-  - case_id_number: 242
+  - case_id_number: 240
     title: Teddy
     start_date: 2020-09-10 06:00:00
     end_date: 2020-09-26 06:00:00
@@ -2903,7 +2879,7 @@ cases:
         longitude_min: 293.4
         longitude_max: 330.9
     event_type: tropical_cyclone
-  - case_id_number: 243
+  - case_id_number: 241
     title: Delta
     start_date: 2020-10-02 18:00:00
     end_date: 2020-10-13 18:00:00
@@ -2915,7 +2891,7 @@ cases:
         longitude_min: 263.9
         longitude_max: 286.1
     event_type: tropical_cyclone
-  - case_id_number: 244
+  - case_id_number: 242
     title: Zeta
     start_date: 2020-10-22 12:00:00
     end_date: 2020-11-01 00:00:00
@@ -2927,7 +2903,7 @@ cases:
         longitude_min: 265.9
         longitude_max: 290.7
     event_type: tropical_cyclone
-  - case_id_number: 245
+  - case_id_number: 243
     title: Eta
     start_date: 2020-10-29 18:00:00
     end_date: 2020-11-16 00:00:00
@@ -2939,7 +2915,7 @@ cases:
         longitude_min: 269.9
         longitude_max: 293.1
     event_type: tropical_cyclone
-  - case_id_number: 246
+  - case_id_number: 244
     title: Iota
     start_date: 2020-11-10 12:00:00
     end_date: 2020-11-20 12:00:00
@@ -2951,7 +2927,7 @@ cases:
         longitude_min: 268.7
         longitude_max: 291.4
     event_type: tropical_cyclone
-  - case_id_number: 247
+  - case_id_number: 245
     title: Genevieve
     start_date: 2020-08-14 12:00:00
     end_date: 2020-08-24 06:00:00
@@ -2963,7 +2939,7 @@ cases:
         longitude_min: 240.3
         longitude_max: 265.8
     event_type: tropical_cyclone
-  - case_id_number: 248
+  - case_id_number: 246
     title: Hagupit (Dindo)
     start_date: 2020-07-29 06:00:00
     end_date: 2020-08-14 00:00:00
@@ -2975,7 +2951,7 @@ cases:
         longitude_min: 117.9
         longitude_max: 182.5
     event_type: tropical_cyclone
-  - case_id_number: 249
+  - case_id_number: 247
     title: Maysak
     start_date: 2020-08-24 00:00:00
     end_date: 2020-09-08 00:00:00
@@ -2987,7 +2963,7 @@ cases:
         longitude_min: 120.7
         longitude_max: 136.2
     event_type: tropical_cyclone
-  - case_id_number: 250
+  - case_id_number: 248
     title: Noul (Leon)
     start_date: 2020-09-12 00:00:00
     end_date: 2020-09-21 00:00:00
@@ -2999,7 +2975,7 @@ cases:
         longitude_min: 98.2
         longitude_max: 129.6
     event_type: tropical_cyclone
-  - case_id_number: 251
+  - case_id_number: 249
     title: Linfa
     start_date: 2020-10-05 06:00:00
     end_date: 2020-10-14 00:00:00
@@ -3011,7 +2987,7 @@ cases:
         longitude_min: 104.6
         longitude_max: 127.1
     event_type: tropical_cyclone
-  - case_id_number: 252
+  - case_id_number: 250
     title: Molave (Quinta)
     start_date: 2020-10-19 18:00:00
     end_date: 2020-10-31 06:00:00
@@ -3023,7 +2999,7 @@ cases:
         longitude_min: 101.8
         longitude_max: 139.8
     event_type: tropical_cyclone
-  - case_id_number: 253
+  - case_id_number: 251
     title: Goni (Rolly)
     start_date: 2020-10-23 06:00:00
     end_date: 2020-11-08 06:00:00
@@ -3035,7 +3011,7 @@ cases:
         longitude_min: 105.6
         longitude_max: 146.2
     event_type: tropical_cyclone
-  - case_id_number: 254
+  - case_id_number: 252
     title: Vamco (Ulysse)
     start_date: 2020-11-06 00:00:00
     end_date: 2020-11-18 00:00:00
@@ -3047,7 +3023,7 @@ cases:
         longitude_min: 101.3
         longitude_max: 137.2
     event_type: tropical_cyclone
-  - case_id_number: 255
+  - case_id_number: 253
     title: Remal
     start_date: 2024-05-23 12:00:00
     end_date: 2024-05-29 18:00:00
@@ -3059,7 +3035,7 @@ cases:
         longitude_min: 86.0
         longitude_max: 92.8
     event_type: tropical_cyclone
-  - case_id_number: 256
+  - case_id_number: 254
     title: Amphan
     start_date: 2020-05-13 06:00:00
     end_date: 2020-05-23 12:00:00
@@ -3071,7 +3047,7 @@ cases:
         longitude_min: 83.8
         longitude_max: 92.4
     event_type: tropical_cyclone
-  - case_id_number: 257
+  - case_id_number: 255
     title: Nisarga
     start_date: 2020-05-29 18:00:00
     end_date: 2020-06-06 06:00:00
@@ -3083,7 +3059,7 @@ cases:
         longitude_min: 68.8
         longitude_max: 79.9
     event_type: tropical_cyclone
-  - case_id_number: 258
+  - case_id_number: 256
     title: Damien
     start_date: 2020-02-01 00:00:00
     end_date: 2020-02-12 12:00:00
@@ -3095,7 +3071,7 @@ cases:
         longitude_min: 113.9
         longitude_max: 131.8
     event_type: tropical_cyclone
-  - case_id_number: 259
+  - case_id_number: 257
     title: January 2020 Australia
     start_date: 2020-01-19 12:00:00
     end_date: 2020-01-20 12:00:00
@@ -3107,7 +3083,7 @@ cases:
         longitude_min: 144.01
         longitude_max: 155.74
     event_type: severe_convection
-  - case_id_number: 260
+  - case_id_number: 258
     title: April 2020 Australia
     start_date: 2020-04-02 12:00:00
     end_date: 2020-04-03 12:00:00
@@ -3119,7 +3095,7 @@ cases:
         longitude_min: 138.03
         longitude_max: 153.47
     event_type: severe_convection
-  - case_id_number: 261
+  - case_id_number: 259
     title: May 2020 Australia
     start_date: 2020-05-30 12:00:00
     end_date: 2020-05-31 12:00:00
@@ -3131,7 +3107,7 @@ cases:
         longitude_min: 132.78
         longitude_max: 143.72
     event_type: severe_convection
-  - case_id_number: 262
+  - case_id_number: 260
     title: September 2020 Australia
     start_date: 2020-09-24 12:00:00
     end_date: 2020-09-25 12:00:00
@@ -3143,7 +3119,7 @@ cases:
         longitude_min: 146.03
         longitude_max: 155.97
     event_type: severe_convection
-  - case_id_number: 263
+  - case_id_number: 261
     title: October 2020 Australia
     start_date: 2020-10-30 12:00:00
     end_date: 2020-10-31 12:00:00
@@ -3155,7 +3131,7 @@ cases:
         longitude_min: 146.13
         longitude_max: 157.87
     event_type: severe_convection
-  - case_id_number: 264
+  - case_id_number: 262
     title: December 2020 Australia
     start_date: 2020-12-04 12:00:00
     end_date: 2020-12-05 12:00:00
@@ -3167,7 +3143,7 @@ cases:
         longitude_min: 142.1
         longitude_max: 152.9
     event_type: severe_convection
-  - case_id_number: 265
+  - case_id_number: 263
     title: September 2021 Australia
     start_date: 2021-09-29 12:00:00
     end_date: 2021-09-30 12:00:00
@@ -3179,7 +3155,7 @@ cases:
         longitude_min: 142.59
         longitude_max: 156.16
     event_type: severe_convection
-  - case_id_number: 266
+  - case_id_number: 264
     title: October 2021 Australia
     start_date: 2021-10-13 12:00:00
     end_date: 2021-10-14 12:00:00
@@ -3191,7 +3167,7 @@ cases:
         longitude_min: 143.83
         longitude_max: 156.67
     event_type: severe_convection
-  - case_id_number: 267
+  - case_id_number: 265
     title: October 2021 Australia
     start_date: 2021-10-17 12:00:00
     end_date: 2021-10-19 12:00:00
@@ -3203,7 +3179,7 @@ cases:
         longitude_min: 144.02
         longitude_max: 157.86
     event_type: severe_convection
-  - case_id_number: 268
+  - case_id_number: 266
     title: October 2021 Australia
     start_date: 2021-10-27 12:00:00
     end_date: 2021-10-28 12:00:00
@@ -3215,7 +3191,7 @@ cases:
         longitude_min: 130.77
         longitude_max: 144.23
     event_type: severe_convection
-  - case_id_number: 269
+  - case_id_number: 267
     title: December 2021 Australia
     start_date: 2021-12-02 12:00:00
     end_date: 2021-12-03 12:00:00
@@ -3227,7 +3203,7 @@ cases:
         longitude_min: 145.3
         longitude_max: 155.95
     event_type: severe_convection
-  - case_id_number: 270
+  - case_id_number: 268
     title: December 2021 Australia
     start_date: 2021-12-08 12:00:00
     end_date: 2021-12-09 12:00:00
@@ -3239,7 +3215,7 @@ cases:
         longitude_min: 145.45
         longitude_max: 156.8
     event_type: severe_convection
-  - case_id_number: 271
+  - case_id_number: 269
     title: January 2022 Australia
     start_date: 2022-01-14 12:00:00
     end_date: 2022-01-15 12:00:00
@@ -3251,7 +3227,7 @@ cases:
         longitude_min: 144.24
         longitude_max: 155.76
     event_type: severe_convection
-  - case_id_number: 272
+  - case_id_number: 270
     title: March 2022 Australia
     start_date: 2022-03-03 12:00:00
     end_date: 2022-03-04 12:00:00
@@ -3263,7 +3239,7 @@ cases:
         longitude_min: 148.23
         longitude_max: 157.77
     event_type: severe_convection
-  - case_id_number: 273
+  - case_id_number: 271
     title: December 2022 Australia
     start_date: 2022-12-07 12:00:00
     end_date: 2022-12-08 12:00:00
@@ -3275,7 +3251,7 @@ cases:
         longitude_min: 147.99
         longitude_max: 157.51
     event_type: severe_convection
-  - case_id_number: 274
+  - case_id_number: 272
     title: February 2023 Australia
     start_date: 2023-02-13 12:00:00
     end_date: 2023-02-14 12:00:00
@@ -3287,7 +3263,7 @@ cases:
         longitude_min: 146.97
         longitude_max: 158.28
     event_type: severe_convection
-  - case_id_number: 275
+  - case_id_number: 273
     title: December 2023 Australia
     start_date: 2023-12-11 12:00:00
     end_date: 2023-12-12 12:00:00
@@ -3299,7 +3275,7 @@ cases:
         longitude_min: 135.16
         longitude_max: 145.34
     event_type: severe_convection
-  - case_id_number: 276
+  - case_id_number: 274
     title: December 2023 Australia
     start_date: 2023-12-24 12:00:00
     end_date: 2023-12-26 12:00:00
@@ -3311,7 +3287,7 @@ cases:
         longitude_min: 146.57
         longitude_max: 158.29
     event_type: severe_convection
-  - case_id_number: 277
+  - case_id_number: 275
     title: August 2024 Australia
     start_date: 2024-08-24 12:00:00
     end_date: 2024-08-25 12:00:00
@@ -3323,7 +3299,7 @@ cases:
         longitude_min: 138.94
         longitude_max: 152.56
     event_type: severe_convection
-  - case_id_number: 278
+  - case_id_number: 276
     title: October 2024 Australia
     start_date: 2024-10-08 12:00:00
     end_date: 2024-10-09 12:00:00
@@ -3335,7 +3311,7 @@ cases:
         longitude_min: 143.73
         longitude_max: 157.77
     event_type: severe_convection
-  - case_id_number: 279
+  - case_id_number: 277
     title: October 2024 Australia
     start_date: 2024-10-16 12:00:00
     end_date: 2024-10-17 12:00:00
@@ -3347,7 +3323,7 @@ cases:
         longitude_min: 136.18
         longitude_max: 147.32
     event_type: severe_convection
-  - case_id_number: 280
+  - case_id_number: 278
     title: November 2024 Australia
     start_date: 2024-10-31 12:00:00
     end_date: 2024-11-01 12:00:00
@@ -3359,7 +3335,7 @@ cases:
         longitude_min: 147.73
         longitude_max: 158.27
     event_type: severe_convection
-  - case_id_number: 281
+  - case_id_number: 279
     title: November 2024 Australia
     start_date: 2024-11-12 12:00:00
     end_date: 2024-11-13 12:00:00
@@ -3371,7 +3347,7 @@ cases:
         longitude_min: 143.38
         longitude_max: 158.37
     event_type: severe_convection
-  - case_id_number: 282
+  - case_id_number: 280
     title: April 2023 Midwest
     start_date: 2023-04-05 12:00:00
     end_date: 2023-04-06 12:00:00
@@ -3383,7 +3359,7 @@ cases:
         longitude_min: 256.04
         longitude_max: 282.71
     event_type: severe_convection
-  - case_id_number: 283
+  - case_id_number: 281
     title: March 2023 Midwest + Southeast
     start_date: 2023-03-31 12:00:00
     end_date: 2023-04-01 12:00:00
@@ -3395,7 +3371,7 @@ cases:
         longitude_min: 259.15
         longitude_max: 284.1
     event_type: severe_convection
-  - case_id_number: 284
+  - case_id_number: 282
     title: March 2023 North America
     start_date: 2023-03-02 12:00:00
     end_date: 2023-03-03 12:00:00
@@ -3407,7 +3383,7 @@ cases:
         longitude_min: 254.81
         longitude_max: 273.19
     event_type: severe_convection
-  - case_id_number: 285
+  - case_id_number: 283
     title: February 2023 North America
     start_date: 2023-02-26 12:00:00
     end_date: 2023-02-27 12:00:00
@@ -3419,7 +3395,7 @@ cases:
         longitude_min: 252.97
         longitude_max: 271.78
     event_type: severe_convection
-  - case_id_number: 286
+  - case_id_number: 284
     title: July 2022 Great Plains
     start_date: 2022-07-22 12:00:00
     end_date: 2022-07-23 12:00:00
@@ -3431,7 +3407,7 @@ cases:
         longitude_min: 251.57
         longitude_max: 280.43
     event_type: severe_convection
-  - case_id_number: 287
+  - case_id_number: 285
     title: June 2022 Southwest
     start_date: 2022-06-07 12:00:00
     end_date: 2022-06-08 12:00:00
@@ -3443,7 +3419,7 @@ cases:
         longitude_min: 249.57
         longitude_max: 272.68
     event_type: severe_convection
-  - case_id_number: 288
+  - case_id_number: 286
     title: May 2022 Midwest
     start_date: 2022-05-12 12:00:00
     end_date: 2022-05-13 12:00:00
@@ -3455,7 +3431,7 @@ cases:
         longitude_min: 250.71
         longitude_max: 277.79
     event_type: severe_convection
-  - case_id_number: 289
+  - case_id_number: 287
     title: April 2022 Great Plains
     start_date: 2022-04-12 12:00:00
     end_date: 2022-04-13 12:00:00
@@ -3467,7 +3443,7 @@ cases:
         longitude_min: 255.41
         longitude_max: 278.09
     event_type: severe_convection
-  - case_id_number: 290
+  - case_id_number: 288
     title: April 2022 South
     start_date: 2022-04-05 12:00:00
     end_date: 2022-04-06 12:00:00
@@ -3479,7 +3455,7 @@ cases:
         longitude_min: 260.49
         longitude_max: 285.51
     event_type: severe_convection
-  - case_id_number: 291
+  - case_id_number: 289
     title: December 2021 Midwest
     start_date: 2021-12-15 12:00:00
     end_date: 2021-12-16 12:00:00
@@ -3491,7 +3467,7 @@ cases:
         longitude_min: 255.01
         longitude_max: 274.74
     event_type: severe_convection
-  - case_id_number: 292
+  - case_id_number: 290
     title: December 2021 Great Plains
     start_date: 2021-12-10 12:00:00
     end_date: 2021-12-11 12:00:00
@@ -3503,7 +3479,7 @@ cases:
         longitude_min: 258.43
         longitude_max: 281.32
     event_type: severe_convection
-  - case_id_number: 293
+  - case_id_number: 291
     title: June 2021 Great Plains
     start_date: 2021-06-18 12:00:00
     end_date: 2021-06-19 12:00:00
@@ -3515,7 +3491,7 @@ cases:
         longitude_min: 258.87
         longitude_max: 281.88
     event_type: severe_convection
-  - case_id_number: 294
+  - case_id_number: 292
     title: May 2021 Great Plains
     start_date: 2021-05-03 12:00:00
     end_date: 2021-05-05 12:00:00
@@ -3527,7 +3503,7 @@ cases:
         longitude_min: 250.26
         longitude_max: 288.49
     event_type: severe_convection
-  - case_id_number: 295
+  - case_id_number: 293
     title: March 2021 South
     start_date: 2021-03-27 12:00:00
     end_date: 2021-03-28 12:00:00
@@ -3539,7 +3515,7 @@ cases:
         longitude_min: 259.22
         longitude_max: 288.03
     event_type: severe_convection
-  - case_id_number: 296
+  - case_id_number: 294
     title: March 2021 South
     start_date: 2021-03-25 12:00:00
     end_date: 2021-03-26 12:00:00
@@ -3551,7 +3527,7 @@ cases:
         longitude_min: 264.48
         longitude_max: 284.27
     event_type: severe_convection
-  - case_id_number: 297
+  - case_id_number: 295
     title: April 2020 South
     start_date: 2020-04-22 12:00:00
     end_date: 2020-04-23 12:00:00
@@ -3563,7 +3539,7 @@ cases:
         longitude_min: 256.05
         longitude_max: 277.2
     event_type: severe_convection
-  - case_id_number: 298
+  - case_id_number: 296
     title: April 2020 Southeast
     start_date: 2020-04-12 12:00:00
     end_date: 2020-04-13 12:00:00
@@ -3575,7 +3551,7 @@ cases:
         longitude_min: 257.06
         longitude_max: 285.94
     event_type: severe_convection
-  - case_id_number: 299
+  - case_id_number: 297
     title: April 2020 Midwest
     start_date: 2020-04-08 12:00:00
     end_date: 2020-04-09 12:00:00
@@ -3587,7 +3563,7 @@ cases:
         longitude_min: 262.2
         longitude_max: 288.8
     event_type: severe_convection
-  - case_id_number: 300
+  - case_id_number: 298
     title: March 2020 South
     start_date: 2020-03-28 12:00:00
     end_date: 2020-03-29 12:00:00
@@ -3599,7 +3575,7 @@ cases:
         longitude_min: 257.9
         longitude_max: 286.35
     event_type: severe_convection
-  - case_id_number: 301
+  - case_id_number: 299
     title: March 2020 Southeast
     start_date: 2020-03-02 12:00:00
     end_date: 2020-03-03 12:00:00
@@ -3611,7 +3587,7 @@ cases:
         longitude_min: 261.93
         longitude_max: 280.82
     event_type: severe_convection
-  - case_id_number: 302
+  - case_id_number: 300
     title: February 2020 East
     start_date: 2020-02-05 12:00:00
     end_date: 2020-02-07 12:00:00
@@ -3623,7 +3599,7 @@ cases:
         longitude_min: 260.81
         longitude_max: 288.16
     event_type: severe_convection
-  - case_id_number: 303
+  - case_id_number: 301
     title: January 2020 South
     start_date: 2020-01-10 12:00:00
     end_date: 2020-01-12 12:00:00
@@ -3635,7 +3611,7 @@ cases:
         longitude_min: 255.04
         longitude_max: 281.51
     event_type: severe_convection
-  - case_id_number: 304
+  - case_id_number: 302
     title: June 2020 Canada
     start_date: 2020-06-10 12:00:00
     end_date: 2020-06-11 12:00:00
@@ -3647,7 +3623,7 @@ cases:
         longitude_min: 265.96
         longitude_max: 288.54
     event_type: severe_convection
-  - case_id_number: 305
+  - case_id_number: 303
     title: June 2020 Canada
     start_date: 2020-06-12 12:00:00
     end_date: 2020-06-13 12:00:00
@@ -3659,7 +3635,7 @@ cases:
         longitude_min: 236.83
         longitude_max: 253.92
     event_type: severe_convection
-  - case_id_number: 306
+  - case_id_number: 304
     title: June 2020 Canada
     start_date: 2020-06-28 12:00:00
     end_date: 2020-06-29 12:00:00
@@ -3671,7 +3647,7 @@ cases:
         longitude_min: 243.43
         longitude_max: 274.07
     event_type: severe_convection
-  - case_id_number: 307
+  - case_id_number: 305
     title: July 2020 Canada
     start_date: 2020-07-04 12:00:00
     end_date: 2020-07-05 12:00:00
@@ -3683,7 +3659,7 @@ cases:
         longitude_min: 241.83
         longitude_max: 275.92
     event_type: severe_convection
-  - case_id_number: 308
+  - case_id_number: 306
     title: July 2020 Canada
     start_date: 2020-07-12 12:00:00
     end_date: 2020-07-13 12:00:00
@@ -3695,7 +3671,7 @@ cases:
         longitude_min: 239.04
         longitude_max: 265.46
     event_type: severe_convection
-  - case_id_number: 309
+  - case_id_number: 307
     title: July 2020 Canada
     start_date: 2020-07-19 12:00:00
     end_date: 2020-07-20 12:00:00
@@ -3707,7 +3683,7 @@ cases:
         longitude_min: 272.02
         longitude_max: 292.73
     event_type: severe_convection
-  - case_id_number: 310
+  - case_id_number: 308
     title: July 2020 Canada
     start_date: 2020-07-23 12:00:00
     end_date: 2020-07-24 12:00:00
@@ -3719,7 +3695,7 @@ cases:
         longitude_min: 238.8
         longitude_max: 268.2
     event_type: severe_convection
-  - case_id_number: 311
+  - case_id_number: 309
     title: August 2020 Canada
     start_date: 2020-08-27 12:00:00
     end_date: 2020-08-28 12:00:00
@@ -3731,7 +3707,7 @@ cases:
         longitude_min: 249.41
         longitude_max: 268.84
     event_type: severe_convection
-  - case_id_number: 312
+  - case_id_number: 310
     title: June 2021 Canada
     start_date: 2021-06-05 12:00:00
     end_date: 2021-06-06 12:00:00
@@ -3743,7 +3719,7 @@ cases:
         longitude_min: 239.25
         longitude_max: 274.0
     event_type: severe_convection
-  - case_id_number: 313
+  - case_id_number: 311
     title: June 2021 Canada
     start_date: 2021-06-14 12:00:00
     end_date: 2021-06-15 12:00:00
@@ -3755,7 +3731,7 @@ cases:
         longitude_min: 235.63
         longitude_max: 263.62
     event_type: severe_convection
-  - case_id_number: 314
+  - case_id_number: 312
     title: July 2021 Canada
     start_date: 2021-07-15 12:00:00
     end_date: 2021-07-16 12:00:00
@@ -3767,7 +3743,7 @@ cases:
         longitude_min: 265.37
         longitude_max: 289.38
     event_type: severe_convection
-  - case_id_number: 315
+  - case_id_number: 313
     title: July 2021 Canada
     start_date: 2021-07-22 12:00:00
     end_date: 2021-07-23 12:00:00
@@ -3779,7 +3755,7 @@ cases:
         longitude_min: 238.54
         longitude_max: 263.46
     event_type: severe_convection
-  - case_id_number: 316
+  - case_id_number: 314
     title: August 2021 Canada
     start_date: 2021-08-23 12:00:00
     end_date: 2021-08-24 12:00:00
@@ -3791,7 +3767,7 @@ cases:
         longitude_min: 244.39
         longitude_max: 272.11
     event_type: severe_convection
-  - case_id_number: 317
+  - case_id_number: 315
     title: August 2021 Canada
     start_date: 2021-08-31 12:00:00
     end_date: 2021-09-01 12:00:00
@@ -3803,7 +3779,7 @@ cases:
         longitude_min: 239.32
         longitude_max: 261.93
     event_type: severe_convection
-  - case_id_number: 318
+  - case_id_number: 316
     title: June 2022 Canada
     start_date: 2022-06-23 12:00:00
     end_date: 2022-06-24 12:00:00
@@ -3815,7 +3791,7 @@ cases:
         longitude_min: 247.12
         longitude_max: 273.88
     event_type: severe_convection
-  - case_id_number: 319
+  - case_id_number: 317
     title: June 2022 Canada
     start_date: 2022-06-29 12:00:00
     end_date: 2022-06-30 12:00:00
@@ -3827,7 +3803,7 @@ cases:
         longitude_min: 241.57
         longitude_max: 274.18
     event_type: severe_convection
-  - case_id_number: 320
+  - case_id_number: 318
     title: July 2022 Canada
     start_date: 2022-07-05 12:00:00
     end_date: 2022-07-06 12:00:00
@@ -3839,7 +3815,7 @@ cases:
         longitude_min: 241.09
         longitude_max: 289.41
     event_type: severe_convection
-  - case_id_number: 321
+  - case_id_number: 319
     title: July 2022 Canada
     start_date: 2022-07-07 12:00:00
     end_date: 2022-07-08 12:00:00
@@ -3851,7 +3827,7 @@ cases:
         longitude_min: 238.14
         longitude_max: 266.86
     event_type: severe_convection
-  - case_id_number: 322
+  - case_id_number: 320
     title: July 2022 Canada
     start_date: 2022-07-08 12:00:00
     end_date: 2022-07-09 12:00:00
@@ -3863,7 +3839,7 @@ cases:
         longitude_min: 238.59
         longitude_max: 267.66
     event_type: severe_convection
-  - case_id_number: 323
+  - case_id_number: 321
     title: July 2022 Canada
     start_date: 2022-07-17 12:00:00
     end_date: 2022-07-18 12:00:00
@@ -3875,7 +3851,7 @@ cases:
         longitude_min: 245.23
         longitude_max: 271.27
     event_type: severe_convection
-  - case_id_number: 324
+  - case_id_number: 322
     title: July 2022 Canada
     start_date: 2022-07-19 12:00:00
     end_date: 2022-07-20 12:00:00
@@ -3887,7 +3863,7 @@ cases:
         longitude_min: 239.06
         longitude_max: 255.19
     event_type: severe_convection
-  - case_id_number: 325
+  - case_id_number: 323
     title: July 2022 Canada
     start_date: 2022-07-31 12:00:00
     end_date: 2022-08-01 12:00:00
@@ -3899,7 +3875,7 @@ cases:
         longitude_min: 236.34
         longitude_max: 258.41
     event_type: severe_convection
-  - case_id_number: 326
+  - case_id_number: 324
     title: May 2023 Canada
     start_date: 2023-05-31 12:00:00
     end_date: 2023-06-01 12:00:00
@@ -3911,7 +3887,7 @@ cases:
         longitude_min: 248.38
         longitude_max: 261.87
     event_type: severe_convection
-  - case_id_number: 327
+  - case_id_number: 325
     title: June 2023 Canada
     start_date: 2023-06-28 12:00:00
     end_date: 2023-06-29 12:00:00
@@ -3923,7 +3899,7 @@ cases:
         longitude_min: 248.09
         longitude_max: 278.91
     event_type: severe_convection
-  - case_id_number: 328
+  - case_id_number: 326
     title: July 2023 Canada
     start_date: 2023-07-13 12:00:00
     end_date: 2023-07-14 12:00:00
@@ -3935,7 +3911,7 @@ cases:
         longitude_min: 249.48
         longitude_max: 294.02
     event_type: severe_convection
-  - case_id_number: 329
+  - case_id_number: 327
     title: July 2023 Canada
     start_date: 2023-07-20 12:00:00
     end_date: 2023-07-21 12:00:00
@@ -3947,7 +3923,7 @@ cases:
         longitude_min: 265.84
         longitude_max: 287.16
     event_type: severe_convection
-  - case_id_number: 330
+  - case_id_number: 328
     title: July 2023 Canada
     start_date: 2023-07-22 12:00:00
     end_date: 2023-07-23 12:00:00
@@ -3959,7 +3935,7 @@ cases:
         longitude_min: 246.28
         longitude_max: 279.97
     event_type: severe_convection
-  - case_id_number: 331
+  - case_id_number: 329
     title: July 2023 Canada
     start_date: 2023-07-26 12:00:00
     end_date: 2023-07-27 12:00:00
@@ -3971,7 +3947,7 @@ cases:
         longitude_min: 250.03
         longitude_max: 284.47
     event_type: severe_convection
-  - case_id_number: 332
+  - case_id_number: 330
     title: August 2023 Canada
     start_date: 2023-08-03 12:00:00
     end_date: 2023-08-04 12:00:00
@@ -3983,7 +3959,7 @@ cases:
         longitude_min: 266.29
         longitude_max: 292.71
     event_type: severe_convection
-  - case_id_number: 333
+  - case_id_number: 331
     title: June 2024 Canada
     start_date: 2024-06-12 12:00:00
     end_date: 2024-06-13 12:00:00
@@ -3995,7 +3971,7 @@ cases:
         longitude_min: 248.23
         longitude_max: 274.52
     event_type: severe_convection
-  - case_id_number: 334
+  - case_id_number: 332
     title: June 2024 Canada
     start_date: 2024-06-22 12:00:00
     end_date: 2024-06-23 12:00:00
@@ -4007,7 +3983,7 @@ cases:
         longitude_min: 247.71
         longitude_max: 293.54
     event_type: severe_convection
-  - case_id_number: 335
+  - case_id_number: 333
     title: June 2024 Canada
     start_date: 2024-06-23 12:00:00
     end_date: 2024-06-24 12:00:00
@@ -4019,7 +3995,7 @@ cases:
         longitude_min: 240.26
         longitude_max: 274.24
     event_type: severe_convection
-  - case_id_number: 336
+  - case_id_number: 334
     title: July 2024 Canada
     start_date: 2024-07-11 12:00:00
     end_date: 2024-07-12 12:00:00
@@ -4031,7 +4007,7 @@ cases:
         longitude_min: 251.25
         longitude_max: 272.5
     event_type: severe_convection
-  - case_id_number: 337
+  - case_id_number: 335
     title: July 2024 Canada
     start_date: 2024-07-24 12:00:00
     end_date: 2024-07-25 12:00:00
@@ -4043,7 +4019,7 @@ cases:
         longitude_min: 236.26
         longitude_max: 252.74
     event_type: severe_convection
-  - case_id_number: 338
+  - case_id_number: 336
     title: August 2024 Canada
     start_date: 2024-08-05 12:00:00
     end_date: 2024-08-06 12:00:00
@@ -4055,7 +4031,7 @@ cases:
         longitude_min: 259.41
         longitude_max: 293.84
     event_type: severe_convection
-  - case_id_number: 339
+  - case_id_number: 337
     title: August 2024 Canada
     start_date: 2024-08-21 12:00:00
     end_date: 2024-08-22 12:00:00


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR removes the two identified duplicate cases in `severe_convection`, occurring as result of regenerating bounds for the cases recently. Cases have been renumbered to reflect this change.