### PR TITLE
`EarlySignal` fixes

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -984,6 +984,11 @@ class EarlySignal(BaseMetric):
     Extends BaseMetric to find the earliest time when a signal is detected
     based on threshold criteria, returning init_time, lead_time, and
     valid_time information. Flexible for different signal detection criteria.
+
+    For any case, the default behavior is to confirm any valid signal in space, then
+    time. This behavior can be changed by setting spatial_aggregation and
+    temporal_aggregation to "any", "all", or "half". Further, the order of aggregation
+    can be changed by setting order to ["temporal", "spatial"] if desired.
     """
 
     def __init__(
@@ -994,7 +999,10 @@ class EarlySignal(BaseMetric):
         ] = ">=",
         threshold: float = 0.5,
         spatial_aggregation: Literal["any", "all", "half"] = "any",
-        preserve_dims: str = "init_time",
+        temporal_aggregation: Literal["any", "all", "half"] = "any",
+        aggregation_order: tuple[
+            Literal["spatial", "temporal"], Literal["temporal", "spatial"]
+        ] = ("spatial", "temporal"),
         **kwargs,
     ):
         """Initialize the Early Signal detection metric.
@@ -1006,15 +1014,48 @@ class EarlySignal(BaseMetric):
             spatial_aggregation: Spatial aggregation method. Options: "any"
                 (any gridpoint meets criteria), "all" (all gridpoints meet
                 criteria), or "half" (at least half meet criteria).
-            preserve_dims: Dimensions to preserve during aggregation.
-                Defaults to "init_time".
+            temporal_aggregation: Temporal aggregation method. Options: "any"
+                (any valid time meets criteria), "all" (all valid times meet
+                criteria), or "half" (at least half valid times meet criteria).
+            aggregation_order: The order of spatial and temporal aggregation. Defaults
+                to ("spatial", "temporal").
             **kwargs: Additional keyword arguments passed to BaseMetric.
         """
-        super().__init__(name=name, preserve_dims=preserve_dims, **kwargs)
+        super().__init__(name=name, **kwargs)
         self.comparison_operator = utils.maybe_get_operator(comparison_operator)
         self.threshold = threshold
         self.spatial_aggregation = spatial_aggregation
+        self.temporal_aggregation = temporal_aggregation
+        self.aggregation_order = aggregation_order
 
+    def _apply_aggregation(
+        self,
+        detection_mask: xr.DataArray,
+        aggregation: Literal["any", "all", "half"],
+        dims_to_reduce: list[str],
+    ) -> xr.DataArray:
+        """Apply aggregation to the detection mask.
+
+        Args:
+            detection_mask: The detection mask DataArray.
+            aggregation: The aggregation method. Options: "any"
+                (any gridpoint meets criteria), "all" (all gridpoints meet
+                criteria), or "half" (at least half meet criteria).
+            dims_to_reduce: The dimensions to reduce.
+        Returns:
+            The aggregated detection mask DataArray.
+        """
+        if aggregation == "any":
+            # fillna(False): NaN means no data, not a True detection
+            result = detection_mask.fillna(False).any(dims_to_reduce)
+        elif aggregation == "all":
+            # fillna(True): NaN means no data, don't penalize "all" condition
+            result = detection_mask.fillna(True).all(dims_to_reduce)
+        elif aggregation == "half":
+            result = detection_mask.mean(dim=dims_to_reduce) >= 0.5
+        else:
+            raise ValueError(f"Aggregation '{aggregation}' not supported")
+        return result
 
     def _compute_metric(
         self,
@@ -1032,29 +1073,57 @@ class EarlySignal(BaseMetric):
             Boolean DataArray with dims [init_time, lead_time] indicating
             whether criteria are met for each init_time and lead_time pair.
         """
-        # Convert valid_time to init_time if preserve_dims is init_time
-        if self.preserve_dims == "init_time" and "init_time" not in forecast.dims:
-            forecast = utils.convert_valid_time_to_init_time(forecast)
-        # Create detection mask
-        detection_mask = self.comparison_operator(forecast, self.threshold)
 
