### PR TITLE
Add NetCDF cache format support to evaluation pipeline

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -4,7 +4,7 @@ import copy
 import dataclasses
 import logging
 import pathlib
-from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
 
 import dask.array as da
 import joblib
@@ -21,6 +21,7 @@ import extremeweatherbench.inputs as inputs
 import extremeweatherbench.metrics as metrics
 import extremeweatherbench.sources as sources
 import extremeweatherbench.utils as utils
+from extremeweatherbench.utils import CacheFormat
 
 if TYPE_CHECKING:
     import extremeweatherbench.regions as regions
@@ -66,7 +67,7 @@ class ExtremeWeatherBench:
         case_metadata: Union[list[dict[str, Any]], "list[cases.IndividualCase]"],
         evaluation_objects: list["inputs.EvaluationObject"],
         cache_dir: Optional[Union[str, pathlib.Path]] = None,
-        cache_format: Literal["zarr", "netcdf"] = "zarr",
+        cache_format: CacheFormat = "zarr",
         region_subsetter: Optional["regions.RegionSubsetter"] = None,
     ):
         """Initialize the ExtremeWeatherBench workflow.
@@ -238,7 +239,7 @@ def _parallel_serial_config_check(
 def _run_evaluation(
     case_operators: list["cases.CaseOperator"],
     cache_dir: Optional[pathlib.Path] = None,
-    cache_format: Literal["zarr", "netcdf"] = "zarr",
+    cache_format: CacheFormat = "zarr",
     parallel_config: Optional[dict] = None,
     **kwargs,
 ) -> list[pd.DataFrame]:
@@ -246,7 +247,7 @@ def _run_evaluation(
 
     Args:
         case_operators: List of case operators to run.
-        cache_dir: Optional directory for caching (serial mode only).
+        cache_dir: Optional directory for caching intermediate data.
         cache_format: Format for cached intermediate data. "zarr" (default)
             uses Zarr archives, "netcdf" uses NetCDF (.nc) files.
         parallel_config: Optional dict of joblib parallel configuration.
@@ -271,7 +272,7 @@ def _run_evaluation(
         for case_operator in tqdm(case_operators):
             run_results.append(
                 compute_case_operator(
-                    case_operator, cache_dir, cache_format=cache_format, **kwargs
+                    case_operator, cache_dir=cache_dir, cache_format=cache_format, **kwargs
                 )
             )
 
@@ -282,7 +283,7 @@ def _run_parallel_evaluation(
     case_operators: list["cases.CaseOperator"],
     parallel_config: dict,
     cache_dir: Optional[pathlib.Path] = None,
-    cache_format: Literal["zarr", "netcdf"] = "zarr",
+    cache_format: CacheFormat = "zarr",
     **kwargs,
 ) -> list[pd.DataFrame]:
     """Run the case operators in parallel.
@@ -326,7 +327,6 @@ def _run_parallel_evaluation(
         # TODO(198): return a generator and compute at a higher level
         with joblib.parallel_config(**parallel_config):
             run_results = utils.ParallelTqdm(total_tasks=len(case_operators))(
-                # None is the cache_dir, we can't cache in parallel mode
                 joblib.delayed(compute_case_operator)(
                     case_operator,
                     cache_dir=cache_dir,
@@ -346,7 +346,7 @@ def _run_parallel_evaluation(
 def compute_case_operator(
     case_operator: "cases.CaseOperator",
     cache_dir: Optional[pathlib.Path] = None,
-    cache_format: Literal["zarr", "netcdf"] = "zarr",
+    cache_format: CacheFormat = "zarr",
     **kwargs,
 ) -> pd.DataFrame:
     """Compute the resulting evaluation of a case operator.

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -4,7 +4,7 @@ import copy
 import dataclasses
 import logging
 import pathlib
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union
 
 import dask.array as da
 import joblib
@@ -54,6 +54,8 @@ class ExtremeWeatherBench:
         evaluation_objects: A list of evaluation objects to run.
         cache_dir: An optional directory to cache the mid-flight outputs of the
             workflow for serial runs.
+        cache_format: The format for cached intermediate data. "zarr" (default) uses
+            Zarr archives, "netcdf" uses NetCDF (.nc) files.
         region_subsetter: An optional region subsetter to subset the cases that are
             part of the evaluation to a Region object or a dictionary of lat/lon
             bounds.
@@ -64,6 +66,7 @@ class ExtremeWeatherBench:
         case_metadata: Union[list[dict[str, Any]], "list[cases.IndividualCase]"],
         evaluation_objects: list["inputs.EvaluationObject"],
         cache_dir: Optional[Union[str, pathlib.Path]] = None,
+        cache_format: Literal["zarr", "netcdf"] = "zarr",
         region_subsetter: Optional["regions.RegionSubsetter"] = None,
     ):
         """Initialize the ExtremeWeatherBench workflow.
@@ -73,6 +76,8 @@ class ExtremeWeatherBench:
             evaluation_objects: List of evaluation objects to run.
             cache_dir: Optional directory for caching mid-flight outputs in
                 serial runs.
+            cache_format: Format for cached intermediate data. "zarr" (default)
+                uses Zarr archives, "netcdf" uses NetCDF (.nc) files.
             region_subsetter: Optional RegionSubsetter to filter cases by
                 spatial region.
         """
@@ -80,6 +85,7 @@ class ExtremeWeatherBench:
         self.case_metadata = cases.load_individual_cases(case_metadata)
         self.evaluation_objects = evaluation_objects
         self.cache_dir = pathlib.Path(cache_dir) if cache_dir else None
+        self.cache_format = cache_format
 
         # Instantiate cache dir if needed
         if self.cache_dir:
@@ -132,6 +138,7 @@ class ExtremeWeatherBench:
         run_results = _run_evaluation(
             self.case_operators,
             cache_dir=self.cache_dir,
+            cache_format=self.cache_format,
             parallel_config=parallel_config,
             **kwargs,
         )
@@ -174,6 +181,7 @@ class ExtremeWeatherBench:
         run_results = _run_evaluation(
             self.case_operators,
             cache_dir=self.cache_dir,
+            cache_format=self.cache_format,
             parallel_config=parallel_config,
             **kwargs,
         )
@@ -230,6 +238,7 @@ def _parallel_serial_config_check(
 def _run_evaluation(
     case_operators: list["cases.CaseOperator"],
     cache_dir: Optional[pathlib.Path] = None,
+    cache_format: Literal["zarr", "netcdf"] = "zarr",
     parallel_config: Optional[dict] = None,
     **kwargs,
 ) -> list[pd.DataFrame]:
@@ -238,6 +247,8 @@ def _run_evaluation(
     Args:
         case_operators: List of case operators to run.
         cache_dir: Optional directory for caching (serial mode only).
+        cache_format: Format for cached intermediate data. "zarr" (default)
+            uses Zarr archives, "netcdf" uses NetCDF (.nc) files.
         parallel_config: Optional dict of joblib parallel configuration.
         **kwargs: Additional keyword arguments passed to case operators.
 
@@ -250,6 +261,7 @@ def _run_evaluation(
             run_results = _run_parallel_evaluation(
                 case_operators,
                 cache_dir=cache_dir,
+                cache_format=cache_format,
                 parallel_config=parallel_config,
                 **kwargs,
             )
@@ -258,7 +270,9 @@ def _run_evaluation(
         run_results = []
         for case_operator in tqdm(case_operators):
             run_results.append(
-                compute_case_operator(case_operator, cache_dir, **kwargs)
+                compute_case_operator(
+                    case_operator, cache_dir, cache_format=cache_format, **kwargs
+                )
             )
 
     return run_results
@@ -268,13 +282,18 @@ def _run_parallel_evaluation(
     case_operators: list["cases.CaseOperator"],
     parallel_config: dict,
     cache_dir: Optional[pathlib.Path] = None,
+    cache_format: Literal["zarr", "netcdf"] = "zarr",
     **kwargs,
 ) -> list[pd.DataFrame]:
     """Run the case operators in parallel.
 
     Args:
         case_operators: List of case operators to run.
-        **kwargs: Additional arguments, must include 'parallel_config' dict.
+        parallel_config: Dictionary of joblib parallel configuration.
+        cache_dir: Optional directory for caching intermediate data.
+        cache_format: Format for cached intermediate data. "zarr" (default)
+            uses Zarr archives, "netcdf" uses NetCDF (.nc) files.
+        **kwargs: Additional keyword arguments passed to case operators.
 
     Returns:
         List of result DataFrames.
@@ -309,7 +328,10 @@ def _run_parallel_evaluation(
             run_results = utils.ParallelTqdm(total_tasks=len(case_operators))(
                 # None is the cache_dir, we can't cache in parallel mode
                 joblib.delayed(compute_case_operator)(
-                    case_operator, cache_dir=cache_dir, **kwargs
+                    case_operator,
+                    cache_dir=cache_dir,
+                    cache_format=cache_format,
+                    **kwargs,
                 )
                 for case_operator in case_operators
             )
@@ -324,6 +346,7 @@ def _run_parallel_evaluation(
 def compute_case_operator(
     case_operator: "cases.CaseOperator",
     cache_dir: Optional[pathlib.Path] = None,
+    cache_format: Literal["zarr", "netcdf"] = "zarr",
     **kwargs,
 ) -> pd.DataFrame:
     """Compute the resulting evaluation of a case operator.
@@ -337,6 +360,8 @@ def compute_case_operator(
     Args:
         case_operator: The case operator to compute the results of.
         cache_dir: The directory to cache mid-flight outputs (serial mode).
+        cache_format: Format for cached intermediate data. "zarr" (default)
+            uses Zarr archives, "netcdf" uses NetCDF (.nc) files.
 
     Returns:
         A pd.DataFrame of results from the case operator.
@@ -377,11 +402,13 @@ def compute_case_operator(
     aligned_forecast_ds = utils.maybe_cache_and_compute(
         aligned_forecast_ds,
         cache_dir=cache_dir,
+        cache_format=cache_format,
         name=f"{case_operator.case_metadata.case_id_number}_{case_operator.forecast.name}",
     )
     aligned_target_ds = utils.maybe_cache_and_compute(
         aligned_target_ds,
         cache_dir=cache_dir,
+        cache_format=cache_format,
         name=f"{case_operator.case_metadata.case_id_number}_{case_operator.target.name}",
     )
     logger.info(

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -2,7 +2,7 @@ import importlib.util
 import os
 import pathlib
 import pickle
-from typing import Literal, Optional
+from typing import Optional
 
 import click
 import pandas as pd
@@ -10,6 +10,7 @@ import pandas as pd
 import extremeweatherbench.cases as cases
 import extremeweatherbench.defaults as defaults
 import extremeweatherbench.evaluate as evaluate
+from extremeweatherbench.utils import CacheFormat
 
 
 @click.command()
@@ -38,7 +39,7 @@ import extremeweatherbench.evaluate as evaluate
     type=click.Choice(["zarr", "netcdf"], case_sensitive=False),
     default="zarr",
     show_default=True,
-    help="Format for cached intermediate data (default: zarr)",
+    help="Format for cached intermediate data",
 )
 @click.option(
     "--n-jobs",
@@ -68,7 +69,7 @@ def cli_runner(
     config_file: Optional[str],
     output_dir: Optional[str],
     cache_dir: Optional[str],
-    cache_format: Literal["zarr", "netcdf"],
+    cache_format: CacheFormat,
     n_jobs: int,
     parallel_config: Optional[dict],
     save_case_operators: Optional[str],
@@ -112,7 +113,7 @@ def cli_runner(
         # Save case operators to pickle file
         $ ewb --default --save-case-operators case_ops.pkl
 
-        # Use custom output and cache directories (cache enables zarr storage)
+        # Use custom output and cache directories (cache enables intermediate data storage)
         $ ewb --default --output-dir ./results --cache-dir ./cache
 
         # Use custom parallel configuration

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -2,7 +2,7 @@ import importlib.util
 import os
 import pathlib
 import pickle
-from typing import Optional
+from typing import Literal, Optional
 
 import click
 import pandas as pd
@@ -34,6 +34,13 @@ import extremeweatherbench.evaluate as evaluate
     help="Optional directory for caching intermediate data",
 )
 @click.option(
+    "--cache-format",
+    type=click.Choice(["zarr", "netcdf"], case_sensitive=False),
+    default="zarr",
+    show_default=True,
+    help="Format for cached intermediate data (default: zarr)",
+)
+@click.option(
     "--n-jobs",
     type=int,
     default=1,
@@ -61,6 +68,7 @@ def cli_runner(
     config_file: Optional[str],
     output_dir: Optional[str],
     cache_dir: Optional[str],
+    cache_format: Literal["zarr", "netcdf"],
     n_jobs: int,
     parallel_config: Optional[dict],
     save_case_operators: Optional[str],
@@ -86,7 +94,9 @@ def cli_runner(
         config_file: Path to a config.py file containing evaluation objects.
         output_dir: Directory for analysis outputs (default: current directory).
         cache_dir: Optional directory for caching intermediate data. When set,
-            datasets or dataarrays are computed and cached as zarrs.
+            datasets or dataarrays are computed and cached in the chosen format.
+        cache_format: Format for cached intermediate data. "zarr" (default) uses
+            Zarr archives, "netcdf" uses NetCDF (.nc) files.
         n_jobs: Number of parallel jobs to run (default: 1 for serial execution).
         parallel_config: Advanced parallel configuration using joblib. Takes
             precedence over n_jobs if provided.
@@ -138,6 +148,7 @@ def cli_runner(
         case_metadata=case_list,
         evaluation_objects=evaluation_objects,
         cache_dir=cache_dir if cache_dir else None,
+        cache_format=cache_format,
     )
 
     # Get case operators

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -805,6 +805,7 @@ def maybe_cache_and_compute(
     data: xr.Dataset | xr.DataArray,
     name: str,
     cache_dir: Optional[Union[str, pathlib.Path]] = None,
+    cache_format: Literal["zarr", "netcdf"] = "zarr",
 ) -> xr.Dataset | xr.DataArray:
     """Compute and cache datasets if cache_dir is provided.
 
@@ -817,13 +818,23 @@ def maybe_cache_and_compute(
         data: The dataset or dataarray to compute and cache.
         name: The name of the dataset for naming cached files.
         cache_dir: The directory to cache the datasets. If provided,
-            datasets or dataarrays will be cached as zarrs and loaded from the cache.
+            datasets or dataarrays will be cached and loaded from the cache.
             Default is None.
+        cache_format: The format to use for cached files. "zarr" uses Zarr
+            archives, "netcdf" uses NetCDF (.nc) files. Default is "zarr".
 
     Returns:
         The computed dataset if cache_dir is set, otherwise the
         original dataset.
+
+    Raises:
+        ValueError: If cache_format is not "zarr" or "netcdf".
     """
+    if cache_format not in ("zarr", "netcdf"):
+        raise ValueError(
+            f"cache_format must be 'zarr' or 'netcdf', got '{cache_format}'"
+        )
+
     # If no caching, return as dataset or dataarray
     if cache_dir is None:
         return data
@@ -831,16 +842,24 @@ def maybe_cache_and_compute(
     # Compute and cache dataset or dataarray
     logger.info("Computing datasets and storing at %s...", cache_dir)
     cache_path = pathlib.Path(cache_dir)
+    ext = ".zarr" if cache_format == "zarr" else ".nc"
 
     # If the cache file does not exist, maybe densify the data and cache it. Sparse data
-    # must be densified to be stored in zarrs
-    if not (cache_path / f"{name}.zarr").exists():
-        _cache_maybe_densify_helper(data).to_zarr(
-            cache_path / f"{name}.zarr", zarr_format=2, mode="w"
-        )
+    # must be densified to be stored in zarrs or netcdf files.
+    if not (cache_path / f"{name}{ext}").exists():
+        densified = _cache_maybe_densify_helper(data)
+
+        if cache_format == "zarr":
+            densified.to_zarr(cache_path / f"{name}{ext}", zarr_format=2, mode="w")
+        else:
+            # NetCDF requires DataArrays to have a name
+            if isinstance(densified, xr.DataArray) and densified.name is None:
+                densified = densified.copy()
+                densified.name = name
+            densified.to_netcdf(cache_path / f"{name}{ext}")
 
     # Load the data from the cache, matching the type of the input data
     if isinstance(data, xr.Dataset):
-        return xr.open_dataset(cache_path / f"{name}.zarr")
+        return xr.open_dataset(cache_path / f"{name}{ext}")
     else:
-        return xr.open_dataarray(cache_path / f"{name}.zarr")
+        return xr.open_dataarray(cache_path / f"{name}{ext}")

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -22,6 +22,9 @@ from joblib import Parallel
 
 logger = logging.getLogger(__name__)
 
+#: Type alias for the supported cache format options.
+CacheFormat = Literal["zarr", "netcdf"]
+
 operators = {
     ">": operator.gt,
     ">=": operator.ge,
@@ -805,7 +808,7 @@ def maybe_cache_and_compute(
     data: xr.Dataset | xr.DataArray,
     name: str,
     cache_dir: Optional[Union[str, pathlib.Path]] = None,
-    cache_format: Literal["zarr", "netcdf"] = "zarr",
+    cache_format: CacheFormat = "zarr",
 ) -> xr.Dataset | xr.DataArray:
     """Compute and cache datasets if cache_dir is provided.
 
@@ -843,23 +846,24 @@ def maybe_cache_and_compute(
     logger.info("Computing datasets and storing at %s...", cache_dir)
     cache_path = pathlib.Path(cache_dir)
     ext = ".zarr" if cache_format == "zarr" else ".nc"
+    cache_file = cache_path / f"{name}{ext}"
 
     # If the cache file does not exist, maybe densify the data and cache it. Sparse data
     # must be densified to be stored in zarrs or netcdf files.
-    if not (cache_path / f"{name}{ext}").exists():
+    if not cache_file.exists():
         densified = _cache_maybe_densify_helper(data)
 
         if cache_format == "zarr":
-            densified.to_zarr(cache_path / f"{name}{ext}", zarr_format=2, mode="w")
+            densified.to_zarr(cache_file, zarr_format=2, mode="w")
         else:
             # NetCDF requires DataArrays to have a name
             if isinstance(densified, xr.DataArray) and densified.name is None:
                 densified = densified.copy()
                 densified.name = name
-            densified.to_netcdf(cache_path / f"{name}{ext}")
+            densified.to_netcdf(cache_file)
 
     # Load the data from the cache, matching the type of the input data
     if isinstance(data, xr.Dataset):
-        return xr.open_dataset(cache_path / f"{name}{ext}")
+        return xr.open_dataset(cache_file)
     else:
-        return xr.open_dataarray(cache_path / f"{name}{ext}")
+        return xr.open_dataarray(cache_file)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -414,6 +414,45 @@ class TestExtremeWeatherBench:
             assert len(result) == 1
 
     @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_evaluation_with_netcdf_cache_format(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        """Test that cache_format='netcdf' is passed through to _run_evaluation."""
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_result = [
+                pd.DataFrame(
+                    {
+                        "value": [1.0],
+                        "metric": ["MockMetric"],
+                        "case_id_number": [1],
+                    }
+                )
+            ]
+            mock_run_evaluation.return_value = mock_result
+
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+                cache_format="netcdf",
+            )
+
+            result = ewb.run_evaluation(n_jobs=1)
+
+            mock_run_evaluation.assert_called_once_with(
+                [sample_case_operator],
+                cache_dir=None,
+                cache_format="netcdf",
+                parallel_config=None,
+            )
+            assert isinstance(result, pd.DataFrame)
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
     def test_run_with_kwargs(
         self,
         mock_run_evaluation,
@@ -488,12 +527,12 @@ class TestExtremeWeatherBench:
                 )
 
                 # Make the mock also perform caching like the real function would
-                def mock_compute_with_caching(case_operator, cache_dir_arg, **kwargs):
-                    if cache_dir_arg:
+                def mock_compute_with_caching(case_operator, cache_dir=None, **kwargs):
+                    if cache_dir:
                         cache_path = (
-                            pathlib.Path(cache_dir_arg)
-                            if isinstance(cache_dir_arg, str)
-                            else cache_dir_arg
+                            pathlib.Path(cache_dir)
+                            if isinstance(cache_dir, str)
+                            else cache_dir
                         )
                         mock_result.to_pickle(cache_path / "case_results.pkl")
                     return mock_result
@@ -564,10 +603,29 @@ class TestRunCaseOperators:
         result = evaluate._run_evaluation([sample_case_operator], cache_dir=None)
 
         mock_compute_case_operator.assert_called_once_with(
-            sample_case_operator, None, cache_format="zarr"
+            sample_case_operator, cache_dir=None, cache_format="zarr"
         )
         assert len(result) == 1
         assert result[0].equals(mock_results)
+
+    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("tqdm.auto.tqdm")
+    def test_run_evaluation_serial_netcdf(
+        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+    ):
+        """Test _run_evaluation passes cache_format='netcdf' in serial mode."""
+        mock_tqdm.return_value = [sample_case_operator]
+        mock_results = pd.DataFrame({"value": [1.0]})
+        mock_compute_case_operator.return_value = mock_results
+
+        result = evaluate._run_evaluation(
+            [sample_case_operator], cache_dir=None, cache_format="netcdf"
+        )
+
+        mock_compute_case_operator.assert_called_once_with(
+            sample_case_operator, cache_dir=None, cache_format="netcdf"
+        )
+        assert len(result) == 1
 
     @mock.patch("extremeweatherbench.evaluate._run_parallel_evaluation")
     def test_run_evaluation_parallel(
@@ -591,6 +649,29 @@ class TestRunCaseOperators:
         )
         assert result == mock_results
 
+    @mock.patch("extremeweatherbench.evaluate._run_parallel_evaluation")
+    def test_run_evaluation_parallel_netcdf(
+        self, mock_run_parallel_evaluation, sample_case_operator
+    ):
+        """Test _run_evaluation passes cache_format='netcdf' in parallel mode."""
+        mock_results = [pd.DataFrame({"value": [1.0]})]
+        mock_run_parallel_evaluation.return_value = mock_results
+
+        result = evaluate._run_evaluation(
+            [sample_case_operator],
+            cache_dir=None,
+            cache_format="netcdf",
+            parallel_config={"backend": "threading", "n_jobs": 4},
+        )
+
+        mock_run_parallel_evaluation.assert_called_once_with(
+            [sample_case_operator],
+            cache_dir=None,
+            cache_format="netcdf",
+            parallel_config={"backend": "threading", "n_jobs": 4},
+        )
+        assert result == mock_results
+
     @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_evaluation_with_kwargs(
@@ -610,7 +691,7 @@ class TestRunCaseOperators:
 
         call_args = mock_compute_case_operator.call_args
         assert call_args[0][0] == sample_case_operator
-        assert call_args[0][1] is None  # cache_dir
+        assert call_args[1]["cache_dir"] is None
         assert call_args[1]["threshold"] == 0.5
         assert isinstance(result, list)
 
@@ -658,7 +739,7 @@ class TestRunSerial:
         result = evaluate._run_evaluation([sample_case_operator], parallel_config=None)
 
         mock_compute_case_operator.assert_called_once_with(
-            sample_case_operator, None, cache_format="zarr"
+            sample_case_operator, cache_dir=None, cache_format="zarr"
         )
         assert len(result) == 1
         assert result[0].equals(mock_result)
@@ -1059,6 +1140,9 @@ class TestComputeCaseOperator:
 
                 # Called twice: once for forecast, once for target
                 assert mock_compute_cache.call_count == 2
+                # Verify cache_format was passed correctly to both calls
+                for call in mock_compute_cache.call_args_list:
+                    assert call.kwargs["cache_format"] == "zarr"
                 assert isinstance(result, pd.DataFrame)
 
     @mock.patch("extremeweatherbench.evaluate._build_datasets")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -368,6 +368,7 @@ class TestExtremeWeatherBench:
             mock_run_evaluation.assert_called_once_with(
                 [sample_case_operator],
                 cache_dir=None,
+                cache_format="zarr",
                 parallel_config=None,
             )
             assert isinstance(result, pd.DataFrame)
@@ -406,6 +407,7 @@ class TestExtremeWeatherBench:
             mock_run_evaluation.assert_called_once_with(
                 [sample_case_operator],
                 cache_dir=None,
+                cache_format="zarr",
                 parallel_config={"backend": "loky", "n_jobs": 2},
             )
             assert isinstance(result, pd.DataFrame)
@@ -561,7 +563,9 @@ class TestRunCaseOperators:
         # Serial mode: don't pass parallel_config
         result = evaluate._run_evaluation([sample_case_operator], cache_dir=None)
 
-        mock_compute_case_operator.assert_called_once_with(sample_case_operator, None)
+        mock_compute_case_operator.assert_called_once_with(
+            sample_case_operator, None, cache_format="zarr"
+        )
         assert len(result) == 1
         assert result[0].equals(mock_results)
 
@@ -582,6 +586,7 @@ class TestRunCaseOperators:
         mock_run_parallel_evaluation.assert_called_once_with(
             [sample_case_operator],
             cache_dir=None,
+            cache_format="zarr",
             parallel_config={"backend": "threading", "n_jobs": 4},
         )
         assert result == mock_results
@@ -652,7 +657,9 @@ class TestRunSerial:
 
         result = evaluate._run_evaluation([sample_case_operator], parallel_config=None)
 
-        mock_compute_case_operator.assert_called_once_with(sample_case_operator, None)
+        mock_compute_case_operator.assert_called_once_with(
+            sample_case_operator, None, cache_format="zarr"
+        )
         assert len(result) == 1
         assert result[0].equals(mock_result)
 

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -446,6 +446,128 @@ class TestResultsSaving:
         # Output suppressed - only check exit code
 
 
+class TestCacheFormat:
+    """Test --cache-format CLI option."""
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_cache_format_default(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test that default cache_format is zarr."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame({"test": [1, 2]})
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            ["--default", "--output-dir", str(temp_config_dir)],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_ewb_class.call_args[1]
+        assert call_kwargs["cache_format"] == "zarr"
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_cache_format_netcdf_option(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test that --cache-format netcdf is passed through to ExtremeWeatherBench."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame({"test": [1, 2]})
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--cache-format",
+                "netcdf",
+                "--output-dir",
+                str(temp_config_dir),
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_ewb_class.call_args[1]
+        assert call_kwargs["cache_format"] == "netcdf"
+
+    def test_cache_format_invalid_rejected(self, runner):
+        """Test that an invalid cache_format choice is rejected by Click."""
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            ["--default", "--cache-format", "parquet"],
+        )
+
+        assert result.exit_code != 0
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_cache_format_case_insensitive(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test that --cache-format accepts uppercase values (case_sensitive=False)."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame({"test": [1, 2]})
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--cache-format",
+                "NETCDF",
+                "--output-dir",
+                str(temp_config_dir),
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_ewb_class.call_args[1]
+        assert call_kwargs["cache_format"] == "netcdf"
+
+    def test_help_shows_cache_format(self, runner):
+        """Test that --help output mentions cache-format."""
+        result = runner.invoke(evaluate_cli.cli_runner, ["--help"])
+
+        assert result.exit_code == 0
+        assert "cache-format" in result.output
+
+
 class TestHelperFunctions:
     """Test helper function functionality."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1542,6 +1542,182 @@ class TestMaybeComputeAndMaybeCache:
         # Should return a dataset
         assert isinstance(result, xr.Dataset)
 
+    def test_cache_netcdf_dataset(self, tmp_path):
+        """Test caching a Dataset in NetCDF format round-trips correctly."""
+        ds = xr.Dataset(
+            {"temp": (["time", "lat"], [[1, 2], [3, 4]])},
+            coords={"time": [0, 1], "lat": [10, 20]},
+        )
+
+        result = utils.maybe_cache_and_compute(
+            ds, name="test", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "test.nc").exists()
+
+        # Verify round-trip equality
+        xr.testing.assert_equal(result, ds)
+
+    def test_cache_netcdf_dataarray(self, tmp_path):
+        """Test caching a named DataArray in NetCDF format round-trips correctly."""
+        da = xr.DataArray(
+            [[1, 2], [3, 4]],
+            dims=["time", "lat"],
+            coords={"time": [0, 1], "lat": [10, 20]},
+            name="temp",
+        )
+
+        result = utils.maybe_cache_and_compute(
+            da, name="temp", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "temp.nc").exists()
+
+        # Verify round-trip equality
+        assert isinstance(result, xr.DataArray)
+        xr.testing.assert_equal(result, da)
+
+    def test_cache_netcdf_unnamed_dataarray(self, tmp_path):
+        """Test caching an unnamed DataArray in NetCDF format assigns a name."""
+        da = xr.DataArray(
+            [[1, 2], [3, 4]],
+            dims=["time", "lat"],
+            coords={"time": [0, 1], "lat": [10, 20]},
+        )
+
+        result = utils.maybe_cache_and_compute(
+            da, name="unnamed_test", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "unnamed_test.nc").exists()
+
+        # Verify round-trip succeeds and returns a DataArray
+        assert isinstance(result, xr.DataArray)
+
+        # The naming guard (utils.py:855-858) should have assigned a name
+        # since NetCDF requires DataArrays to have a name
+        assert result.name is not None
+
+        # Verify data values are preserved (names differ, so compare values directly)
+        np.testing.assert_array_equal(result.values, da.values)
+
+    def test_cache_netcdf_sparse_dataset(self, sample_sparse_target_dataset, tmp_path):
+        """Test caching a sparse Dataset in NetCDF format densifies and round-trips."""
+        result = utils.maybe_cache_and_compute(
+            sample_sparse_target_dataset,
+            name="test",
+            cache_dir=tmp_path,
+            cache_format="netcdf",
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "test.nc").exists()
+
+        # Should return a dataset
+        assert isinstance(result, xr.Dataset)
+
+        # Should be densified (no longer sparse)
+        assert not isinstance(result["target"].data, sparse.COO)
+
+    def test_cache_netcdf_sparse_dataarray(
+        self, sample_sparse_target_dataarray, tmp_path
+    ):
+        """Test caching a sparse DataArray in NetCDF format densifies and round-trips."""
+        result = utils.maybe_cache_and_compute(
+            sample_sparse_target_dataarray,
+            name="test",
+            cache_dir=tmp_path,
+            cache_format="netcdf",
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "test.nc").exists()
+
+        # Should return a DataArray
+        assert isinstance(result, xr.DataArray)
+
+        # Should be densified (no longer sparse)
+        assert not isinstance(result.data, sparse.COO)
+
+    def test_cache_netcdf_existing_loads_from_cache(self, tmp_path):
+        """Test that calling twice with NetCDF format reuses the cache."""
+        ds = xr.Dataset(
+            {"temp": (["time", "lat"], [[1, 2], [3, 4]])},
+            coords={"time": [0, 1], "lat": [10, 20]},
+        )
+
+        # First call - caches the data
+        result1 = utils.maybe_cache_and_compute(
+            ds, name="test", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Second call - should load from cache
+        result2 = utils.maybe_cache_and_compute(
+            ds, name="test", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Both should be equal
+        xr.testing.assert_equal(result1, result2)
+
+    def test_cache_netcdf_string_path(self, tmp_path):
+        """Test that NetCDF caching works with a string path instead of pathlib.Path."""
+        ds = xr.Dataset({"temp": (["x"], [1, 2])}, coords={"x": [0, 1]})
+
+        result = utils.maybe_cache_and_compute(
+            ds, name="test", cache_dir=str(tmp_path), cache_format="netcdf"
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "test.nc").exists()
+        assert isinstance(result, xr.Dataset)
+
+    def test_cache_format_default_is_zarr(self, tmp_path):
+        """Test that the default cache_format is zarr (not netcdf)."""
+        ds = xr.Dataset({"temp": (["x"], [1, 2])}, coords={"x": [0, 1]}).chunk()
+
+        # Call without specifying cache_format -- should default to zarr
+        utils.maybe_cache_and_compute(ds, name="test", cache_dir=tmp_path)
+
+        # Zarr directory should exist
+        assert (tmp_path / "test.zarr").exists()
+
+        # NetCDF file should NOT exist
+        assert not (tmp_path / "test.nc").exists()
+
+    def test_cache_format_invalid_raises_valueerror(self, tmp_path):
+        """Test that an invalid cache_format raises ValueError."""
+        ds = xr.Dataset({"temp": (["x"], [1, 2])}, coords={"x": [0, 1]})
+
+        with pytest.raises(ValueError, match="cache_format"):
+            utils.maybe_cache_and_compute(
+                ds, name="test", cache_dir=tmp_path, cache_format="parquet"
+            )
+
+    def test_cache_netcdf_lazy_dask_arrays(self, tmp_path):
+        """Test caching dask-backed Dataset in NetCDF format round-trips correctly."""
+        import dask.array as da
+
+        ds = xr.Dataset(
+            {"temp": (["time", "lat"], da.ones((5, 10), chunks=(2, 5)))},
+            coords={"time": range(5), "lat": range(10)},
+        )
+
+        result = utils.maybe_cache_and_compute(
+            ds, name="lazy", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        # Verify .nc file exists
+        assert (tmp_path / "lazy.nc").exists()
+
+        # Should return a dataset
+        assert isinstance(result, xr.Dataset)
+
+        # Verify values round-trip correctly
+        xr.testing.assert_equal(result, ds.compute())
+
 
 class TestCacheMaybeDensifyHelper:
     """Test the _cache_maybe_densify_helper function."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1559,6 +1559,23 @@ class TestMaybeComputeAndMaybeCache:
         # Verify round-trip equality
         xr.testing.assert_equal(result, ds)
 
+    def test_cache_netcdf_multi_variable_dataset(self, tmp_path):
+        """Test caching a multi-variable Dataset in NetCDF format round-trips correctly."""
+        ds = xr.Dataset(
+            {
+                "temp": (["time", "lat"], [[1.0, 2.0], [3.0, 4.0]]),
+                "humidity": (["time", "lat"], [[50.0, 60.0], [70.0, 80.0]]),
+            },
+            coords={"time": [0, 1], "lat": [10, 20]},
+        )
+
+        result = utils.maybe_cache_and_compute(
+            ds, name="multi_var", cache_dir=tmp_path, cache_format="netcdf"
+        )
+
+        assert (tmp_path / "multi_var.nc").exists()
+        xr.testing.assert_equal(result, ds)
+
     def test_cache_netcdf_dataarray(self, tmp_path):
         """Test caching a named DataArray in NetCDF format round-trips correctly."""
         da = xr.DataArray(
@@ -1597,8 +1614,8 @@ class TestMaybeComputeAndMaybeCache:
         # Verify round-trip succeeds and returns a DataArray
         assert isinstance(result, xr.DataArray)
 
-        # The naming guard (utils.py:855-858) should have assigned a name
-        # since NetCDF requires DataArrays to have a name
+        # NetCDF caching assigns a name to unnamed DataArrays since
+        # the NetCDF format requires DataArrays to have a name
         assert result.name is not None
 
         # Verify data values are preserved (names differ, so compare values directly)


### PR DESCRIPTION
# EWB Pull Request

## Description

Add support for NetCDF (.nc) as an alternative cache format alongside the existing Zarr format. This enables interoperability with tools that natively support NetCDF, which is widely used in climate and weather science workflows.

Changes:
- New `cache_format` parameter in `ExtremeWeatherBench.__init__()` (defaults to "zarr")
- New `--cache-format` CLI option (case-insensitive, choices: zarr/netcdf)
- Updated `maybe_cache_and_compute()` in utils to handle both formats
- Handles NetCDF-specific requirements (DataArray naming, sparse densification)
- Fully backward compatible — default behavior unchanged

## Type of change

- [x] New feature

### If this PR is a breaking change, please explain:

Not a breaking change. All defaults remain "zarr" and existing behavior is preserved.

## How Has This Been Tested?

- New unit tests in `tests/test_utils.py` covering NetCDF caching for Datasets, DataArrays, sparse data, unnamed arrays, cache reuse, and invalid format handling
- New unit tests in `tests/test_evaluate.py` verifying NetCDF format propagation through serial and parallel evaluation paths
- New CLI tests in `tests/test_evaluate_cli.py` covering default format, explicit netcdf option, invalid format rejection, case insensitivity, and help output