### PR TITLE
Add `overlap_target_threshold` to `EarlySignal`

### DIFF
--- a/docs/examples/applied_severe.py
+++ b/docs/examples/applied_severe.py
@@ -40,7 +40,7 @@ pph_metrics = [
         forecast_threshold=15000,
         target_threshold=0.3,
     ),
-    ewb.metrics.EarlySignal(threshold=15000),
+    ewb.metrics.EarlySignal(forecast_threshold=15000),
 ]
 
 # Define LSR metrics as thresholdmetric to share scores contingency table

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -373,7 +373,7 @@ def get_brightband_evaluation_objects() -> list[inputs.EvaluationObject]:
             forecast_threshold=15000,
             target_threshold=0.3,
         ),
-        metrics.EarlySignal(threshold=15000),
+        metrics.EarlySignal(forecast_threshold=15000),
     ]
 
     # Define LSR metrics as thresholdmetric to share scores contingency table

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -997,7 +997,8 @@ class EarlySignal(BaseMetric):
         comparison_operator: Union[
             Callable, Literal[">", ">=", "<", "<=", "==", "!="]
         ] = ">=",
-        threshold: float = 0.5,
+        forecast_threshold: float = 0.5,
+        overlap_target_threshold: float | None = None,
         spatial_aggregation: Literal["any", "all", "half"] = "any",
         temporal_aggregation: Literal["any", "all", "half"] = "any",
         aggregation_order: tuple[
@@ -1010,7 +1011,9 @@ class EarlySignal(BaseMetric):
         Args:
             name: The name of the metric. Defaults to "EarlySignal".
             comparison_operator: The comparison operator for signal detection.
-            threshold: The threshold value for signal detection.
+            forecast_threshold: The threshold value for signal detection.
+            overlap_target_threshold: The target threshold for signal detection if
+                target is meant to overlap. Defaults to None for no overlap applied.
             spatial_aggregation: Spatial aggregation method. Options: "any"
                 (any gridpoint meets criteria), "all" (all gridpoints meet
                 criteria), or "half" (at least half meet criteria).
@@ -1023,7 +1026,8 @@ class EarlySignal(BaseMetric):
         """
         super().__init__(name=name, **kwargs)
         self.comparison_operator = utils.maybe_get_operator(comparison_operator)
-        self.threshold = threshold
+        self.forecast_threshold = forecast_threshold
+        self.overlap_target_threshold = overlap_target_threshold
         self.spatial_aggregation = spatial_aggregation
         self.temporal_aggregation = temporal_aggregation
         self.aggregation_order = aggregation_order
@@ -1076,19 +1080,20 @@ class EarlySignal(BaseMetric):
 
         # Create detection masks with nans preserved
         forecast_detection_mask = self.comparison_operator(
-            forecast, self.threshold
+            forecast, self.forecast_threshold
         ).where(~forecast.isnull())
-        target_detection_mask = self.comparison_operator(target, self.threshold).where(
-            ~target.isnull()
-        )
+        if self.overlap_target_threshold:
+            target_detection_mask = self.comparison_operator(
+                target, self.overlap_target_threshold
+            ).where(~target.isnull())
 
-        # Only assess forecast where target detects the event (value == 1);
-        # locations where target is 0 or NaN are set to NaN (not dropped).
-        # drop=True uses boolean dask indexing which is unsupported; NaN
-        # values are handled correctly by _apply_aggregation downstream.
-        forecast_detection_mask = forecast_detection_mask.where(
-            target_detection_mask == 1
-        )
+            # Only assess forecast where target detects the event (value == 1);
+            # locations where target is 0 or NaN are set to NaN (not dropped).
+            # drop=True uses boolean dask indexing which is unsupported; NaN
+            # values are handled correctly by _apply_aggregation downstream.
+            forecast_detection_mask = forecast_detection_mask.where(
+                target_detection_mask == 1
+            )
 
         # Create lists of dimensions to reduce
         spatial_dims = [

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -163,7 +163,7 @@ class TestGoldenTests:
                 forecast_threshold=15000,
                 target_threshold=0.3,
             ),
-            metrics.EarlySignal(threshold=15000),
+            metrics.EarlySignal(forecast_threshold=15000),
         ]
         severe_convection_evaluation_objects = [
             inputs.EvaluationObject(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3496,7 +3496,8 @@ class TestEarlySignal:
     def test_default_init(self):
         """Default EarlySignal has expected attribute values."""
         m = self._make_metric()
-        assert m.threshold == 0.5
+        assert m.forecast_threshold == 0.5
+        assert m.overlap_target_threshold is None
         assert m.spatial_aggregation == "any"
         assert m.temporal_aggregation == "any"
         assert m.aggregation_order == ("spatial", "temporal")
@@ -3504,12 +3505,14 @@ class TestEarlySignal:
     def test_custom_init(self):
         """Custom params are stored correctly."""
         m = self._make_metric(
-            threshold=1.0,
+            forecast_threshold=1.0,
+            overlap_target_threshold=0.8,
             spatial_aggregation="all",
             temporal_aggregation="half",
             aggregation_order=("temporal", "spatial"),
         )
-        assert m.threshold == 1.0
+        assert m.forecast_threshold == 1.0
+        assert m.overlap_target_threshold == 0.8
         assert m.spatial_aggregation == "all"
         assert m.temporal_aggregation == "half"
         assert m.aggregation_order == ("temporal", "spatial")
@@ -3602,7 +3605,11 @@ class TestEarlySignal:
 
     def test_compute_metric_target_zero_excluded(self):
         """Forecast not evaluated at locations where target is 0."""
-        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
         # target row 0: all 0 → excluded; row 1: all 1 → included
         # forecast row 1: all above threshold → should detect
         forecast, target = self._make_forecast_target(
@@ -3615,7 +3622,11 @@ class TestEarlySignal:
 
     def test_compute_metric_target_nan_excluded(self):
         """Forecast not evaluated where target is NaN."""
-        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
         # Only target==1 at space=1, t=0; forecast is below threshold there
         forecast, target = self._make_forecast_target(
             forecast_vals=[[0.9, 0.1]],
@@ -3627,7 +3638,11 @@ class TestEarlySignal:
 
     def test_compute_metric_only_target_one_locations_matter(self):
         """High forecast values at target==0 locations don't trigger True."""
-        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
         # target: space=0 → 0 (excluded), space=1 → 1 (included)
         # forecast: space=0 → 0.9 (would fire if not masked), space=1 → 0.1
         forecast, target = self._make_forecast_target(
@@ -3676,27 +3691,216 @@ class TestEarlySignal:
                 spatial_aggregation="any",
                 temporal_aggregation="any",
                 aggregation_order=order,
+                overlap_target_threshold=0.5,
             )
             result = m._compute_metric(forecast, target)
             assert bool(result.values), f"Expected True for order={order}"
 
-    def test_compute_metric_works_with_dask_backed_arrays(self):
-        """_compute_metric must not raise on dask-backed inputs.
+    def test_no_target_masking_when_overlap_target_threshold_is_none(self):
+        """Without overlap_target_threshold, all forecast locations count."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=None,
+            spatial_aggregation="any",
+        )
+        # target is all 0, but with no overlap threshold
+        # the target is ignored and forecast is evaluated everywhere
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9]],
+            target_vals=[[0.0, 0.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert bool(result.any().values)
 
-        drop=True in xr.DataArray.where() uses boolean indexing which
-        is unsupported for dask arrays; drop=False avoids this.
-        """
-        pytest.importorskip("dask.array")
+    def test_target_masking_applied_when_overlap_target_threshold_set(self):
+        """With overlap_target_threshold, target==0 locations are excluded."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
+        # Same data as above but now overlap is enforced;
+        # target is all 0 so all forecast locations are masked → False
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9]],
+            target_vals=[[0.0, 0.0]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert not bool(result.any().values)
 
-        m = self._make_metric(threshold=0.5, spatial_aggregation="any")
+    def test_overlap_target_threshold_differs_from_forecast_threshold(self):
+        """overlap_target_threshold can be different from forecast_threshold."""
+        m = self._make_metric(
+            forecast_threshold=0.3,
+            overlap_target_threshold=0.8,
+            spatial_aggregation="any",
+        )
+        # target value 0.7 is below overlap_target_threshold 0.8 → masked
+        # target value 0.9 is above → included; forecast 0.5 >= 0.3 → True
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.5, 0.5]],
+            target_vals=[[0.7, 0.9]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert bool(result.any().values)
+
+    def test_overlap_target_threshold_high_excludes_low_target(self):
+        """High overlap_target_threshold excludes moderate target values."""
+        m = self._make_metric(
+            forecast_threshold=0.3,
+            overlap_target_threshold=0.8,
+            spatial_aggregation="all",
+        )
+        # target 0.7 fails overlap threshold (0.8) → masked to NaN
+        # target 0.9 passes → included; forecast 0.5 >= 0.3 → True
+        # With "all" aggregation, NaN is filled True so result is True
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.5, 0.5]],
+            target_vals=[[0.7, 0.9]],
+        )
+        result = m._compute_metric(forecast, target)
+        assert bool(result.any().values)
+
+        # Now both targets below overlap threshold → all masked, no signal
+        # "all" over all-NaN fillna(True) → True (vacuous truth)
+        forecast2, target2 = self._make_forecast_target(
+            forecast_vals=[[0.5, 0.5]],
+            target_vals=[[0.1, 0.2]],
+        )
+        result2 = m._compute_metric(forecast2, target2)
+        assert bool(result2.any().values)
+
+    def test_no_overlap_ignores_target_values_entirely(self):
+        """With no overlap, forecast detection is independent of target."""
+        m_no_overlap = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=None,
+            spatial_aggregation="any",
+        )
+        m_overlap = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
+        # forecast high at space=0, low at space=1
+        # target 0 at space=0, 1 at space=1
         forecast, target = self._make_forecast_target(
             forecast_vals=[[0.9, 0.1]],
             target_vals=[[0.0, 1.0]],
         )
-        forecast_dask = forecast.chunk({"valid_time": 1, "space": 1})
-        target_dask = target.chunk({"valid_time": 1, "space": 1})
+        # No overlap: forecast=0.9 at space=0 fires → True
+        result_no = m_no_overlap._compute_metric(forecast, target)
+        assert bool(result_no.any().values)
 
-        result = m._compute_metric(forecast_dask, target_dask)
-        result_computed = result.compute()
-        # space=0 excluded (target=0); space=1: forecast=0.1 < 0.5 → False
-        assert not bool(result_computed.any().values)
+        # With overlap: space=0 masked (target=0), space=1 forecast=0.1 → False
+        result_yes = m_overlap._compute_metric(forecast, target)
+        assert not bool(result_yes.any().values)
+
+    @staticmethod
+    def _to_backend(forecast, target, backend):
+        """Convert numpy-backed DataArrays to the requested backend."""
+        if backend == "numpy":
+            return forecast, target
+        elif backend == "dask":
+            return (
+                forecast.chunk({"valid_time": 1, "space": 1}),
+                target.chunk({"valid_time": 1, "space": 1}),
+            )
+        elif backend == "sparse":
+            return (
+                forecast.copy(data=sparse.COO.from_numpy(forecast.values)),
+                target.copy(data=sparse.COO.from_numpy(target.values)),
+            )
+        raise ValueError(f"Unknown backend: {backend}")
+
+    @staticmethod
+    def _resolve(result):
+        """Compute dask results; pass through numpy/sparse."""
+        if hasattr(result, "compute"):
+            return result.compute()
+        return result
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask", "sparse"])
+    def test_no_overlap_across_backends(self, backend):
+        """Without overlap, forecast fires at all locations."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=None,
+            spatial_aggregation="any",
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[0.0, 1.0]],
+        )
+        f, t = self._to_backend(forecast, target, backend)
+        result = self._resolve(m._compute_metric(f, t))
+        # No overlap: space=0 forecast=0.9 >= 0.5 → True
+        assert bool(result.any().values)
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask", "sparse"])
+    def test_overlap_masking_across_backends(self, backend):
+        """With overlap, target==0 locations are excluded."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[0.0, 1.0]],
+        )
+        f, t = self._to_backend(forecast, target, backend)
+        result = self._resolve(m._compute_metric(f, t))
+        # space=0 excluded (target=0); space=1: f=0.1 < 0.5 → False
+        assert not bool(result.any().values)
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask", "sparse"])
+    def test_overlap_detection_across_backends(self, backend):
+        """With overlap enabled, high forecast at target==1 fires."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.9]],
+            target_vals=[[1.0, 1.0]],
+        )
+        f, t = self._to_backend(forecast, target, backend)
+        result = self._resolve(m._compute_metric(f, t))
+        assert bool(result.any().values)
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask", "sparse"])
+    def test_different_thresholds_across_backends(self, backend):
+        """Separate forecast and target thresholds work on all backends."""
+        m = self._make_metric(
+            forecast_threshold=0.3,
+            overlap_target_threshold=0.8,
+            spatial_aggregation="any",
+        )
+        # target 0.7 < 0.8 → masked; target 0.9 >= 0.8 → kept
+        # forecast 0.5 >= 0.3 at kept location → True
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.5, 0.5]],
+            target_vals=[[0.7, 0.9]],
+        )
+        f, t = self._to_backend(forecast, target, backend)
+        result = self._resolve(m._compute_metric(f, t))
+        assert bool(result.any().values)
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask", "sparse"])
+    def test_nan_target_across_backends(self, backend):
+        """NaN in target is handled correctly on all backends."""
+        m = self._make_metric(
+            forecast_threshold=0.5,
+            overlap_target_threshold=0.5,
+            spatial_aggregation="any",
+        )
+        forecast, target = self._make_forecast_target(
+            forecast_vals=[[0.9, 0.1]],
+            target_vals=[[np.nan, 1.0]],
+        )
+        f, t = self._to_backend(forecast, target, backend)
+        result = self._resolve(m._compute_metric(f, t))
+        # space=0 excluded (NaN); space=1: f=0.1 < 0.5 → False
+        assert not bool(result.any().values)


### PR DESCRIPTION
# EWB Pull Request

## Description

Oh boy, `EarlySignal` is fun. We use it for AR's and severe convective cases. Because AR's version is focused on overlap between ERA5 and the forecast data, it's important to include an option that emphasizes the signal only over the intersection of target and forecast data. That originally wasn't the case for severe convection, which caused the metric to always return `False`. 

Now, we provide the option with `overlap_target_threshold` to accomplish two objectives:

1. If left to its default, `None`, the metric computes the signal over the bounding box and timeframe of the case.

2. If provided a threshold (only a `float` for now, though a DataArray could be an option in the future), it will use that for the target data to use as an intersection to compute the signal for the forecast over. 

Some examples: 

For the AR mask, using `overlap_target_threshold` of 0.5 with a `comparison_operator = '>='`, i.e.:

```python
ewb.metrics.EarlySignal(
comparison_operator=">=",
forecast_threshold=0.5,
overlap_target_threshold=0.5
)
```

will select all True locations in the target to compare the forecast over.


For severe's comparison between CBSS and PPH, using `forecast_threshold=15000` and `overlap_target_threshold=0.3`, i.e.:

```python
ewb.metrics.EarlySignal(
comparison_operator=">=",
forecast_threshold=15000,
overlap_target_threshold=0.3
)
```

will use the intersection of CBSS and PPH to determine if the signal is there.

## Type of change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

New tests were added to confirm functionality for numpy, dask, and sparse arrays. Existing tests pass.