### PR TITLE
Update ARs with pressure ceiling and cleaner derived variable

### DIFF
--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -432,12 +432,11 @@ class AtmosphericRiverVariables(DerivedVariable):
             "integrated_vapor_transport",
             "atmospheric_river_land_intersection",
         ],
-        
     ):
         """Initialize the AtmosphericRiverVariables variable.
 
         Args:
-            top_pressure_level: The top pressure level to compute integrated variables 
+            top_pressure_level: The top pressure level to compute integrated variables
                 for. Defaults to 300 hPa.
             output_variables: Optional list of variable names that specify
                 which outputs to use from the derived computation.
@@ -451,9 +450,7 @@ class AtmosphericRiverVariables(DerivedVariable):
         """Derive the atmospheric river mask and land intersection."""
 
         # Subset the data to the top pressure level
-        data = data.sel(
-            level=data.level[data.level >= self.top_pressure_level]
-        )
+        data = data.sel(level=data.level[data.level >= self.top_pressure_level])
 
         # Generate IVT
         ivt_data = ar.integrated_vapor_transport(
@@ -466,7 +463,9 @@ class AtmosphericRiverVariables(DerivedVariable):
         ivt_laplacian = ar.integrated_vapor_transport_laplacian(ivt=ivt_data, sigma=3)
 
         # Compute AR mask with default parameters
-        ar_mask_result = ar.atmospheric_river_mask(ivt=ivt_data, ivt_laplacian=ivt_laplacian)
+        ar_mask_result = ar.atmospheric_river_mask(
+            ivt=ivt_data, ivt_laplacian=ivt_laplacian
+        )
 
         # Compute land intersection
         land_intersection = calc.find_land_intersection(ar_mask_result)

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -425,26 +425,59 @@ class AtmosphericRiverVariables(DerivedVariable):
 
     def __init__(
         self,
+        name: str = "atmospheric_river",
+        top_pressure_level: int = 300,
         output_variables: Optional[List[str]] = [
             "atmospheric_river_mask",
             "integrated_vapor_transport",
             "atmospheric_river_land_intersection",
         ],
-        name: Optional[str] = "atmospheric_river",
+        
     ):
         """Initialize the AtmosphericRiverVariables variable.
 
         Args:
+            top_pressure_level: The top pressure level to compute integrated variables 
+                for. Defaults to 300 hPa.
             output_variables: Optional list of variable names that specify
                 which outputs to use from the derived computation.
             name: The name of the derived variable. Defaults to class-level
                 name attribute if present, otherwise the class name.
         """
         super().__init__(output_variables=output_variables, name=name)
+        self.top_pressure_level = top_pressure_level
 
     def derive_variable(self, data: xr.Dataset, *args, **kwargs) -> xr.Dataset:
         """Derive the atmospheric river mask and land intersection."""
-        return ar.build_atmospheric_river_mask_and_land_intersection(data)
+
+        # Subset the data to the top pressure level
+        data = data.sel(
+            level=data.level[data.level >= self.top_pressure_level]
+        )
+
+        # Generate IVT
+        ivt_data = ar.integrated_vapor_transport(
+            specific_humidity=data["specific_humidity"],
+            eastward_wind=data["eastward_wind"],
+            northward_wind=data["northward_wind"],
+        )
+
+        # Compute IVT Laplacian
+        ivt_laplacian = ar.integrated_vapor_transport_laplacian(ivt=ivt_data, sigma=3)
+
+        # Compute AR mask with default parameters
+        ar_mask_result = ar.atmospheric_river_mask(ivt=ivt_data, ivt_laplacian=ivt_laplacian)
+
+        # Compute land intersection
+        land_intersection = calc.find_land_intersection(ar_mask_result)
+
+        return xr.Dataset(
+            {
+                "atmospheric_river_mask": ar_mask_result,
+                "atmospheric_river_land_intersection": land_intersection,
+                "integrated_vapor_transport": ivt_data,
+            }
+        )
 
 
 def maybe_derive_variables(


### PR DESCRIPTION
# EWB Pull Request

## Description

This PR does two quick changes:

1. Trims the upper levels out of the AR calculations which are negligible to total IVT (as detailed in Mo 2024)

2. Moves the steps in the function `build_atmospheric_river_mask_and_land_intersection` explicitly into the `derive_variable` method for atmospheric rivers to make it somewhat easier to trace.

## Type of change

- [x] Refactor
- [x] New feature
- [x] Chore

## How Has This Been Tested?

`applied_ar.py` was run as well as tests and pre-commit to ensure formatting and typing works as expected.