### PR TITLE
Change `threshold_criteria` to local var to prevent in-place mutation

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1338,15 +1338,17 @@ class DurationMeanError(MeanError):
             if dim not in ["init_time", "lead_time", "valid_time"]
         ]
         # Handle criteria - either climatology (xr.DataArray) or float threshold
-        if isinstance(self.threshold_criteria, xr.DataArray):
+        # Use local variable to avoid mutating self.threshold_criteria
+        threshold_criteria = self.threshold_criteria
+        if isinstance(threshold_criteria, xr.DataArray):
             # Climatology case, convert from dayofyear/hour to valid_time
-            self.threshold_criteria = utils.convert_day_yearofday_to_time(
-                self.threshold_criteria, forecast.valid_time.dt.year.values[0]
+            threshold_criteria = utils.convert_day_yearofday_to_time(
+                threshold_criteria, forecast.valid_time.dt.year.values[0]
             )
 
             # Interpolate climatology to target coordinates
-            self.threshold_criteria = utils.interp_climatology_to_target(
-                target, self.threshold_criteria
+            threshold_criteria = utils.interp_climatology_to_target(
+                target, threshold_criteria
             )
         forecast = utils.reduce_dataarray(
             forecast, method="mean", reduce_dims=spatial_dims
@@ -1354,8 +1356,8 @@ class DurationMeanError(MeanError):
         target = utils.reduce_dataarray(target, method="mean", reduce_dims=spatial_dims)
         forecast = forecast.compute()
         target = target.compute()
-        forecast_mask = self.op_func(forecast, self.threshold_criteria)
-        target_mask = self.op_func(target, self.threshold_criteria)
+        forecast_mask = self.op_func(forecast, threshold_criteria)
+        target_mask = self.op_func(target, threshold_criteria)
         # Track NaN locations in forecast data
         forecast_valid_mask = ~forecast.isnull()
 


### PR DESCRIPTION
# EWB Pull Request

## Description

When using DurationMeanError in-place with a climatology, `self.threshold_criteria` is mutated inside `_compute_metric`. The problem with this approach arises when the same instantiation of the metric is used multiple times, e.g. for both ERA5 and GHCNh targets. 

In this scenario, `self.threshold_criteria` will reference a mutated dataarray and fail out due to missing dimensions. 

For now, this fix addresses it by instead mutating a local variable that uses `self.threshold_criteria`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules