### PR TITLE
Move parallel config check outside of function

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -112,7 +112,7 @@ class ExtremeWeatherBench:
                 Ignored if parallel_config is provided.
             parallel_config: Optional dictionary of joblib parallel configuration.
                 If provided, this takes precedence over n_jobs. If not provided and
-                n_jobs is specified, a default config with threading backend is used.
+                n_jobs is specified, a default config with loky backend is used.
 
         Returns:
             A concatenated dataframe of the evaluation results.
@@ -122,7 +122,10 @@ class ExtremeWeatherBench:
         # Check for serial or parallel configuration
         parallel_config = _parallel_serial_config_check(n_jobs, parallel_config)
         run_results = _run_case_operators(
-            self.case_operators, cache_dir=self.cache_dir, **kwargs
+            self.case_operators,
+            cache_dir=self.cache_dir,
+            parallel_config=parallel_config,
+            **kwargs,
         )
 
         # If there are results, concatenate them and return, else return an empty
@@ -153,7 +156,12 @@ def _run_case_operators(
         # Run in parallel if parallel_config exists and n_jobs != 1
         if parallel_config is not None:
             logger.info("Running case operators in parallel...")
-            return _run_parallel(case_operators, cache_dir=cache_dir, **kwargs)
+            return _run_parallel(
+                case_operators,
+                cache_dir=cache_dir,
+                parallel_config=parallel_config,
+                **kwargs,
+            )
         else:
             logger.info("Running case operators in serial...")
             return _run_serial(case_operators, cache_dir=cache_dir, **kwargs)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -366,10 +366,11 @@ class TestExtremeWeatherBench:
 
             result = ewb.run(n_jobs=1)
 
-            # Serial mode should not pass parallel_config
+            # Serial mode passes parallel_config=None
             mock_run_case_operators.assert_called_once_with(
                 [sample_case_operator],
                 cache_dir=None,
+                parallel_config=None,
             )
             assert isinstance(result, pd.DataFrame)
             assert len(result) == 1
@@ -407,7 +408,7 @@ class TestExtremeWeatherBench:
             mock_run_case_operators.assert_called_once_with(
                 [sample_case_operator],
                 cache_dir=None,
-                parallel_config={"backend": "threading", "n_jobs": 2},
+                parallel_config={"backend": "loky", "n_jobs": 2},
             )
             assert isinstance(result, pd.DataFrame)
             assert len(result) == 1


### PR DESCRIPTION
# EWB Pull Request

## Description

The check to handle whether or not to run EWB in parallel was all handled within the `ExtremeWeatherrBench.run()` script. This PR pulls the logic out of that method and creates its own (and adds a new edge case which wasn't caught before - if the parallel configuration is `{n_jobs: 1}`, to make a serial run. In the scenario someone is automating scripting for this `dict`, this case might pop up!

Also, within `run()` included creating a cache directory if it didn't exist. I moved this to `init()`.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (non-breaking change which improves or clarifies code)
- [ ] Refactor (breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built out new tests to handle a bunch of normal and edge cases; all pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules