### PR TITLE
Simplify IBTrACS polars subset; prevent in-memory

### DIFF
--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -901,34 +901,21 @@ class IBTrACS(TargetBase):
         case_metadata: "cases.IndividualCase",
         **kwargs,
     ) -> IncomingDataInput:
-        # Note: drop parameter not applicable for polars LazyFrame data
         if not isinstance(data, pl.LazyFrame):
             raise ValueError(f"Expected polars LazyFrame, got {type(data)}")
 
-        # Get the season (year) from the case start date, cast as string as
-        # polars is interpreting the schema as strings
         season = case_metadata.start_date.year
         if case_metadata.start_date.month > 11:
             season += 1
 
-        # Create a subquery to find all storm numbers in the same season
-        matching_numbers = (
-            data.filter(pl.col("season").cast(pl.Int64) == season)
-            .select("number")
-            .unique()
-        )
-
         possible_names = utils.extract_tc_names(case_metadata.title)
 
-        # Apply the filter to get all data for storms with the same number in
-        # the same season, matching any of the possible names
-        # This maintains the lazy evaluation
-        name_filter = pl.col("tc_name").is_in(possible_names)
-        subset_target_data = data.join(
-            matching_numbers, on="number", how="inner"
-        ).filter(name_filter & (pl.col("season").cast(pl.Int64) == season))
+        # Direct filter - eliminates join, group-by, and second CSV scan
+        subset_target_data = data.filter(
+            (pl.col("season").cast(pl.Int64) == season)
+            & pl.col("tc_name").is_in(possible_names)
+        )
 
-        # Select only the columns to keep
         columns_to_keep = [
             "valid_time",
             "tc_name",
@@ -942,8 +929,6 @@ class IBTrACS(TargetBase):
 
         subset_target_data = subset_target_data.select(columns_to_keep)
 
-        # Drop rows where wind speed OR pressure are null (equivalent to pandas
-        # dropna with how="any")
         subset_target_data = subset_target_data.filter(
             pl.col("surface_wind_speed").is_not_null()
             & pl.col("air_pressure_at_mean_sea_level").is_not_null()


### PR DESCRIPTION
# EWB Pull Request

## Description

Polars is a wonderful library for managing tabular datasets. It also is very verbose and has some pitfalls wrt memory usage. When running tropical cyclone track analyses, I noticed a massive jump in memory usage in the beginning corresponding with the polars `collect()` method. This PR removes the steps that were either redundant and/or caused polars to fall back to the in-memory engine instead of streaming (which prevents some of the memory usage).

## Type of change

- [x] Refactor (non-breaking change which improves or clarifies code)

## How Has This Been Tested?

Re-ran the existing tests to ensure consistent functionality, as this is exclusively an optimization.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules