### PR TITLE
docs: fix README example bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ ewb --default
 ## Using Jupyter Notebook or a Script:
  
 ```python
-from extremeweatherbench import inputs, metrics, evaluate, utils
+from extremeweatherbench import cases, inputs, metrics, evaluate, utils
 
 # Select model
 model = 'FOUR_v200_GFS'
@@ -73,6 +73,7 @@ forecast_dir = f'gs://extremeweatherbench/{model}.parq'
 
 # Define a forecast object; in this case, a KerchunkForecast
 fcnv2_forecast = inputs.KerchunkForecast(
+    name="fcnv2_forecast", # identifier for this forecast in results
     source=forecast_dir, # source path
     variables=["surface_air_temperature"], # variables to use in the evaluation
     variable_mapping=inputs.CIRA_metadata_variable_mapping, # mapping to use for variables in forecast dataset to EWB variable names


### PR DESCRIPTION
## Description
Fixes two bugs in the README "Using Jupyter Notebook or a Script" example that prevent the code from running.

## Changes
1. Added missing `cases` to import statement (required for `cases.load_ewb_events_yaml_into_case_collection()`)
2. Added required `name` parameter to `KerchunkForecast` example

## Testing
Tested the corrected example: runs to completion successfully.

## Related
Ref: Discussion #277