### PR TITLE
CIRA geopotential, not geopotential height

### DIFF
--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -184,7 +184,6 @@ def _preprocess_bb_severe_cira_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
             relative_humidity=ds["r"] / 100,  # Convert relative humidity to percentage
             levels=ds["level"],
         )
-    ds["geopotential"] = ds["z"] * calc.g0
     return ds
 
 

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -75,7 +75,7 @@ CIRA_metadata_variable_mapping = {
     "u": "eastward_wind",
     "v": "northward_wind",
     "p": "air_pressure",
-    "z": "geopotential_height",
+    "z": "geopotential",
     "r": "relative_humidity",
     "u10": "surface_eastward_wind",
     "v10": "surface_northward_wind",


### PR DESCRIPTION
# EWB Pull Request

## Description

CIRA data uses `'z'` as the name of the variable for geopotential. It is, in fact, geopotential and NOT geopotential height. This PR fixes the naming convention and removes ` * calc.g0` from the preprocessing function for severe convective cases in `defaults.py`.