-        # Apply spatial aggregation
-        dims_to_reduce = [
-            dim for dim in detection_mask.dims if dim not in self.preserve_dims
+        # Create detection masks with nans preserved
+        forecast_detection_mask = self.comparison_operator(
+            forecast, self.threshold
+        ).where(~forecast.isnull())
+        target_detection_mask = self.comparison_operator(target, self.threshold).where(
+            ~target.isnull()
+        )
+
+        # Only assess forecast where target detects the event (value == 1);
+        # locations where target is 0 or NaN are excluded
+        forecast_detection_mask = forecast_detection_mask.where(
+            target_detection_mask == 1, drop=True
+        )
+
+        # Create lists of dimensions to reduce
+        spatial_dims = [
+            dim
+            for dim in forecast_detection_mask.dims
+            if dim not in ["init_time", "lead_time", "valid_time"]
+            and dim not in self.preserve_dims
         ]
-        if dims_to_reduce:
-            if self.spatial_aggregation == "any":
-                detection_mask = detection_mask.any(dims_to_reduce)
-            elif self.spatial_aggregation == "all":
-                detection_mask = detection_mask.all(dims_to_reduce)
-            elif self.spatial_aggregation == "half":
-                detection_mask = detection_mask.astype(bool).mean(dim=dims_to_reduce) >= 0.5
-            else:
-                raise ValueError(
-                    f"Spatial aggregation '{self.spatial_aggregation}' not supported"
-                )
-        detection_mask.name = self.name
-        return detection_mask
+        temporal_dims = [
+            dim
+            for dim in forecast_detection_mask.dims
+            if dim in ["init_time", "lead_time", "valid_time"]
+            and dim not in self.preserve_dims
+        ]
+
+        # Apply aggregation in the order specified
+        if self.aggregation_order[0] == "spatial":
+            forecast_detection_mask = self._apply_aggregation(
+                forecast_detection_mask, self.spatial_aggregation, spatial_dims
+            )
+            forecast_detection_mask = self._apply_aggregation(
+                forecast_detection_mask,
+                self.temporal_aggregation,
+                temporal_dims,
+            )
+        elif self.aggregation_order[0] == "temporal":
+            forecast_detection_mask = self._apply_aggregation(
+                forecast_detection_mask,
+                self.temporal_aggregation,
+                temporal_dims,
+            )
+            forecast_detection_mask = self._apply_aggregation(
+                forecast_detection_mask, self.spatial_aggregation, spatial_dims
+            )
+
+        forecast_detection_mask.name = self.name
+        return forecast_detection_mask
 
 
 class MaximumMeanAbsoluteError(MeanAbsoluteError):

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -994,6 +994,7 @@ class EarlySignal(BaseMetric):
         ] = ">=",
         threshold: float = 0.5,
         spatial_aggregation: Literal["any", "all", "half"] = "any",
+        preserve_dims: str = "init_time",
         **kwargs,
     ):
         """Initialize the Early Signal detection metric.
@@ -1005,13 +1006,15 @@ class EarlySignal(BaseMetric):
             spatial_aggregation: Spatial aggregation method. Options: "any"
                 (any gridpoint meets criteria), "all" (all gridpoints meet
                 criteria), or "half" (at least half meet criteria).
+            preserve_dims: Dimensions to preserve during aggregation.
+                Defaults to "init_time".
             **kwargs: Additional keyword arguments passed to BaseMetric.
         """
-        # Extract threshold params before passing to super
+        super().__init__(name=name, preserve_dims=preserve_dims, **kwargs)
         self.comparison_operator = utils.maybe_get_operator(comparison_operator)
         self.threshold = threshold
         self.spatial_aggregation = spatial_aggregation
