### PR TITLE
Avoid dask-backed array failure in EarlySignal

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1083,9 +1083,11 @@ class EarlySignal(BaseMetric):
         )
 
         # Only assess forecast where target detects the event (value == 1);
-        # locations where target is 0 or NaN are excluded
+        # locations where target is 0 or NaN are set to NaN (not dropped).
+        # drop=True uses boolean dask indexing which is unsupported; NaN
+        # values are handled correctly by _apply_aggregation downstream.
         forecast_detection_mask = forecast_detection_mask.where(
-            target_detection_mask == 1, drop=True
+            target_detection_mask == 1
         )
 
         # Create lists of dimensions to reduce

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3679,3 +3679,24 @@ class TestEarlySignal:
             )
             result = m._compute_metric(forecast, target)
             assert bool(result.values), f"Expected True for order={order}"
+
+    def test_compute_metric_works_with_dask_backed_arrays(self):
+        """_compute_metric must not raise on dask-backed inputs.
+
+        drop=True in xr.DataArray.where() uses boolean indexing which
+        is unsupported for dask arrays; drop=False avoids this.
+        """
+        pytest.importorskip("dask.array")
+
+        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[0.0, 1.0]],
+        )
+        forecast_dask = forecast.chunk({"valid_time": 1, "space": 1})
+        target_dask = target.chunk({"valid_time": 1, "space": 1})
+
+        result = m._compute_metric(forecast_dask, target_dask)
+        result_computed = result.compute()
+        # space=0 excluded (target=0); space=1: forecast=0.1 < 0.5 → False
+        assert not bool(result_computed.any().values)


### PR DESCRIPTION
# EWB Pull Request

## Description

We had set up a `drop=True` that triggered boolean comparison inside `EarlySignal` which wasn't necessary. This PR removes that argument and tests to ensure dask-backed arrays function as intended.

## Type of change
- [x] Bug fix

## How Has This Been Tested?

A new test has been included and existing tests pass.