### PR TITLE
Add preprocess func for heatwaves to remove ocean gridpoints

### DIFF
--- a/docs/examples/applied_heatwave.py
+++ b/docs/examples/applied_heatwave.py
@@ -29,6 +29,7 @@ hres_forecast = ewb.forecasts.ZarrForecast(
     source="gs://weatherbench2/datasets/hres/2016-2022-0012-1440x721.zarr",
     variables=["surface_air_temperature"],
     variable_mapping=ewb.HRES_metadata_variable_mapping,
+    preprocess_func=ewb.defaults.preprocess_hres_heatwave_forecast_dataset,
 )
 
 # Load the climatology for DurationMeanError

--- a/docs/examples/applied_heatwave.py
+++ b/docs/examples/applied_heatwave.py
@@ -29,7 +29,7 @@ hres_forecast = ewb.forecasts.ZarrForecast(
     source="gs://weatherbench2/datasets/hres/2016-2022-0012-1440x721.zarr",
     variables=["surface_air_temperature"],
     variable_mapping=ewb.HRES_metadata_variable_mapping,
-    preprocess=ewb.defaults.preprocess_hres_heatwave_forecast_dataset,
+    preprocess=ewb.defaults.preprocess_heatwave_forecast_dataset,
 )
 
 # Load the climatology for DurationMeanError

--- a/docs/examples/applied_heatwave.py
+++ b/docs/examples/applied_heatwave.py
@@ -29,7 +29,7 @@ hres_forecast = ewb.forecasts.ZarrForecast(
     source="gs://weatherbench2/datasets/hres/2016-2022-0012-1440x721.zarr",
     variables=["surface_air_temperature"],
     variable_mapping=ewb.HRES_metadata_variable_mapping,
-    preprocess_func=ewb.defaults.preprocess_hres_heatwave_forecast_dataset,
+    preprocess=ewb.defaults.preprocess_hres_heatwave_forecast_dataset,
 )
 
 # Load the climatology for DurationMeanError

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -4,7 +4,7 @@ import operator
 import numpy as np
 import xarray as xr
 
-from extremeweatherbench import calc, derived, inputs
+from extremeweatherbench import calc, derived, inputs, utils
 
 # Suppress noisy log messages
 logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
@@ -56,6 +56,34 @@ DEFAULT_VARIABLE_NAMES = [
     "wind_from_direction",  # degrees (from, not to)
     "wind_speed",  # m/s
 ]
+
+
+def preprocess_cira_icechunk_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """A preprocess function for CIRA icechunk data that removes ocean gridpoints for
+    heatwave events.
+
+    Args:
+        ds: The forecast dataset.
+
+    Returns:
+        The forecast dataset with ocean gridpoints removed.
+    """
+    ds = utils.remove_ocean_gridpoints(ds)
+    return ds
+
+
+def preprocess_hres_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """Preprocess HRES data from the WeatherBench store that removes ocean gridpoints
+    for heatwave events.
+    Args:
+        ds: The forecast dataset to rename.
+
+    Returns:
+        The forecast dataset with ocean gridpoints removed.
+    """
+
+    ds = utils.remove_ocean_gridpoints(ds)
+    return ds
 
 
 def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -58,28 +58,13 @@ DEFAULT_VARIABLE_NAMES = [
 ]
 
 
-def preprocess_cira_icechunk_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
-    """A preprocess function for CIRA icechunk data that removes ocean gridpoints for
-    heatwave events.
-
+def preprocess_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """Preprocess forecast data that removes ocean gridpoints for heatwave events.
     Args:
         ds: The forecast dataset.
 
     Returns:
-        The forecast dataset with ocean gridpoints removed.
-    """
-    ds = utils.remove_ocean_gridpoints(ds)
-    return ds
-
-
-def preprocess_hres_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
-    """Preprocess HRES data from the WeatherBench store that removes ocean gridpoints
-    for heatwave events.
-    Args:
-        ds: The forecast dataset to rename.
-
-    Returns:
-        The forecast dataset with ocean gridpoints removed.
+        The forecast dataset with ocean gridpoints removed for heatwave events.
     """
 
     ds = utils.remove_ocean_gridpoints(ds)


### PR DESCRIPTION
# EWB Pull Request

## Description

For heatwaves, we determined it's better to not include ocean gridpoints when doing the calculations. This PR adds this requirement in as a preprocessing function, now available in `defaults.py`.

Running it on an 80-core VM shows about a ~15-20% slowdown with this extra command added to the DAG. Not terrible, but something to note.

## Type of change

- [x] New feature
- [x] Chore

## How Has This Been Tested?

Ran `applied_heatwave.py` to confirm functionality without issue.