-        super().__init__(name, **kwargs)
+
 
     def _compute_metric(
         self,
@@ -1029,44 +1032,27 @@ class EarlySignal(BaseMetric):
             Boolean DataArray with dims [init_time, lead_time] indicating
             whether criteria are met for each init_time and lead_time pair.
         """
-        if self.threshold is None:
-            # Return False for all when no detection criteria specified
-            dims = ["init_time", "lead_time"]
-            coords = {
-                "init_time": forecast.valid_time - forecast.lead_time,
-                "lead_time": forecast.lead_time,
-            }
-            if "valid_time" in forecast.dims:
-                dims.append("valid_time")
-                coords["valid_time"] = forecast.valid_time
-            return xr.DataArray(
-                False,
-                dims=dims,
-                coords=coords,
-                name=self.name,
-            )
+        # Convert valid_time to init_time if preserve_dims is init_time
+        if self.preserve_dims == "init_time" and "init_time" not in forecast.dims:
+            forecast = utils.convert_valid_time_to_init_time(forecast)
         # Create detection mask
         detection_mask = self.comparison_operator(forecast, self.threshold)
 
         # Apply spatial aggregation
-        spatial_dims = [
-            dim
-            for dim in detection_mask.dims
-            if dim not in ["init_time", "lead_time", "valid_time"]
+        dims_to_reduce = [
+            dim for dim in detection_mask.dims if dim not in self.preserve_dims
         ]
-
-        if spatial_dims:
+        if dims_to_reduce:
             if self.spatial_aggregation == "any":
-                detection_mask = detection_mask.any(spatial_dims)
+                detection_mask = detection_mask.any(dims_to_reduce)
             elif self.spatial_aggregation == "all":
-                detection_mask = detection_mask.all(spatial_dims)
+                detection_mask = detection_mask.all(dims_to_reduce)
             elif self.spatial_aggregation == "half":
-                detection_mask = operator.ge(detection_mask.mean(spatial_dims), 0.5)
+                detection_mask = detection_mask.astype(bool).mean(dim=dims_to_reduce) >= 0.5
             else:
                 raise ValueError(
                     f"Spatial aggregation '{self.spatial_aggregation}' not supported"
                 )
-
         detection_mask.name = self.name
         return detection_mask
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3468,3 +3468,197 @@ class TestBaseMetricVariableValidation:
         metric = metrics.MeanAbsoluteError()
         assert metric.forecast_variable is None
         assert metric.target_variable is None
+
+
+class TestEarlySignal:
+    """Tests for EarlySignal metric and its aggregation helpers."""
+
+    def _make_metric(self, **kwargs):
+        return metrics.EarlySignal(**kwargs)
+
+    def test_default_init(self):
+        """Default EarlySignal has expected attribute values."""
+        m = self._make_metric()
+        assert m.threshold == 0.5
+        assert m.spatial_aggregation == "any"
+        assert m.temporal_aggregation == "any"
+        assert m.aggregation_order == ("spatial", "temporal")
+
+    def test_custom_init(self):
+        """Custom params are stored correctly."""
+        m = self._make_metric(
+            threshold=1.0,
+            spatial_aggregation="all",
+            temporal_aggregation="half",
+            aggregation_order=("temporal", "spatial"),
+        )
+        assert m.threshold == 1.0
+        assert m.spatial_aggregation == "all"
+        assert m.temporal_aggregation == "half"
+        assert m.aggregation_order == ("temporal", "spatial")
+
+    def test_apply_aggregation_any_all_nan_returns_false(self):
+        """any over all-NaN slice should return False (not True)."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, np.nan, np.nan], dims=["space"])
+        result = m._apply_aggregation(da, "any", ["space"])
+        assert bool(result.values) is False
+
+    def test_apply_aggregation_any_nan_and_zero_returns_false(self):
+        """any over NaN+False values must return False, not True."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, np.nan, 0.0], dims=["space"])
+        result = m._apply_aggregation(da, "any", ["space"])
+        assert bool(result.values) is False
+
+    def test_apply_aggregation_any_nan_and_one_returns_true(self):
+        """any returns True when at least one non-NaN value is True."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, 0.0, 1.0], dims=["space"])
+        result = m._apply_aggregation(da, "any", ["space"])
+        assert bool(result.values) is True
+
+    def test_apply_aggregation_all_all_nan_returns_true(self):
+        """all over all-NaN: no data means nothing fails the condition."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, np.nan], dims=["space"])
+        result = m._apply_aggregation(da, "all", ["space"])
+        assert bool(result.values) is True
+
+    def test_apply_aggregation_all_nan_and_zero_returns_false(self):
+        """all returns False when a non-NaN False is present."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, 1.0, 0.0], dims=["space"])
+        result = m._apply_aggregation(da, "all", ["space"])
+        assert bool(result.values) is False
+
+    def test_apply_aggregation_half_nan_excluded_from_denominator(self):
+        """half uses skipna mean, so NaN positions don't dilute fraction."""
+        m = self._make_metric()
+        # 2 True, 2 NaN means mean of valid = 1.0 >= 0.5 is True
+        # (with fillna(0) first it would be 2/4=0.5; still True, but with
+        # uneven splits it matters)
+        da = xr.DataArray([1.0, 1.0, np.nan, np.nan], dims=["space"])
+        result = m._apply_aggregation(da, "half", ["space"])
+        assert bool(result.values) is True
+
+    def test_apply_aggregation_half_nan_excluded_unequal_groups(self):
+        """NaN exclusion changes result vs fillna(0) when groups are uneven."""
+        m = self._make_metric()
+        # 1 True, 3 NaN → skipna mean = 1/1 = 1.0 >= 0.5 → True
+        # fillna(0) mean = 1/4 = 0.25 → False
+        da = xr.DataArray([1.0, np.nan, np.nan, np.nan], dims=["space"])
+        result = m._apply_aggregation(da, "half", ["space"])
+        assert bool(result.values) is True
+
+    def test_apply_aggregation_half_all_nan_returns_false(self):
+        """half over all-NaN returns False (NaN >= 0.5 is False)."""
+        m = self._make_metric()
+        da = xr.DataArray([np.nan, np.nan], dims=["space"])
+        result = m._apply_aggregation(da, "half", ["space"])
+        assert bool(result.values) is False
+
+    def test_apply_aggregation_invalid_raises(self):
+        """Unsupported aggregation raises ValueError."""
+        m = self._make_metric()
+        da = xr.DataArray([1.0], dims=["space"])
+        with pytest.raises(ValueError, match="not supported"):
+            m._apply_aggregation(da, "median", ["space"])
+
+    def _make_forecast_target(self, forecast_vals, target_vals, spatial_size=3):
+        """Build minimal forecast/target DataArrays with space+valid_time dims.
+
+        spatial_size ignored when vals are already 2-D arrays.
+        """
+        vtime = pd.to_timedelta(np.arange(len(forecast_vals)), unit="h")
+        forecast = xr.DataArray(
+            np.array(forecast_vals, dtype=float),
+            dims=["valid_time", "space"],
+            coords={"valid_time": vtime},
+        )
+        target = xr.DataArray(
+            np.array(target_vals, dtype=float),
+            dims=["valid_time", "space"],
+            coords={"valid_time": vtime},
+        )
+        return forecast, target
+
+    def test_compute_metric_target_zero_excluded(self):
+        """Forecast not evaluated at locations where target is 0."""
+        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        # target row 0: all 0 → excluded; row 1: all 1 → included
+        # forecast row 1: all above threshold → should detect
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9], [0.9, 0.9]],
+            target_vals=[[0.0, 0.0], [1.0, 1.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        # spatial any→ True because row1 forecast > 0.5 at target==1 locs
+        assert bool(result.any().values)
+
+    def test_compute_metric_target_nan_excluded(self):
+        """Forecast not evaluated where target is NaN."""
+        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        # Only target==1 at space=1, t=0; forecast is below threshold there
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[np.nan, 1.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        # space=0 excluded (target NaN); space=1 forecast=0.1 < 0.5 → False
+        assert not bool(result.any().values)
+
+    def test_compute_metric_only_target_one_locations_matter(self):
+        """High forecast values at target==0 locations don't trigger True."""
+        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        # target: space=0 → 0 (excluded), space=1 → 1 (included)
+        # forecast: space=0 → 0.9 (would fire if not masked), space=1 → 0.1
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[0.0, 1.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert not bool(result.any().values)
+
+    def test_aggregation_order_spatial_then_temporal(self):
+        """spatial to temporal order produces a scalar result."""
+        m = self._make_metric(
+            spatial_aggregation="any",
+            temporal_aggregation="any",
+            aggregation_order=("spatial", "temporal"),
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9], [0.9, 0.9]],
+            target_vals=[[1.0, 1.0], [1.0, 1.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert result.ndim == 0
+
+    def test_aggregation_order_temporal_then_spatial(self):
+        """temporal to spatial order produces a scalar result."""
+        m = self._make_metric(
+            spatial_aggregation="any",
+            temporal_aggregation="any",
+            aggregation_order=("temporal", "spatial"),
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9], [0.9, 0.9]],
+            target_vals=[[1.0, 1.0], [1.0, 1.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert result.ndim == 0
+
+    def test_aggregation_order_both_detect(self):
+        """Both orders give the same True result when forecast validates."""
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9], [0.9, 0.9]],
+            target_vals=[[1.0, 1.0], [1.0, 1.0]],
+        )
+        for order in [("spatial", "temporal"), ("temporal", "spatial")]:
+            m = self._make_metric(
+                spatial_aggregation="any",
+                temporal_aggregation="any",
+                aggregation_order=order,
+            )
+            result = m._compute_metric(forecast, target)
+            assert bool(result.values), f"Expected True for order={order}"


### PR DESCRIPTION
# EWB Pull Request

## Description

`EarlySignal` wasn't reducing properly but was successfully being called. Further investigation showed some issues including:

1. The rollup was not occurring as mentioned
2. Spatiotemporal aggregations had a few quirks including needing to have an option for sequential ordering of the reduction (spatial, then temporal) for the "half" option, depending on the use case.

This PR adds a private aggregation function into the metric and also manages NaN's in the arrays where NaN's, 0's, and 1's are present.

## Type of change

- [x] Refactor
- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

Tests are currently being added to confirm the new changes work as intended.