### PR TITLE
remove east/west hemisphere valid time split

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -590,9 +590,8 @@ class GHCN(TargetBase):
 class LSR(TargetBase):
     """Target class for local storm report (LSR) tabular data.
 
-    run_pipeline() returns a dataset with LSRs as mapped to numeric values (1=wind, 2=hail, 3=tor). IndividualCase date ranges for LSRs should ideally be 12 UTC to
-    the next day at 12 UTC to match SPC methods for US data. Australia data should be 00
-    UTC to 00 UTC.
+    run_pipeline() returns a dataset with LSRs as mapped to numeric values (1=wind, 2=hail, 3=tor). IndividualCase date ranges for LSRs should be 12 UTC to
+    the next day at 12 UTC (exclusive) to match SPC's reporting window.
     """
 
     name: str = "local_storm_reports"


### PR DESCRIPTION
# EWB Pull Request

## Description

We originally had decided to specify LSR time ranges differently between NA and Aus data. A recent change aligned all of the data on the 12Z - 1159Z paradigm for all data (intentionally set to match SPC's approach).

This PR closes the loop on this change and aligns all LSR data on this same valid time paradigm, fixing an issue where Aus data was returning all NaNs due to all `valid_time` values being filtered out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Pytest and running on problematic cases in Australia to confirm NaN occurrence no longer happening.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules