### PR TITLE
Manage landfall edge cases

### DIFF
--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -1058,6 +1058,114 @@ def filter_inits_by_track_start(
     return forecast_landfalls
 
 
+def _can_filter_landfall_pair(
+    forecast_landfalls: xr.DataArray,
+    target_landfalls: xr.DataArray,
+) -> bool:
+    """True if both arrays have init_time dim and valid_time coord."""
+    return (
+        "init_time" in forecast_landfalls.dims
+        and "valid_time" in forecast_landfalls.coords
+        and "valid_time" in target_landfalls.coords
+    )
+
+
+def _apply_landfall_keep_mask(
+    forecast_landfalls: xr.DataArray,
+    target_landfalls: xr.DataArray,
+    keep: np.ndarray,
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Select init_times where ``keep`` is True."""
+    if keep.all():
+        return forecast_landfalls, target_landfalls
+    if not keep.any():
+        return (
+            utils._empty_init_time_array(),
+            utils._empty_init_time_array(),
+        )
+    idx = np.where(keep)[0]
+    return (
+        forecast_landfalls.isel(init_time=idx),
+        target_landfalls.isel(init_time=idx),
+    )
+
+
+def filter_by_landfall_time_window(
+    forecast_landfalls: xr.DataArray,
+    target_landfalls: xr.DataArray,
+    window_hours: float = 24.0,
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Drop pairs where forecast and target landfall times
+    differ by more than ``window_hours``.
+
+    Keeps:
+
+        abs(fc_valid_time - tgt_valid_time) <= window_hours
+
+    Args:
+        forecast_landfalls: ``(init_time,)`` with
+            ``valid_time`` coord.
+        target_landfalls: Same shape/coords.
+        window_hours: Max allowed mismatch in hours.
+
+    Returns:
+        Filtered (forecast, target) pair. May be empty.
+    """
+    if not _can_filter_landfall_pair(forecast_landfalls, target_landfalls):
+        return forecast_landfalls, target_landfalls
+
+    fc_vt = forecast_landfalls.coords["valid_time"].values
+    tgt_vt = target_landfalls.coords["valid_time"].values
+
+    mismatch = np.abs(fc_vt - tgt_vt)
+    threshold = np.timedelta64(int(window_hours * 3600), "s")
+
+    return _apply_landfall_keep_mask(
+        forecast_landfalls, target_landfalls, mismatch <= threshold
+    )
+
+
+def filter_by_landfall_time_tolerance(
+    forecast_landfalls: xr.DataArray,
+    target_landfalls: xr.DataArray,
+    tolerance_fraction: float = 0.5,
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Drop pairs where forecast landfall timing error exceeds
+    a fraction of the lead time.
+
+    Keeps::
+
+        abs(fc_vt - tgt_vt) <= fraction * (tgt_vt - init_time)
+
+    A 2-day forecast predicting landfall 4 days late would be
+    dropped with the default fraction of 0.5.
+
+    Args:
+        forecast_landfalls: ``(init_time,)`` with
+            ``valid_time`` coord.
+        target_landfalls: Same shape/coords.
+        tolerance_fraction: Multiplier on the lead time
+            that sets the max allowed mismatch.
+
+    Returns:
+        Filtered (forecast, target) pair. May be empty.
+    """
+    if not _can_filter_landfall_pair(forecast_landfalls, target_landfalls):
+        return forecast_landfalls, target_landfalls
+
+    fc_vt = forecast_landfalls.coords["valid_time"].values
+    tgt_vt = target_landfalls.coords["valid_time"].values
+    init_vals = forecast_landfalls.coords["init_time"].values
+
+    mismatch = np.abs(fc_vt - tgt_vt)
+    lead = np.abs(tgt_vt - init_vals)
+    threshold = tolerance_fraction * lead
+
+    return _apply_landfall_keep_mask(
+        forecast_landfalls, target_landfalls, mismatch <= threshold
+    )
+
+
 def select_first_forecast_landfall_per_init(
     forecast_landfalls: xr.DataArray,
 ) -> xr.DataArray:

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -491,57 +491,95 @@ def find_landfalls(
 def find_next_landfall_for_init_time(
     forecast_landfalls: xr.DataArray,
     target_landfalls: xr.DataArray,
+    max_lead_time: Optional[np.timedelta64] = None,
 ) -> xr.DataArray:
-    """Find unique next upcoming landfalls from target data.
+    """Match forecast landfalls to the closest target landfall.
 
-    For each forecast initialization time, finds the next landfall
-    event in the target data that occurs after that init_time. Only
-    unique landfalls are returned (multiple init_times mapping to the
-    same landfall are deduplicated). Init_times without future
-    landfalls are excluded.
+    For each forecast initialization time, finds the target landfall
+    whose valid_time is closest to the forecast's predicted landfall
+    time, constrained to be after init_time (and optionally within
+    max_lead_time). This ensures that multi-landfall storms pair the
+    model's prediction with the observed event it is actually
+    attempting to forecast, rather than a chronologically earlier
+    landfall the model cannot represent.
 
     Args:
         forecast_landfalls: Forecast landfall DataArray with init_time
-            dimension (from find_landfalls)
+            dimension (from find_landfalls). Must have valid_time
+            coordinate indicating when the model predicts landfall.
         target_landfalls: Target landfall DataArray from find_landfalls
-            with return_all=True (has landfall dimension)
+            with landfall dimension and valid_time coordinate.
+        max_lead_time: If provided, only consider target landfalls
+            within this duration after each init_time.
 
     Returns:
-        DataArray with unique next landfalls indexed by init_time. Returns
-        a zero-length DataArray if no future landfalls exist.
+        DataArray with matched target landfalls indexed by init_time.
+        Returns a zero-length DataArray if no matches exist.
     """
-    # Extract init_times from forecast landfalls
     if "init_time" in forecast_landfalls.dims:
         init_times = forecast_landfalls.init_time.values
     elif "init_time" in forecast_landfalls.coords:
-        # init_time as coordinate (scalar case)
         init_times = np.array([forecast_landfalls.coords["init_time"].values])
     else:
         raise KeyError("Missing init_time dimension or coordinate.")
 
-    # Get target landfall times
+    has_forecast_vt = "valid_time" in forecast_landfalls.coords
+    forecast_vt_map: dict[np.datetime64, np.datetime64] = {}
+    if has_forecast_vt:
+        if (
+            "landfall" in forecast_landfalls.dims
+            and "init_time" in forecast_landfalls.dims
+        ):
+            # 2D: valid_time lives on the landfall dim while
+            # init_time is a separate dim. Map each init to
+            # the earliest forecast landfall valid_time.
+            lf_vts = forecast_landfalls.coords["valid_time"].values
+            data = forecast_landfalls.values
+            n_lf = forecast_landfalls.sizes["landfall"]
+            for j in range(n_lf):
+                col = data[:, j]
+                non_nan = np.where(~np.isnan(col))[0]
+                if len(non_nan) == 0:
+                    continue
+                owner = init_times[non_nan[0]]
+                vt = lf_vts[j]
+                if owner not in forecast_vt_map or vt < forecast_vt_map[owner]:
+                    forecast_vt_map[owner] = vt
+        else:
+            # 1D / scalar: valid_time aligns with init_time.
+            fvts = np.atleast_1d(forecast_landfalls.coords["valid_time"].values)
+            for idx, it_val in enumerate(init_times):
+                if idx < len(fvts):
+                    forecast_vt_map[it_val] = fvts[idx]
+
     target_times = target_landfalls.coords["valid_time"].values
 
-    # Use searchsorted to find next landfall index for each init_time
-    next_indices = np.searchsorted(target_times, init_times, side="right")
-
-    # Create mask for init_times with future landfalls
-    valid_mask = next_indices < len(target_times)
-
-    # Build result for all init_times, keeping only unique landfalls
     results = []
 
-    for i, init_time in enumerate(init_times):
-        if valid_mask[i]:
-            # There is a future landfall for this init_time
-            landfall_idx = next_indices[i]
-            landfall = target_landfalls.isel(landfall=landfall_idx)
-            landfall = landfall.expand_dims("init_time", axis=0)
-            landfall = landfall.assign_coords(init_time=("init_time", [init_time]))
+    for init_time in init_times:
+        future_mask = target_times > init_time
 
-            results.append(landfall)
+        if max_lead_time is not None:
+            horizon = init_time + max_lead_time
+            future_mask &= target_times <= horizon
 
-    # Combine landfalls indexed by init_time or return empty if no results
+        if not future_mask.any():
+            continue
+
+        future_indices = np.where(future_mask)[0]
+        future_times = target_times[future_indices]
+
+        fc_vt = forecast_vt_map.get(init_time)
+        if fc_vt is not None:
+            best = future_indices[np.argmin(np.abs(future_times - fc_vt))]
+        else:
+            best = future_indices[0]
+
+        landfall = target_landfalls.isel(landfall=int(best))
+        landfall = landfall.expand_dims("init_time", axis=0)
+        landfall = landfall.assign_coords(init_time=("init_time", [init_time]))
+        results.append(landfall)
+
     if not results:
         return xr.DataArray(
             np.array([], dtype=float),
@@ -549,7 +587,11 @@ def find_next_landfall_for_init_time(
             coords={"init_time": np.array([], dtype="datetime64[ns]")},
         )
     return xr.concat(
-        results, dim="init_time", coords="different", compat="equals", join="outer"
+        results,
+        dim="init_time",
+        coords="different",
+        compat="equals",
+        join="outer",
     )
 
 

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -16,7 +16,7 @@ from extremeweatherbench import utils
 epsilon: float = 0.6219569100577033  # Ratio of molecular weights (H2O/dry air)
 sat_press_0c: float = 6.112  # Saturation vapor pressure at 0°C (hPa)
 g0: float = 9.80665  # Standard gravity (m/s^2)
-
+_ns_per_hour = 3_600_000_000_000
 logger = logging.getLogger("extremeweatherbench.calc")
 logger.setLevel(logging.INFO)
 
@@ -488,20 +488,75 @@ def find_landfalls(
     return _deduplicate_landfalls(landfalls)
 
 
+def _filter_minor_landfalls(
+    target_landfalls: xr.DataArray,
+    min_separation_hours: float,
+) -> xr.DataArray:
+    """Remove target landfalls within min_separation_hours of the prior one.
+
+    For multi-landfall storms, rapid sequential crossings (e.g., a TC
+    clipping several Caribbean islands within hours of each other) are
+    treated as a single landfall event. Only the first crossing in each
+    rapid sequence is kept; later crossings within min_separation_hours
+    are dropped.
+
+    Args:
+        target_landfalls: DataArray with ``landfall`` dim and
+            ``valid_time`` coord, as returned by find_landfalls.
+        min_separation_hours: Minimum gap (hours) between consecutive
+            retained landfalls.
+
+    Returns:
+        Filtered DataArray with minor landfalls removed.
+    """
+    if len(target_landfalls) <= 1:
+        return target_landfalls
+    times = target_landfalls.coords["valid_time"].values.astype("datetime64[ns]")
+    keep_idx = [0]
+    last_kept = times[0]
+    for i in range(1, len(times)):
+        gap_h = (np.int64(times[i]) - np.int64(last_kept)) / _ns_per_hour
+        if gap_h >= min_separation_hours:
+            keep_idx.append(i)
+            last_kept = times[i]
+    return target_landfalls.isel(landfall=keep_idx)
+
+
+def _landfall_point_to_init_row(
+    da: xr.DataArray,
+    init_time: np.datetime64,
+) -> xr.DataArray:
+    """Promote a scalar landfall point to (init_time,) with coords."""
+    lat = float(da.coords["latitude"].values)
+    lon = float(da.coords["longitude"].values)
+    vt = da.coords["valid_time"].values
+    da = da.expand_dims("init_time")
+    return da.assign_coords(
+        init_time=("init_time", [init_time]),
+        latitude=("init_time", [lat]),
+        longitude=("init_time", [lon]),
+        valid_time=("init_time", [vt]),
+    )
+
+
 def find_next_landfall_for_init_time(
     forecast_landfalls: xr.DataArray,
     target_landfalls: xr.DataArray,
     max_lead_time: Optional[np.timedelta64] = None,
+    min_target_separation_hours: float = 0.0,
+    max_time_mismatch_hours: Optional[float] = None,
+    track_start_times: Optional[dict[np.datetime64, np.datetime64]] = None,
 ) -> xr.DataArray:
     """Match forecast landfalls to the closest target landfall.
 
     For each forecast initialization time, finds the target landfall
     whose valid_time is closest to the forecast's predicted landfall
-    time, constrained to be after init_time (and optionally within
-    max_lead_time). This ensures that multi-landfall storms pair the
-    model's prediction with the observed event it is actually
-    attempting to forecast, rather than a chronologically earlier
-    landfall the model cannot represent.
+    time, constrained to be after the forecast track's actual start
+    time (and optionally within max_lead_time). This ensures that
+    multi-landfall storms pair the model's prediction with the
+    observed event it is actually attempting to forecast, rather
+    than a chronologically earlier landfall the model cannot
+    represent.
 
     Args:
         forecast_landfalls: Forecast landfall DataArray with init_time
@@ -511,11 +566,31 @@ def find_next_landfall_for_init_time(
             with landfall dimension and valid_time coordinate.
         max_lead_time: If provided, only consider target landfalls
             within this duration after each init_time.
+        min_target_separation_hours: If > 0, pre-filter target
+            landfalls so that consecutive retained landfalls are at
+            least this many hours apart.
+        max_time_mismatch_hours: If provided, discard matched pairs
+            where the absolute difference between the forecast's
+            predicted landfall valid_time and the matched target
+            landfall valid_time exceeds this threshold (hours).
+        track_start_times: Optional dict mapping init_time to the
+            earliest valid_time with non-NaN forecast track data
+            (from ``get_forecast_track_start_times``). When
+            provided, only target landfalls after the track start
+            are considered. Falls back to init_time when not
+            provided or when a given init_time is missing.
 
     Returns:
         DataArray with matched target landfalls indexed by init_time.
         Returns a zero-length DataArray if no matches exist.
     """
+    if min_target_separation_hours > 0:
+        target_landfalls = _filter_minor_landfalls(
+            target_landfalls, min_target_separation_hours
+        )
+        if len(target_landfalls) == 0:
+            return utils._empty_init_time_array()
+
     if "init_time" in forecast_landfalls.dims:
         init_times = forecast_landfalls.init_time.values
     elif "init_time" in forecast_landfalls.coords:
@@ -530,10 +605,11 @@ def find_next_landfall_for_init_time(
             "landfall" in forecast_landfalls.dims
             and "init_time" in forecast_landfalls.dims
         ):
-            # 2D: valid_time lives on the landfall dim while
-            # init_time is a separate dim. Map each init to
-            # the earliest forecast landfall valid_time.
+            # 2D: Map each init to earliest forecast landfall
+            # valid_time. valid_time may be 1D (landfall,) or
+            # 2D (init_time, landfall).
             lf_vts = forecast_landfalls.coords["valid_time"].values
+            vt_2d = lf_vts.ndim == 2
             data = forecast_landfalls.values
             n_lf = forecast_landfalls.sizes["landfall"]
             for j in range(n_lf):
@@ -542,7 +618,7 @@ def find_next_landfall_for_init_time(
                 if len(non_nan) == 0:
                     continue
                 owner = init_times[non_nan[0]]
-                vt = lf_vts[j]
+                vt = lf_vts[non_nan[0], j] if vt_2d else lf_vts[j]
                 if owner not in forecast_vt_map or vt < forecast_vt_map[owner]:
                     forecast_vt_map[owner] = vt
         else:
@@ -557,7 +633,15 @@ def find_next_landfall_for_init_time(
     results = []
 
     for init_time in init_times:
-        future_mask = target_times > init_time
+        # With track_start_times, cutoff is when the forecast
+        # has data (>= because the track exists at cutoff).
+        # Without, cutoff is the nominal init_time which
+        # predates any forecast output (strict >).
+        if track_start_times is not None:
+            cutoff = track_start_times.get(init_time, init_time)
+            future_mask = target_times >= cutoff
+        else:
+            future_mask = target_times > init_time
 
         if max_lead_time is not None:
             horizon = init_time + max_lead_time
@@ -575,17 +659,17 @@ def find_next_landfall_for_init_time(
         else:
             best = future_indices[0]
 
+        if max_time_mismatch_hours is not None and fc_vt is not None:
+            target_vt = target_times[int(best)]
+            mismatch_h = abs(np.int64(fc_vt) - np.int64(target_vt)) / _ns_per_hour
+            if mismatch_h > max_time_mismatch_hours:
+                continue
+
         landfall = target_landfalls.isel(landfall=int(best))
-        landfall = landfall.expand_dims("init_time", axis=0)
-        landfall = landfall.assign_coords(init_time=("init_time", [init_time]))
-        results.append(landfall)
+        results.append(_landfall_point_to_init_row(landfall, init_time))
 
     if not results:
-        return xr.DataArray(
-            np.array([], dtype=float),
-            dims=["init_time"],
-            coords={"init_time": np.array([], dtype="datetime64[ns]")},
-        )
+        return utils._empty_init_time_array()
     return xr.concat(
         results,
         dim="init_time",
@@ -905,6 +989,129 @@ def _deduplicate_landfalls(
     return landfalls.isel(landfall=kept_indices)
 
 
+def get_forecast_track_start_times(
+    forecast: xr.DataArray,
+) -> dict[np.datetime64, np.datetime64]:
+    """Map each init_time to the earliest valid_time with data.
+
+    TC tracker output contains NaN at lead times before the
+    storm is detected. This returns the valid_time of each
+    init_time's first non-NaN data point, telling us when the
+    forecast track actually begins.
+
+    Args:
+        forecast: Forecast DataArray with ``lead_time`` and
+            ``valid_time`` dimensions.
+
+    Returns:
+        Dict mapping ``init_time`` → earliest ``valid_time``
+        with non-NaN track data for that initialization.
+    """
+    if "lead_time" not in forecast.dims:
+        return {}
+
+    lt_vals = forecast.lead_time.values
+    if len(lt_vals) == 0:
+        return {}
+    if not isinstance(lt_vals[0], np.timedelta64):
+        lt_vals = np.array([np.timedelta64(int(lt), "h") for lt in lt_vals])
+
+    vt_vals = forecast.valid_time.values
+    data = forecast.values
+
+    start_times: dict[np.datetime64, np.datetime64] = {}
+    for j, vt in enumerate(vt_vals):
+        for i, lt in enumerate(lt_vals):
+            if not np.isnan(data[i, j]):
+                init = vt - lt
+                if init not in start_times or vt < start_times[init]:
+                    start_times[init] = vt
+
+    return start_times
+
+
+def filter_inits_by_track_start(
+    forecast_landfalls: xr.DataArray,
+    first_valid_time: np.datetime64,
+    track_starts: dict[np.datetime64, np.datetime64],
+) -> xr.DataArray:
+    """Drop init_times whose track starts after a target event.
+
+    Keeps init_times where the track starts at or before
+    ``first_valid_time``, or where the track start is unknown.
+
+    Args:
+        forecast_landfalls: DataArray with ``init_time`` dim.
+        first_valid_time: Target landfall valid_time cutoff.
+        track_starts: Dict from ``get_forecast_track_start_times``.
+
+    Returns:
+        Filtered DataArray (may be empty).
+    """
+    keep = [
+        it
+        for it in forecast_landfalls.init_time.values
+        if track_starts.get(it, first_valid_time) <= first_valid_time
+    ]
+    if len(keep) < len(forecast_landfalls.init_time):
+        return forecast_landfalls.sel(init_time=np.array(keep))
+    return forecast_landfalls
+
+
+def select_first_forecast_landfall_per_init(
+    forecast_landfalls: xr.DataArray,
+) -> xr.DataArray:
+    """Reduce forecast landfalls to one per init_time.
+
+    For each init_time, keeps the forecast landfall with the
+    earliest valid_time. This prevents downstream metrics from
+    averaging distances across multiple forecast landfalls
+    (e.g. island-hopping detections) for a single init_time.
+
+    Args:
+        forecast_landfalls: DataArray with ``init_time`` and
+            ``landfall`` dimensions, as returned by
+            ``find_landfalls`` on forecast data.
+
+    Returns:
+        DataArray with one landfall per init_time, indexed by
+        ``init_time`` with ``landfall`` dim removed.
+    """
+    if "init_time" not in forecast_landfalls.dims:
+        return forecast_landfalls
+    if "landfall" not in forecast_landfalls.dims:
+        return forecast_landfalls
+
+    init_times = forecast_landfalls.init_time.values
+    vt_vals = forecast_landfalls.coords["valid_time"].values
+    data = forecast_landfalls.values
+    vt_2d = vt_vals.ndim == 2
+
+    results = []
+    for i, it in enumerate(init_times):
+        row = data[i, :]
+        non_nan = np.where(~np.isnan(row))[0]
+        if len(non_nan) == 0:
+            continue
+        row_vts = vt_vals[i, non_nan] if vt_2d else vt_vals[non_nan]
+        earliest_j = non_nan[np.argmin(row_vts)]
+        pt = forecast_landfalls.isel(
+            init_time=i,
+            landfall=earliest_j,
+        )
+        results.append(_landfall_point_to_init_row(pt, it))
+
+    if not results:
+        return utils._empty_init_time_array()
+    return xr.concat(
+        results,
+        dim="init_time",
+        coords="different",
+        compat="equals",
+        join="outer",
+    )
+
+
 def broadcast_first_target_to_init_times(
     init_times: xr.DataArray,
     target: xr.DataArray,
@@ -921,15 +1128,17 @@ def broadcast_first_target_to_init_times(
     landfall) before passing it here.
 
     Args:
-        target: ``(landfall,)`` DataArray from ``find_landfalls`` for
-            observations. Must contain exactly one element.
-        forecast: ``(init_time,)`` DataArray from ``find_landfalls`` for
-            the forecast, used to determine which init_times the broadcast
-            target should span.
+        init_times: ``init_time`` coordinate from the forecast
+            landfall DataArray, determines which init_times the
+            broadcast target should span.
+        target: ``(landfall,)`` DataArray from ``find_landfalls``
+            for observations. Must contain at least one element
+            (uses the first).
 
     Returns:
-        ``(init_time,)`` DataArray with the target value, latitude,
-        longitude, and valid_time repeated across all forecast init_times.
+        ``(init_time,)`` DataArray with the target value,
+        latitude, longitude, and valid_time repeated across
+        all provided init_times.
     """
     t = target.isel(landfall=0)
     n = len(init_times)

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -511,14 +511,20 @@ def _filter_minor_landfalls(
     """
     if len(target_landfalls) <= 1:
         return target_landfalls
-    times = target_landfalls.coords["valid_time"].values.astype("datetime64[ns]")
+    ns = (
+        target_landfalls.coords["valid_time"]
+        .values.astype("datetime64[ns]")
+        .astype(np.int64)
+    )
+    min_gap_ns = int(min_separation_hours * _ns_per_hour)
+    # Greedy reset-anchor walk: each kept landfall becomes the new
+    # reference, so this cannot be a plain ``np.diff`` threshold.
     keep_idx = [0]
-    last_kept = times[0]
-    for i in range(1, len(times)):
-        gap_h = (np.int64(times[i]) - np.int64(last_kept)) / _ns_per_hour
-        if gap_h >= min_separation_hours:
+    last_ns = ns[0]
+    for i in range(1, len(ns)):
+        if ns[i] - last_ns >= min_gap_ns:
             keep_idx.append(i)
-            last_kept = times[i]
+            last_ns = ns[i]
     return target_landfalls.isel(landfall=keep_idx)
 
 
@@ -1058,16 +1064,24 @@ def filter_inits_by_track_start(
     return forecast_landfalls
 
 
-def _can_filter_landfall_pair(
+def _landfall_pair_time_mismatch(
     forecast_landfalls: xr.DataArray,
     target_landfalls: xr.DataArray,
-) -> bool:
-    """True if both arrays have init_time dim and valid_time coord."""
-    return (
+) -> Optional[tuple[np.ndarray, np.ndarray, np.ndarray]]:
+    """Return ``(fc_vt, tgt_vt, |fc_vt - tgt_vt|)`` as numpy arrays.
+
+    Returns ``None`` if either array lacks the ``init_time`` dim or
+    the ``valid_time`` coord needed for pairwise timing filters.
+    """
+    if not (
         "init_time" in forecast_landfalls.dims
         and "valid_time" in forecast_landfalls.coords
         and "valid_time" in target_landfalls.coords
-    )
+    ):
+        return None
+    fc_vt = forecast_landfalls.coords["valid_time"].values
+    tgt_vt = target_landfalls.coords["valid_time"].values
+    return fc_vt, tgt_vt, np.abs(fc_vt - tgt_vt)
 
 
 def _apply_landfall_keep_mask(
@@ -1111,13 +1125,11 @@ def filter_by_landfall_time_window(
     Returns:
         Filtered (forecast, target) pair. May be empty.
     """
-    if not _can_filter_landfall_pair(forecast_landfalls, target_landfalls):
+    pair = _landfall_pair_time_mismatch(forecast_landfalls, target_landfalls)
+    if pair is None:
         return forecast_landfalls, target_landfalls
+    _fc_vt, _tgt_vt, mismatch = pair
 
-    fc_vt = forecast_landfalls.coords["valid_time"].values
-    tgt_vt = target_landfalls.coords["valid_time"].values
-
-    mismatch = np.abs(fc_vt - tgt_vt)
     threshold = np.timedelta64(int(window_hours * 3600), "s")
 
     return _apply_landfall_keep_mask(
@@ -1150,16 +1162,13 @@ def filter_by_landfall_time_tolerance(
     Returns:
         Filtered (forecast, target) pair. May be empty.
     """
-    if not _can_filter_landfall_pair(forecast_landfalls, target_landfalls):
+    pair = _landfall_pair_time_mismatch(forecast_landfalls, target_landfalls)
+    if pair is None:
         return forecast_landfalls, target_landfalls
+    _fc_vt, tgt_vt, mismatch = pair
 
-    fc_vt = forecast_landfalls.coords["valid_time"].values
-    tgt_vt = target_landfalls.coords["valid_time"].values
     init_vals = forecast_landfalls.coords["init_time"].values
-
-    mismatch = np.abs(fc_vt - tgt_vt)
-    lead = np.abs(tgt_vt - init_vals)
-    threshold = tolerance_fraction * lead
+    threshold = tolerance_fraction * np.abs(tgt_vt - init_vals)
 
     return _apply_landfall_keep_mask(
         forecast_landfalls, target_landfalls, mismatch <= threshold

--- a/src/extremeweatherbench/data/marginal_temperature_events.yaml
+++ b/src/extremeweatherbench/data/marginal_temperature_events.yaml
@@ -9,7 +9,7 @@
       latitude_max: 30.25
       longitude_min: 11.0
       longitude_max: 38.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 2
   title: February 2020 Event 0018
   start_date: 2020-02-01 00:00:00
@@ -21,7 +21,7 @@
       latitude_max: 29.5
       longitude_min: 0.0
       longitude_max: 38.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 3
   title: February 2020 Event 0019
   start_date: 2020-02-01 00:00:00
@@ -33,7 +33,7 @@
       latitude_max: 77.0
       longitude_min: 87.0
       longitude_max: 128.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 4
   title: February 2020 Event 0023
   start_date: 2020-02-05 00:00:00
@@ -45,7 +45,7 @@
       latitude_max: 81.0
       longitude_min: 296.5
       longitude_max: 324.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 5
   title: February 2020 Event 0025
   start_date: 2020-02-09 00:00:00
@@ -57,7 +57,7 @@
       latitude_max: 60.5
       longitude_min: 28.25
       longitude_max: 58.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 6
   title: February 2020 Event 0034
   start_date: 2020-02-22 00:00:00
@@ -69,7 +69,7 @@
       latitude_max: 76.75
       longitude_min: 296.5
       longitude_max: 317.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 7
   title: March 2020 Event 0037
   start_date: 2020-03-01 00:00:00
@@ -81,7 +81,7 @@
       latitude_max: 53.5
       longitude_min: 0.0
       longitude_max: 16.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 8
   title: April 2020 Event 0047
   start_date: 2020-04-03 00:00:00
@@ -93,7 +93,7 @@
       latitude_max: 77.75
       longitude_min: 293.5
       longitude_max: 339.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 9
   title: April 2020 Event 0048
   start_date: 2020-04-07 00:00:00
@@ -105,7 +105,7 @@
       latitude_max: 70.25
       longitude_min: 228.0
       longitude_max: 267.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 10
   title: May 2020 Event 0053
   start_date: 2020-05-10 00:00:00
@@ -117,7 +117,7 @@
       latitude_max: -14.75
       longitude_min: 118.25
       longitude_max: 140.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 11
   title: May 2020 Event 0060
   start_date: 2020-05-30 00:00:00
@@ -129,7 +129,7 @@
       latitude_max: 75.5
       longitude_min: 235.0
       longitude_max: 259.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 12
   title: June 2020 Event 0062
   start_date: 2020-06-03 00:00:00
@@ -141,7 +141,7 @@
       latitude_max: -15.5
       longitude_min: 119.5
       longitude_max: 140.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 13
   title: June 2020 Event 0064
   start_date: 2020-06-11 00:00:00
@@ -153,7 +153,7 @@
       latitude_max: 74.25
       longitude_min: 71.0
       longitude_max: 116.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 14
   title: July 2020 Event 0068
   start_date: 2020-07-13 00:00:00
@@ -165,7 +165,7 @@
       latitude_max: 75.5
       longitude_min: 72.25
       longitude_max: 97.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 15
   title: September 2020 Event 0076
   start_date: 2020-09-11 00:00:00
@@ -177,7 +177,7 @@
       latitude_max: 71.0
       longitude_min: 12.75
       longitude_max: 50.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 16
   title: September 2020 Event 0079
   start_date: 2020-09-28 00:00:00
@@ -189,7 +189,7 @@
       latitude_max: 64.25
       longitude_min: 248.75
       longitude_max: 269.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 17
   title: October 2020 Event 0081
   start_date: 2020-10-06 00:00:00
@@ -201,7 +201,7 @@
       latitude_max: 71.5
       longitude_min: 62.25
       longitude_max: 99.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 18
   title: October 2020 Event 0082
   start_date: 2020-10-09 00:00:00
@@ -213,7 +213,7 @@
       latitude_max: 28.25
       longitude_min: 10.5
       longitude_max: 24.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 19
   title: October 2020 Event 0084
   start_date: 2020-10-19 00:00:00
@@ -225,7 +225,7 @@
       latitude_max: 67.5
       longitude_min: 281.75
       longitude_max: 299.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 20
   title: November 2020 Event 0087
   start_date: 2020-11-01 00:00:00
@@ -237,7 +237,7 @@
       latitude_max: 23.75
       longitude_min: 0.0
       longitude_max: 11.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 21
   title: November 2020 Event 0088
   start_date: 2020-11-04 00:00:00
@@ -249,7 +249,7 @@
       latitude_max: 54.0
       longitude_min: 13.25
       longitude_max: 32.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 22
   title: November 2020 Event 0092
   start_date: 2020-11-09 00:00:00
@@ -261,7 +261,7 @@
       latitude_max: 73.75
       longitude_min: 12.25
       longitude_max: 116.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 23
   title: December 2020 Event 0108
   start_date: 2020-12-03 00:00:00
@@ -273,7 +273,7 @@
       latitude_max: 57.75
       longitude_min: 265.0
       longitude_max: 294.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 24
   title: December 2020 Event 0109
   start_date: 2020-12-04 00:00:00
@@ -285,7 +285,7 @@
       latitude_max: 71.25
       longitude_min: 192.25
       longitude_max: 230.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 25
   title: December 2020 Event 0111
   start_date: 2020-12-06 00:00:00
@@ -297,7 +297,7 @@
       latitude_max: 78.5
       longitude_min: 306.5
       longitude_max: 341.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 26
   title: December 2020 Event 0115
   start_date: 2020-12-13 00:00:00
@@ -309,7 +309,7 @@
       latitude_max: 81.25
       longitude_min: 289.5
       longitude_max: 344.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 27
   title: December 2020 Event 0126
   start_date: 2020-12-27 00:00:00
@@ -321,7 +321,7 @@
       latitude_max: 59.0
       longitude_min: 0.0
       longitude_max: 27.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 28
   title: January 2021 Event 0138
   start_date: 2021-01-20 00:00:00
@@ -333,7 +333,7 @@
       latitude_max: 75.5
       longitude_min: 306.75
       longitude_max: 329.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 29
   title: February 2021 Event 0157
   start_date: 2021-02-21 00:00:00
@@ -345,7 +345,7 @@
       latitude_max: 74.0
       longitude_min: 73.25
       longitude_max: 118.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 30
   title: March 2021 Event 0168
   start_date: 2021-03-11 00:00:00
@@ -357,7 +357,7 @@
       latitude_max: 74.25
       longitude_min: 76.75
       longitude_max: 123.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 31
   title: April 2021 Event 0182
   start_date: 2021-04-18 00:00:00
@@ -369,7 +369,7 @@
       latitude_max: 84.5
       longitude_min: 292.0
       longitude_max: 339.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 32
   title: June 2021 Event 0208
   start_date: 2021-06-21 00:00:00
@@ -381,7 +381,7 @@
       latitude_max: 74.0
       longitude_min: 70.75
       longitude_max: 94.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 33
   title: July 2021 Event 0215
   start_date: 2021-07-24 00:00:00
@@ -393,7 +393,7 @@
       latitude_max: 35.25
       longitude_min: 0.0
       longitude_max: 18.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 34
   title: August 2021 Event 0216
   start_date: 2021-08-22 00:00:00
@@ -405,7 +405,7 @@
       latitude_max: 77.5
       longitude_min: 80.75
       longitude_max: 113.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 35
   title: November 2021 Event 0236
   start_date: 2021-11-09 00:00:00
@@ -417,7 +417,7 @@
       latitude_max: 74.0
       longitude_min: 27.0
       longitude_max: 122.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 36
   title: November 2021 Event 0240
   start_date: 2021-11-19 00:00:00
@@ -429,7 +429,7 @@
       latitude_max: 57.5
       longitude_min: 0.0
       longitude_max: 26.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 37
   title: December 2021 Event 0248
   start_date: 2021-12-07 00:00:00
@@ -441,7 +441,7 @@
       latitude_max: 21.75
       longitude_min: 4.0
       longitude_max: 31.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 38
   title: December 2021 Event 0258
   start_date: 2021-12-20 00:00:00
@@ -453,7 +453,7 @@
       latitude_max: 23.75
       longitude_min: 0.0
       longitude_max: 11.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 39
   title: December 2021 Event 0260
   start_date: 2021-12-22 00:00:00
@@ -465,7 +465,7 @@
       latitude_max: 73.0
       longitude_min: 16.75
       longitude_max: 76.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 40
   title: December 2021 Event 0264
   start_date: 2021-12-27 00:00:00
@@ -477,7 +477,7 @@
       latitude_max: 71.0
       longitude_min: 5.25
       longitude_max: 47.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 41
   title: January 2022 Event 0270
   start_date: 2022-01-02 00:00:00
@@ -489,7 +489,7 @@
       latitude_max: 62.5
       longitude_min: 280.5
       longitude_max: 298.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 42
   title: January 2022 Event 0273
   start_date: 2022-01-08 00:00:00
@@ -501,7 +501,7 @@
       latitude_max: 63.5
       longitude_min: 280.75
       longitude_max: 293.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 43
   title: January 2022 Event 0274
   start_date: 2022-01-08 00:00:00
@@ -513,7 +513,7 @@
       latitude_max: 69.5
       longitude_min: 105.25
       longitude_max: 134.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 44
   title: January 2022 Event 0280
   start_date: 2022-01-14 00:00:00
@@ -525,7 +525,7 @@
       latitude_max: 48.25
       longitude_min: 237.5
       longitude_max: 252.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 45
   title: January 2022 Event 0282
   start_date: 2022-01-18 00:00:00
@@ -537,7 +537,7 @@
       latitude_max: 80.5
       longitude_min: 247.5
       longitude_max: 275.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 46
   title: January 2022 Event 0284
   start_date: 2022-01-20 00:00:00
@@ -549,7 +549,7 @@
       latitude_max: 23.5
       longitude_min: 348.25
       longitude_max: 359.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 47
   title: March 2022 Event 0306
   start_date: 2022-03-01 00:00:00
@@ -561,7 +561,7 @@
       latitude_max: 68.5
       longitude_min: 280.75
       longitude_max: 299.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 48
   title: March 2022 Event 0309
   start_date: 2022-03-07 00:00:00
@@ -573,7 +573,7 @@
       latitude_max: 61.75
       longitude_min: 281.75
       longitude_max: 303.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 49
   title: April 2022 Event 0322
   start_date: 2022-04-06 00:00:00
@@ -585,7 +585,7 @@
       latitude_max: 77.5
       longitude_min: 73.25
       longitude_max: 118.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 50
   title: May 2022 Event 0332
   start_date: 2022-05-14 00:00:00
@@ -597,7 +597,7 @@
       latitude_max: 69.5
       longitude_min: 280.75
       longitude_max: 291.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 51
   title: June 2022 Event 0341
   start_date: 2022-06-27 00:00:00
@@ -609,7 +609,7 @@
       latitude_max: 26.25
       longitude_min: 20.0
       longitude_max: 28.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 52
   title: July 2022 Event 0345
   start_date: 2022-07-26 00:00:00
@@ -621,7 +621,7 @@
       latitude_max: 57.75
       longitude_min: 33.75
       longitude_max: 66.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 53
   title: September 2022 Event 0355
   start_date: 2022-09-11 00:00:00
@@ -633,7 +633,7 @@
       latitude_max: 75.25
       longitude_min: 219.5
       longitude_max: 263.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 54
   title: September 2022 Event 0358
   start_date: 2022-09-18 00:00:00
@@ -645,7 +645,7 @@
       latitude_max: 71.25
       longitude_min: 192.25
       longitude_max: 231.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 55
   title: September 2022 Event 0361
   start_date: 2022-09-29 00:00:00
@@ -657,7 +657,7 @@
       latitude_max: 71.25
       longitude_min: 193.25
       longitude_max: 226.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 56
   title: October 2022 Event 0372
   start_date: 2022-10-18 00:00:00
@@ -669,7 +669,7 @@
       latitude_max: 67.5
       longitude_min: 39.5
       longitude_max: 74.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 57
   title: October 2022 Event 0373
   start_date: 2022-10-19 00:00:00
@@ -681,7 +681,7 @@
       latitude_max: 24.25
       longitude_min: 19.0
       longitude_max: 31.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 58
   title: October 2022 Event 0378
   start_date: 2022-10-28 00:00:00
@@ -693,7 +693,7 @@
       latitude_max: 69.75
       longitude_min: 24.75
       longitude_max: 78.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 59
   title: November 2022 Event 0386
   start_date: 2022-11-17 00:00:00
@@ -705,7 +705,7 @@
       latitude_max: 28.5
       longitude_min: 0.0
       longitude_max: 31.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 60
   title: November 2022 Event 0391
   start_date: 2022-11-25 00:00:00
@@ -717,7 +717,7 @@
       latitude_max: 70.25
       longitude_min: 0.0
       longitude_max: 108.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 61
   title: December 2022 Event 0394
   start_date: 2022-12-10 00:00:00
@@ -729,7 +729,7 @@
       latitude_max: 74.25
       longitude_min: 73.25
       longitude_max: 103.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 62
   title: December 2022 Event 0401
   start_date: 2022-12-19 00:00:00
@@ -741,7 +741,7 @@
       latitude_max: 69.0
       longitude_min: 231.25
       longitude_max: 302.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 63
   title: December 2022 Event 0405
   start_date: 2022-12-21 00:00:00
@@ -753,7 +753,7 @@
       latitude_max: 51.5
       longitude_min: 43.75
       longitude_max: 72.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 64
   title: December 2022 Event 0408
   start_date: 2022-12-24 00:00:00
@@ -765,7 +765,7 @@
       latitude_max: 71.25
       longitude_min: 192.25
       longitude_max: 218.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 65
   title: January 2023 Event 0412
   start_date: 2023-01-01 00:00:00
@@ -777,7 +777,7 @@
       latitude_max: 69.75
       longitude_min: 166.5
       longitude_max: 190.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 66
   title: January 2023 Event 0427
   start_date: 2023-01-20 00:00:00
@@ -789,7 +789,7 @@
       latitude_max: 59.5
       longitude_min: 4.25
       longitude_max: 31.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 67
   title: February 2023 Event 0436
   start_date: 2023-02-13 00:00:00
@@ -801,7 +801,7 @@
       latitude_max: 67.0
       longitude_min: 135.0
       longitude_max: 179.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 68
   title: February 2023 Event 0438
   start_date: 2023-02-21 00:00:00
@@ -813,7 +813,7 @@
       latitude_max: 69.25
       longitude_min: 5.25
       longitude_max: 24.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 69
   title: February 2023 Event 0439
   start_date: 2023-02-21 00:00:00
@@ -825,7 +825,7 @@
       latitude_max: -17.75
       longitude_min: 116.25
       longitude_max: 137.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 70
   title: February 2023 Event 0440
   start_date: 2023-02-23 00:00:00
@@ -837,7 +837,7 @@
       latitude_max: 80.5
       longitude_min: 286.75
       longitude_max: 331.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 71
   title: February 2023 Event 0443
   start_date: 2023-02-28 00:00:00
@@ -849,7 +849,7 @@
       latitude_max: 62.25
       longitude_min: 281.75
       longitude_max: 300.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 72
   title: March 2023 Event 0458
   start_date: 2023-03-17 00:00:00
@@ -861,7 +861,7 @@
       latitude_max: 62.25
       longitude_min: 280.5
       longitude_max: 301.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 73
   title: May 2023 Event 0471
   start_date: 2023-05-08 00:00:00
@@ -873,7 +873,7 @@
       latitude_max: -20.5
       longitude_min: 117.0
       longitude_max: 134.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 74
   title: May 2023 Event 0474
   start_date: 2023-05-16 00:00:00
@@ -885,7 +885,7 @@
       latitude_max: 72.0
       longitude_min: 283.75
       longitude_max: 298.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 75
   title: May 2023 Event 0476
   start_date: 2023-05-17 00:00:00
@@ -897,7 +897,7 @@
       latitude_max: 71.25
       longitude_min: 280.75
       longitude_max: 298.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 76
   title: May 2023 Event 0480
   start_date: 2023-05-26 00:00:00
@@ -909,7 +909,7 @@
       latitude_max: 51.0
       longitude_min: 28.75
       longitude_max: 42.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 77
   title: June 2023 Event 0488
   start_date: 2023-06-23 00:00:00
@@ -921,7 +921,7 @@
       latitude_max: 31.75
       longitude_min: 15.75
       longitude_max: 38.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 78
   title: July 2023 Event 0493
   start_date: 2023-07-30 00:00:00
@@ -933,7 +933,7 @@
       latitude_max: 76.75
       longitude_min: 299.0
       longitude_max: 336.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 79
   title: August 2023 Event 0495
   start_date: 2023-08-21 00:00:00
@@ -945,7 +945,7 @@
       latitude_max: -15.0
       longitude_min: 123.25
       longitude_max: 133.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 80
   title: September 2023 Event 0499
   start_date: 2023-09-17 00:00:00
@@ -957,7 +957,7 @@
       latitude_max: 70.75
       longitude_min: 192.25
       longitude_max: 232.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 81
   title: October 2023 Event 0508
   start_date: 2023-10-06 00:00:00
@@ -969,7 +969,7 @@
       latitude_max: 32.25
       longitude_min: 351.5
       longitude_max: 359.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 82
   title: October 2023 Event 0509
   start_date: 2023-10-06 00:00:00
@@ -981,7 +981,7 @@
       latitude_max: 35.25
       longitude_min: 0.0
       longitude_max: 13.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 83
   title: October 2023 Event 0512
   start_date: 2023-10-15 00:00:00
@@ -993,7 +993,7 @@
       latitude_max: -21.25
       longitude_min: 121.5
       longitude_max: 133.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 84
   title: October 2023 Event 0515
   start_date: 2023-10-24 00:00:00
@@ -1005,7 +1005,7 @@
       latitude_max: 62.5
       longitude_min: 280.5
       longitude_max: 297.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 85
   title: October 2023 Event 0517
   start_date: 2023-10-29 00:00:00
@@ -1017,7 +1017,7 @@
       latitude_max: 67.25
       longitude_min: 240.0
       longitude_max: 276.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 86
   title: December 2023 Event 0530
   start_date: 2023-12-04 00:00:00
@@ -1029,7 +1029,7 @@
       latitude_max: 73.75
       longitude_min: 73.25
       longitude_max: 97.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 87
   title: December 2023 Event 0537
   start_date: 2023-12-11 00:00:00
@@ -1041,7 +1041,7 @@
       latitude_max: 72.75
       longitude_min: 73.25
       longitude_max: 98.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 88
   title: December 2023 Event 0544
   start_date: 2023-12-24 00:00:00
@@ -1053,7 +1053,7 @@
       latitude_max: 71.0
       longitude_min: 5.5
       longitude_max: 62.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 89
   title: January 2024 Event 0548
   start_date: 2024-01-01 00:00:00
@@ -1065,7 +1065,7 @@
       latitude_max: 22.75
       longitude_min: 20.75
       longitude_max: 37.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 90
   title: January 2024 Event 0555
   start_date: 2024-01-11 00:00:00
@@ -1077,7 +1077,7 @@
       latitude_max: 69.75
       longitude_min: 163.5
       longitude_max: 179.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 91
   title: February 2024 Event 0588
   start_date: 2024-02-24 00:00:00
@@ -1089,7 +1089,7 @@
       latitude_max: 73.5
       longitude_min: 270.25
       longitude_max: 298.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 92
   title: February 2024 Event 0590
   start_date: 2024-02-25 00:00:00
@@ -1101,7 +1101,7 @@
       latitude_max: 59.5
       longitude_min: 32.5
       longitude_max: 73.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 93
   title: February 2024 Event 0592
   start_date: 2024-02-25 00:00:00
@@ -1113,7 +1113,7 @@
       latitude_max: 81.5
       longitude_min: 296.0
       longitude_max: 320.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 94
   title: February 2024 Event 0593
   start_date: 2024-02-29 00:00:00
@@ -1125,7 +1125,7 @@
       latitude_max: 63.5
       longitude_min: 280.75
       longitude_max: 299.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 95
   title: April 2024 Event 0611
   start_date: 2024-04-27 00:00:00
@@ -1137,7 +1137,7 @@
       latitude_max: -14.0
       longitude_min: 116.0
       longitude_max: 140.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 96
   title: May 2024 Event 0614
   start_date: 2024-05-07 00:00:00
@@ -1149,7 +1149,7 @@
       latitude_max: 76.25
       longitude_min: 73.25
       longitude_max: 138.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 97
   title: May 2024 Event 0616
   start_date: 2024-05-19 00:00:00
@@ -1161,7 +1161,7 @@
       latitude_max: 62.5
       longitude_min: 282.0
       longitude_max: 297.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 98
   title: June 2024 Event 0621
   start_date: 2024-06-13 00:00:00
@@ -1173,7 +1173,7 @@
       latitude_max: 84.5
       longitude_min: 299.75
       longitude_max: 347.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 99
   title: June 2024 Event 0622
   start_date: 2024-06-15 00:00:00
@@ -1185,7 +1185,7 @@
       latitude_max: 77.75
       longitude_min: 250.25
       longitude_max: 273.75
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 100
   title: August 2024 Event 0624
   start_date: 2024-08-07 00:00:00
@@ -1197,7 +1197,7 @@
       latitude_max: 35.0
       longitude_min: 1.5
       longitude_max: 16.5
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 101
   title: September 2024 Event 0636
   start_date: 2024-09-19 00:00:00
@@ -1209,7 +1209,7 @@
       latitude_max: 77.5
       longitude_min: 73.25
       longitude_max: 129.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 102
   title: October 2024 Event 0641
   start_date: 2024-10-06 00:00:00
@@ -1221,7 +1221,7 @@
       latitude_max: 70.75
       longitude_min: 154.75
       longitude_max: 190.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 103
   title: October 2024 Event 0646
   start_date: 2024-10-27 00:00:00
@@ -1233,7 +1233,7 @@
       latitude_max: 61.5
       longitude_min: 233.0
       longitude_max: 264.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 104
   title: October 2024 Event 0647
   start_date: 2024-10-28 00:00:00
@@ -1245,7 +1245,7 @@
       latitude_max: 69.25
       longitude_min: 192.25
       longitude_max: 230.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 105
   title: November 2024 Event 0656
   start_date: 2024-11-17 00:00:00
@@ -1257,7 +1257,7 @@
       latitude_max: 78.5
       longitude_min: 297.75
       longitude_max: 340.25
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 106
   title: November 2024 Event 0659
   start_date: 2024-11-21 00:00:00
@@ -1269,7 +1269,7 @@
       latitude_max: 69.75
       longitude_min: 237.25
       longitude_max: 291.0
-  event_type: marginal_temperature
+  event_type: heat_wave
 - case_id_number: 107
   title: December 2024 Event 0674
   start_date: 2024-12-17 00:00:00
@@ -1281,4 +1281,4 @@
       latitude_max: 51.25
       longitude_min: 48.0
       longitude_max: 75.0
-  event_type: marginal_temperature
+  event_type: heat_wave

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -162,12 +162,16 @@ class TropicalCycloneTrackVariables(DerivedVariable):
                 Defaults to 48.0.
             use_contour_validation: Whether to apply closed contour validation.
                 Defaults to True.
-            min_track_timesteps: Minimum number of timesteps required for a valid track.
-                Defaults to 10.
+            timestep_count_wind_minimum: Minimum number of lead times where
+                the neighbourhood peak wind (max within
+                wind_search_radius_degrees) is >= 10 m/s for a track to be
+                retained. Defaults to 10.
             latitude_max_degrees: Maximum latitude in degrees for TC detection.
                 Defaults to 50.0.
-            surface_pressure_threshold: Surface pressure threshold in Pa.
-                Defaults to 100500.0.
+            surface_pressure_threshold: Maximum SLP (Pa) a candidate grid
+                point may have to be considered for peak detection. Defaults
+                to 101000.0 Pa, so only below-average pressure cells are
+                examined.
             orography: Optional orography DataArray for terrain filtering.
                 Defaults to None.
             max_gc_distance_slp_contour_degrees: Maximum great circle distance for
@@ -177,6 +181,9 @@ class TropicalCycloneTrackVariables(DerivedVariable):
                 degrees.
             orography_filter_threshold: Orography filter threshold in meters.
                 Defaults to 150.0.
+            wind_search_radius_degrees: GCD radius in degrees for
+                neighbourhood wind sampling, per TempestExtremes 2.1.
+                Converted to grid points at runtime. Defaults to 2.0.
         """
         super().__init__(output_variables=output_variables, name=name)
         self.slp_contour_magnitude = slp_contour_magnitude

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -129,13 +129,13 @@ class TropicalCycloneTrackVariables(DerivedVariable):
         name: Optional[str] = None,
         slp_contour_magnitude: float = 200.0,
         dz_contour_magnitude: float = -6.0,
-        min_distance_between_peaks: int = 5,
+        min_distance_between_peaks_degrees: float = 1.0,
         max_spatial_distance_degrees: float = 5.0,
         max_temporal_hours: float = 48.0,
         use_contour_validation: bool = True,
         timestep_count_wind_minimum: int = 10,
         latitude_max_degrees: float = 50.0,
-        surface_pressure_threshold: float = 100500.0,
+        surface_pressure_threshold: float = 101000.0,
         orography: Optional[xr.DataArray] = None,
         max_gc_distance_slp_contour_degrees: float = 5.5,
         max_gc_distance_dz_contour_degrees: float = 6.5,
@@ -153,8 +153,9 @@ class TropicalCycloneTrackVariables(DerivedVariable):
                 Defaults to 200.0.
             dz_contour_magnitude: Geopotential thickness contour threshold in m.
                 Defaults to -6.0.
-            min_distance_between_peaks: Minimum grid points between detected peaks.
-                Defaults to 5.
+            min_distance_between_peaks_degrees: Minimum distance
+                between detected peaks in degrees. Defaults
+                to 1.0.
             max_spatial_distance_degrees: Maximum distance in degrees for track matching.
                 Defaults to 5.0.
             max_temporal_hours: Maximum hours between detections for track continuity.
@@ -180,7 +181,7 @@ class TropicalCycloneTrackVariables(DerivedVariable):
         super().__init__(output_variables=output_variables, name=name)
         self.slp_contour_magnitude = slp_contour_magnitude
         self.dz_contour_magnitude = dz_contour_magnitude
-        self.min_distance_between_peaks = min_distance_between_peaks
+        self.min_distance_between_peaks_degrees = min_distance_between_peaks_degrees
         self.max_spatial_distance_degrees = max_spatial_distance_degrees
         self.max_temporal_hours = max_temporal_hours
         self.use_contour_validation = use_contour_validation
@@ -255,7 +256,7 @@ class TropicalCycloneTrackVariables(DerivedVariable):
             geopotential_thickness=prepared_data.get("geopotential_thickness", None),
             slp_contour_magnitude=self.slp_contour_magnitude,
             dz_contour_magnitude=self.dz_contour_magnitude,
-            min_distance_between_peaks=self.min_distance_between_peaks,
+            min_distance_between_peaks_degrees=self.min_distance_between_peaks_degrees,
             max_spatial_distance_degrees=self.max_spatial_distance_degrees,
             max_temporal_hours=self.max_temporal_hours,
             use_contour_validation=self.use_contour_validation,

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -129,13 +129,13 @@ class TropicalCycloneTrackVariables(DerivedVariable):
         name: Optional[str] = None,
         slp_contour_magnitude: float = 200.0,
         dz_contour_magnitude: float = -6.0,
-        min_distance_between_peaks_degrees: float = 1.0,
+        min_distance_between_peaks: int = 5,
         max_spatial_distance_degrees: float = 5.0,
         max_temporal_hours: float = 48.0,
         use_contour_validation: bool = True,
         timestep_count_wind_minimum: int = 10,
         latitude_max_degrees: float = 50.0,
-        surface_pressure_threshold: float = 102000.0,
+        surface_pressure_threshold: float = 100500.0,
         orography: Optional[xr.DataArray] = None,
         max_gc_distance_slp_contour_degrees: float = 5.5,
         max_gc_distance_dz_contour_degrees: float = 6.5,
@@ -153,24 +153,20 @@ class TropicalCycloneTrackVariables(DerivedVariable):
                 Defaults to 200.0.
             dz_contour_magnitude: Geopotential thickness contour threshold in m.
                 Defaults to -6.0.
-            min_distance_between_peaks_degrees: Minimum GCD distance between
-                detected peaks in degrees. Converted to grid points at runtime
-                using the actual model resolution. Defaults to 1.0 degree.
+            min_distance_between_peaks: Minimum grid points between detected peaks.
+                Defaults to 5.
             max_spatial_distance_degrees: Maximum distance in degrees for track matching.
                 Defaults to 5.0.
             max_temporal_hours: Maximum hours between detections for track continuity.
                 Defaults to 48.0.
             use_contour_validation: Whether to apply closed contour validation.
                 Defaults to True.
-            timestep_count_wind_minimum: Minimum number of lead times where the
-                neighbourhood peak wind (max within wind_search_radius_degrees)
-                is >= 10 m/s for a track to be retained. Defaults to 10.
+            min_track_timesteps: Minimum number of timesteps required for a valid track.
+                Defaults to 10.
             latitude_max_degrees: Maximum latitude in degrees for TC detection.
                 Defaults to 50.0.
-            surface_pressure_threshold: Maximum SLP (Pa) a candidate grid
-                point may have to be considered for peak detection. Defaults
-                to 101325.0 Pa (standard atmosphere), so only below-average
-                pressure cells are examined.
+            surface_pressure_threshold: Surface pressure threshold in Pa.
+                Defaults to 100500.0.
             orography: Optional orography DataArray for terrain filtering.
                 Defaults to None.
             max_gc_distance_slp_contour_degrees: Maximum great circle distance for
@@ -180,14 +176,11 @@ class TropicalCycloneTrackVariables(DerivedVariable):
                 degrees.
             orography_filter_threshold: Orography filter threshold in meters.
                 Defaults to 150.0.
-            wind_search_radius_degrees: GCD radius in degrees for neighbourhood
-                wind sampling, per TempestExtremes 2.1. Converted to grid
-                points at runtime. Defaults to 2.0 degrees.
         """
         super().__init__(output_variables=output_variables, name=name)
         self.slp_contour_magnitude = slp_contour_magnitude
         self.dz_contour_magnitude = dz_contour_magnitude
-        self.min_distance_between_peaks_degrees = min_distance_between_peaks_degrees
+        self.min_distance_between_peaks = min_distance_between_peaks
         self.max_spatial_distance_degrees = max_spatial_distance_degrees
         self.max_temporal_hours = max_temporal_hours
         self.use_contour_validation = use_contour_validation
@@ -262,7 +255,7 @@ class TropicalCycloneTrackVariables(DerivedVariable):
             geopotential_thickness=prepared_data.get("geopotential_thickness", None),
             slp_contour_magnitude=self.slp_contour_magnitude,
             dz_contour_magnitude=self.dz_contour_magnitude,
-            min_distance_between_peaks_degrees=self.min_distance_between_peaks_degrees,
+            min_distance_between_peaks=self.min_distance_between_peaks,
             max_spatial_distance_degrees=self.max_spatial_distance_degrees,
             max_temporal_hours=self.max_temporal_hours,
             use_contour_validation=self.use_contour_validation,

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -575,9 +575,11 @@ def _ensure_output_schema(df: pd.DataFrame, **metadata) -> pd.DataFrame:
     if missing_cols:
         logger.warning("Missing expected columns: %s.", missing_cols)
 
-    # Ensure all OUTPUT_COLUMNS are present (missing ones will be NaN)
-    # and reorder to match OUTPUT_COLUMNS specification
-    return df.reindex(columns=OUTPUT_COLUMNS)
+    # Ensure all OUTPUT_COLUMNS are present (missing ones will be NaN),
+    # reorder to match OUTPUT_COLUMNS specification, and preserve any
+    # extra columns (e.g. landfall metadata) appended at the end.
+    extra_cols = [c for c in df.columns if c not in OUTPUT_COLUMNS]
+    return df.reindex(columns=OUTPUT_COLUMNS + extra_cols)
 
 
 def _evaluate_metric_and_return_df(

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -56,13 +56,13 @@ def generate_tc_tracks_by_init_time(
     tc_track_analysis_data: xr.DataArray,
     slp_contour_magnitude: float = 200.0,
     dz_contour_magnitude: float = -6.0,
-    min_distance_between_peaks_degrees: float = 1.0,
+    min_distance_between_peaks: int = 5,
     max_spatial_distance_degrees: float = 5.0,
     max_temporal_hours: float = 48.0,
     use_contour_validation: bool = True,
     timestep_count_wind_minimum: int = 10,
     latitude_max_degrees: float = 50.0,
-    surface_pressure_threshold: float = 102000.0,
+    surface_pressure_threshold: float = 100500.0,
     orography: Optional[xr.DataArray] = None,
     max_gc_distance_slp_contour_degrees: float = 5.5,
     max_gc_distance_dz_contour_degrees: float = 6.5,
@@ -94,17 +94,15 @@ def generate_tc_tracks_by_init_time(
             200.0 Pa
         dz_contour_magnitude: DZ contour threshold for validation in m. Defaults to
             -6.0 m
-        min_distance_between_peaks_degrees: Minimum GCD distance between detected
-            peaks in degrees. Converted to grid points at runtime using the
-            actual grid resolution. Defaults to 1.0 degree
+        min_distance_between_peaks: Minimum distance between detected peaks in grid
+            points. Defaults to 5
         max_spatial_distance_degrees: Max spatial distance for TC track data filtering
             in degrees. Defaults to 5.0 degrees
         max_temporal_hours: Maximum temporal window from init_time in hours. Defaults
             to 48.0 hours
         use_contour_validation: Whether to use contour validation. Defaults to True
-        timestep_count_wind_minimum: Minimum number of lead times where the neighbourhood
-            peak wind speed (max within wind_search_radius_degrees) is >= 10 m/s
-            for a track to be considered valid. Defaults to 2
+        min_track_timesteps: Minimum consecutive lead times for valid tracks. Defaults
+            to 10
         latitude_max_degrees: Maximum latitude for valid tracks in degrees. Defaults
             to 50.0 degrees
         surface_pressure_threshold: Maximum surface pressure threshold for valid peaks
@@ -116,10 +114,6 @@ def generate_tc_tracks_by_init_time(
             in degrees. Defaults to 6.5 degrees
         orography_filter_threshold: Threshold for the orography filter's max height
             in m. Defaults to 150.0 m
-        wind_search_radius_degrees: GCD radius in degrees used to sample the
-            neighbourhood maximum wind speed around each detected peak, following
-            TempestExtremes 2.1. Converted to grid points at runtime. Defaults
-            to 2.0 degrees
 
     Returns:
         xarray Dataset with detected tropical cyclone tracks
@@ -182,7 +176,7 @@ def generate_tc_tracks_by_init_time(
             "latitude": latitude.values,
             "longitude": longitude.values,
             "tc_track_data_df": tc_track_data_df,
-            "min_distance_between_peaks_degrees": min_distance_between_peaks_degrees,
+            "min_distance_between_peaks": min_distance_between_peaks,
             "max_spatial_distance_degrees": max_spatial_distance_degrees,
             "max_temporal_hours": max_temporal_hours,
             "slp_contour_magnitude": slp_contour_magnitude,
@@ -195,7 +189,6 @@ def generate_tc_tracks_by_init_time(
             "max_gc_distance_slp_contour_degrees": max_gc_distance_slp_contour_degrees,
             "max_gc_distance_dz_contour_degrees": max_gc_distance_dz_contour_degrees,
             "orography_filter_threshold": orography_filter_threshold,
-            "wind_search_radius_degrees": wind_search_radius_degrees,
         },
         input_core_dims=[
             ["lead_time", "latitude", "longitude"],
@@ -260,7 +253,7 @@ def _process_single_init_time(
     latitude: npt.NDArray,
     longitude: npt.NDArray,
     tc_track_data_df: pd.DataFrame,
-    min_distance_between_peaks_degrees: float,
+    min_distance_between_peaks: float,
     max_spatial_distance_degrees: float,
     max_temporal_hours: float,
     slp_contour_magnitude: float,
@@ -321,7 +314,7 @@ def _process_single_init_time(
     # Convert degree-based spatial parameters to grid points using the
     # actual grid resolution so the code is resolution-agnostic.
     min_distance_between_peaks_gridpts = _degrees_to_gridpoints(
-        min_distance_between_peaks_degrees, latitude, longitude
+        min_distance_between_peaks, latitude, longitude
     )
     wind_search_radius_gridpts = _degrees_to_gridpoints(
         wind_search_radius_degrees, latitude, longitude
@@ -735,18 +728,18 @@ def _find_peaks_for_time_slice(
     current_valid_time: pd.Timestamp,
     tc_track_data_df: pd.DataFrame,
     min_distance_between_peaks: int,
-    lat_coords: npt.NDArray,
-    lon_coords: npt.NDArray,
-    max_spatial_distance_degrees: float,
-    max_temporal_hours: float,
-    slp_contour_magnitude: float,
-    dz_contour_magnitude: float,
-    use_contour_validation: bool,
-    is_first_timestep: bool,
-    surface_pressure_threshold: float,
-    latitude_max_degrees: float,
-    max_gc_distance_slp_contour_degrees: float,
-    max_gc_distance_dz_contour_degrees: float,
+    lat_coords: Optional[npt.NDArray] = None,
+    lon_coords: Optional[npt.NDArray] = None,
+    max_spatial_distance_degrees: float = 5.0,
+    max_temporal_hours: float = 48.0,
+    slp_contour_magnitude: float = 200.0,
+    dz_contour_magnitude: float = -6.0,
+    use_contour_validation: bool = True,
+    is_first_timestep: bool = False,
+    surface_pressure_threshold: float = 100500.0,
+    latitude_max_degrees: float = 50.0,
+    max_gc_distance_slp_contour_degrees: float = 5.5,
+    max_gc_distance_dz_contour_degrees: float = 6.5,
 ) -> npt.NDArray:
     """Find peaks with tropical cyclone track data filtering.
 
@@ -808,6 +801,10 @@ def _find_peaks_for_time_slice(
     low_pressure_mask = slp_slice < surface_pressure_threshold
 
     if not np.any(low_pressure_mask):
+        return np.array([])
+
+    # OPTIMIZED: Vectorized spatial masking
+    if lat_coords is None or lon_coords is None:
         return np.array([])
 
     spatial_mask = _create_spatial_mask(

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -117,12 +117,13 @@ def generate_tc_tracks_by_init_time(
         max_temporal_hours: Maximum temporal window from init_time in hours. Defaults
             to 48.0 hours
         use_contour_validation: Whether to use contour validation. Defaults to True
-        min_track_timesteps: Minimum consecutive lead times for valid tracks. Defaults
-            to 10
+        timestep_count_wind_minimum: Minimum number of lead times where the
+            neighbourhood peak wind speed (max within wind_search_radius_degrees)
+            is >= 10 m/s for a track to be considered valid. Defaults to 10
         latitude_max_degrees: Maximum latitude for valid tracks in degrees. Defaults
             to 50.0 degrees
         surface_pressure_threshold: Maximum surface pressure threshold for valid peaks
-            in Pa. Defaults to 100500.0 Pa
+            in Pa. Defaults to 101000.0 Pa
         orography: Orography dataarray in m. Defaults to None
         max_gc_distance_slp_contour_degrees: Max great circle distance for SLP contour
             in degrees. Defaults to 5.5 degrees
@@ -130,6 +131,10 @@ def generate_tc_tracks_by_init_time(
             in degrees. Defaults to 6.5 degrees
         orography_filter_threshold: Threshold for the orography filter's max height
             in m. Defaults to 150.0 m
+        wind_search_radius_degrees: GCD radius in degrees used to sample the
+            neighbourhood maximum wind speed around each detected peak,
+            following TempestExtremes 2.1. Converted to grid points at
+            runtime. Defaults to 2.0 degrees
 
     Returns:
         xarray Dataset with detected tropical cyclone tracks
@@ -755,8 +760,8 @@ def _find_peaks_for_time_slice(
     current_valid_time: pd.Timestamp,
     tc_track_data_df: pd.DataFrame,
     min_distance_between_peaks: int,
-    lat_coords: Optional[npt.NDArray] = None,
-    lon_coords: Optional[npt.NDArray] = None,
+    lat_coords: npt.NDArray,
+    lon_coords: npt.NDArray,
     max_spatial_distance_degrees: float = 5.0,
     max_temporal_hours: float = 48.0,
     slp_contour_magnitude: float = 200.0,
@@ -780,8 +785,8 @@ def _find_peaks_for_time_slice(
         current_valid_time: Current valid time being processed
         tc_track_data_df: Tropical cyclone track data
         min_distance_between_peaks: Minimum distance between peaks in grid points
-        lat_coords: Latitude coordinates in degrees. Defaults to None
-        lon_coords: Longitude coordinates in degrees. Defaults to None
+        lat_coords: 1-D latitude coordinate array in degrees
+        lon_coords: 1-D longitude coordinate array in degrees
         max_spatial_distance_degrees: Max spatial distance in degrees. Defaults to
             5.0 degrees
         max_temporal_hours: Max temporal buffer for genesis in hours. Defaults to
@@ -791,7 +796,7 @@ def _find_peaks_for_time_slice(
         use_contour_validation: Whether to use contour validation. Defaults to True
         is_first_timestep: If True, applies temporal buffer. Defaults to False
         surface_pressure_threshold: Maximum surface pressure threshold for valid peaks
-            in Pa. Defaults to 100500.0 Pa
+            in Pa. Defaults to 101000.0 Pa
         latitude_max_degrees: Maximum latitude for valid tracks in degrees. Defaults
             to 50.0 degrees
         max_gc_distance_slp_contour_degrees: Max great circle distance for SLP contour
@@ -828,10 +833,6 @@ def _find_peaks_for_time_slice(
     low_pressure_mask = slp_slice < surface_pressure_threshold
 
     if not np.any(low_pressure_mask):
-        return np.array([])
-
-    # OPTIMIZED: Vectorized spatial masking
-    if lat_coords is None or lon_coords is None:
         return np.array([])
 
     spatial_mask = _create_spatial_mask(

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -959,14 +959,21 @@ def _fill_track_gaps_from_fields(
     latitude: npt.NDArray,
     longitude: npt.NDArray,
     wind_search_radius_gridpts: int,
-    search_radius_degrees: float = 8.0,
+    search_radius_degrees: float = 3.0,
+    n_candidates: int = 5,
 ) -> list[dict]:
     """Fill track gaps using SLP minima from forecast fields.
 
     When the tracker loses a storm (e.g. over land), this
-    finds the nearest SLP minimum to the expected track
+    finds the SLP minimum closest to the expected track
     position for each missing timestep, ensuring continuous
     tracks between the first and last detection.
+
+    The algorithm picks the top-N lowest-SLP cells within
+    the search radius, then selects the one nearest to the
+    interpolated expected position. Each filled point
+    updates the "previous" anchor so successive gap fills
+    stay physically consistent along the track.
 
     Args:
         detections: Existing detections from the tracking pass.
@@ -982,6 +989,8 @@ def _fill_track_gaps_from_fields(
             grid points for sampling peak wind.
         search_radius_degrees: Max distance from the expected
             position to search for SLP minima (degrees).
+        n_candidates: Number of lowest-SLP cells to consider
+            when choosing the closest to expected position.
 
     Returns:
         detections list with gap-fill entries appended.
@@ -1014,22 +1023,28 @@ def _fill_track_gaps_from_fields(
         ts_dets.sort(key=lambda x: x[0])
         first_ts = ts_dets[0][0]
         last_ts = ts_dets[-1][0]
-        detected_set = {ts for ts, _ in ts_dets}
 
         if last_ts - first_ts <= 1:
             continue
 
+        # Mutable map so gap-fills update the "previous"
+        # anchor for subsequent gaps.
+        ts_to_det: dict[int, dict] = {
+            ts: d for ts, d in ts_dets
+        }
+
         for ts_idx in range(first_ts + 1, last_ts):
-            if ts_idx in detected_set:
+            if ts_idx in ts_to_det:
                 continue
 
-            # Find bracketing detections
             prev_det = next_det = None
-            for ts, det in ts_dets:
-                if ts < ts_idx:
-                    prev_det = (ts, det)
-                if ts > ts_idx:
-                    next_det = (ts, det)
+            for lb in range(ts_idx - 1, first_ts - 1, -1):
+                if lb in ts_to_det:
+                    prev_det = (lb, ts_to_det[lb])
+                    break
+            for lf in range(ts_idx + 1, last_ts + 1):
+                if lf in ts_to_det:
+                    next_det = (lf, ts_to_det[lf])
                     break
 
             if prev_det is None or next_det is None:
@@ -1045,22 +1060,24 @@ def _fill_track_gaps_from_fields(
             slp_slice = slp_data[_lt_idx]
             wind_slice = wind_data[_lt_idx]
 
-            # Approx distance in degrees from each grid
-            # point to expected position.
             dlat = latitude[:, np.newaxis] - exp_lat
             dlon = longitude[np.newaxis, :] - exp_lon
-            dlon = np.where(dlon > 180, dlon - 360, dlon)
-            dlon = np.where(dlon < -180, dlon + 360, dlon)
+            dlon = np.mod(dlon + 180, 360) - 180
             cos_lat = np.cos(np.radians(exp_lat))
             dist = np.sqrt(dlat**2 + (dlon * cos_lat) ** 2)
 
             mask = dist <= search_radius_degrees
-            if not mask.any():
+            n_valid = int(np.count_nonzero(mask))
+            if n_valid == 0:
                 continue
 
             slp_masked = np.where(mask, slp_slice, np.inf)
 
-            r, c = np.unravel_index(np.argmin(slp_masked), slp_masked.shape)
+            k = min(n_candidates, n_valid)
+            flat_idx = np.argpartition(slp_masked.ravel(), k)[:k]
+            cand_r, cand_c = np.unravel_index(flat_idx, slp_masked.shape)
+            best = int(np.argmin(dist[cand_r, cand_c]))
+            r, c = int(cand_r[best]), int(cand_c[best])
 
             peak_wind = _neighbourhood_max_wind(
                 wind_slice,
@@ -1069,17 +1086,17 @@ def _fill_track_gaps_from_fields(
                 wind_search_radius_gridpts,
             )
 
-            new_detections.append(
-                {
-                    "lead_time_index": int(_lt_idx),
-                    "valid_time_index": int(valid_time_indices_seq[ts_idx]),
-                    "track_id": tid,
-                    "latitude": float(latitude[r]),
-                    "longitude": float(longitude[c]),
-                    "slp": float(slp_slice[r, c]),
-                    "wind": float(peak_wind),
-                }
-            )
+            filled = {
+                "lead_time_index": int(_lt_idx),
+                "valid_time_index": int(valid_time_indices_seq[ts_idx]),
+                "track_id": tid,
+                "latitude": float(latitude[r]),
+                "longitude": float(longitude[c]),
+                "slp": float(slp_slice[r, c]),
+                "wind": float(peak_wind),
+            }
+            new_detections.append(filled)
+            ts_to_det[ts_idx] = filled
 
     detections.extend(new_detections)
     return detections

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -20,6 +20,22 @@ logger = logging.getLogger(__name__)
 Location = namedtuple("Location", ["latitude", "longitude"])
 
 
+def _neighbourhood_max_wind(
+    wind_slice: npt.NDArray,
+    row: int,
+    col: int,
+    radius_gridpts: int,
+) -> float:
+    """Return max wind speed in a box of ±radius around (row, col)."""
+    nr, nc = wind_slice.shape
+    return float(
+        wind_slice[
+            max(0, row - radius_gridpts) : min(nr, row + radius_gridpts + 1),
+            max(0, col - radius_gridpts) : min(nc, col + radius_gridpts + 1),
+        ].max()
+    )
+
+
 def _degrees_to_gridpoints(
     degrees: float,
     lat_coords: npt.NDArray,
@@ -56,13 +72,13 @@ def generate_tc_tracks_by_init_time(
     tc_track_analysis_data: xr.DataArray,
     slp_contour_magnitude: float = 200.0,
     dz_contour_magnitude: float = -6.0,
-    min_distance_between_peaks: int = 5,
+    min_distance_between_peaks_degrees: float = 1.0,
     max_spatial_distance_degrees: float = 5.0,
     max_temporal_hours: float = 48.0,
     use_contour_validation: bool = True,
     timestep_count_wind_minimum: int = 10,
     latitude_max_degrees: float = 50.0,
-    surface_pressure_threshold: float = 100500.0,
+    surface_pressure_threshold: float = 101000.0,
     orography: Optional[xr.DataArray] = None,
     max_gc_distance_slp_contour_degrees: float = 5.5,
     max_gc_distance_dz_contour_degrees: float = 6.5,
@@ -94,8 +110,8 @@ def generate_tc_tracks_by_init_time(
             200.0 Pa
         dz_contour_magnitude: DZ contour threshold for validation in m. Defaults to
             -6.0 m
-        min_distance_between_peaks: Minimum distance between detected peaks in grid
-            points. Defaults to 5
+        min_distance_between_peaks_degrees: Minimum distance
+            between detected peaks in degrees. Defaults to 1.0
         max_spatial_distance_degrees: Max spatial distance for TC track data filtering
             in degrees. Defaults to 5.0 degrees
         max_temporal_hours: Maximum temporal window from init_time in hours. Defaults
@@ -176,7 +192,7 @@ def generate_tc_tracks_by_init_time(
             "latitude": latitude.values,
             "longitude": longitude.values,
             "tc_track_data_df": tc_track_data_df,
-            "min_distance_between_peaks": min_distance_between_peaks,
+            "min_distance_between_peaks": min_distance_between_peaks_degrees,
             "max_spatial_distance_degrees": max_spatial_distance_degrees,
             "max_temporal_hours": max_temporal_hours,
             "slp_contour_magnitude": slp_contour_magnitude,
@@ -396,17 +412,14 @@ def _process_single_init_time(
             peak_lats = latitude[peaks[:, 0]]
             peak_lons = longitude[peaks[:, 1]]
             peak_slps = slp_slice[peaks[:, 0], peaks[:, 1]]
-            # Sample max wind within wind_search_radius_degrees of each
-            # detected peak (per TempestExtremes 2.1) to capture the eyewall
-            # rather than the low-wind eye at the SLP minimum.
-            _nrows, _ncols = wind_slice.shape
-            _nb = wind_search_radius_gridpts
             peak_winds = np.array(
                 [
-                    wind_slice[
-                        max(0, r - _nb) : min(_nrows, r + _nb + 1),
-                        max(0, c - _nb) : min(_ncols, c + _nb + 1),
-                    ].max()
+                    _neighbourhood_max_wind(
+                        wind_slice,
+                        r,
+                        c,
+                        wind_search_radius_gridpts,
+                    )
                     for r, c in peaks
                 ]
             )
@@ -505,6 +518,20 @@ def _process_single_init_time(
             timestep_count_wind_minimum,
         )
         detections = filtered_detections
+
+    # Fill gaps in surviving tracks using SLP minima from
+    # the forecast fields as a fallback when the standard
+    # peak-finding/validation failed at intermediate leads.
+    detections = _fill_track_gaps_from_fields(
+        detections,
+        slp_data,
+        wind_data,
+        lead_time_indices_seq,
+        valid_time_indices_seq,
+        latitude,
+        longitude,
+        wind_search_radius_gridpts,
+    )
 
     return {"detections": detections}
 
@@ -736,7 +763,7 @@ def _find_peaks_for_time_slice(
     dz_contour_magnitude: float = -6.0,
     use_contour_validation: bool = True,
     is_first_timestep: bool = False,
-    surface_pressure_threshold: float = 100500.0,
+    surface_pressure_threshold: float = 101000.0,
     latitude_max_degrees: float = 50.0,
     max_gc_distance_slp_contour_degrees: float = 5.5,
     max_gc_distance_dz_contour_degrees: float = 6.5,
@@ -921,6 +948,141 @@ def _create_spatial_mask(
         spatial_mask |= distances <= max_distance_degrees
 
     return spatial_mask
+
+
+def _fill_track_gaps_from_fields(
+    detections: list[dict],
+    slp_data: npt.NDArray,
+    wind_data: npt.NDArray,
+    lead_time_indices_seq: npt.NDArray,
+    valid_time_indices_seq: npt.NDArray,
+    latitude: npt.NDArray,
+    longitude: npt.NDArray,
+    wind_search_radius_gridpts: int,
+    search_radius_degrees: float = 8.0,
+) -> list[dict]:
+    """Fill track gaps using SLP minima from forecast fields.
+
+    When the tracker loses a storm (e.g. over land), this
+    finds the nearest SLP minimum to the expected track
+    position for each missing timestep, ensuring continuous
+    tracks between the first and last detection.
+
+    Args:
+        detections: Existing detections from the tracking pass.
+        slp_data: Full SLP array (lead_time, lat, lon) in Pa.
+        wind_data: Full wind array (lead_time, lat, lon) in m/s.
+        lead_time_indices_seq: Ordered lead_time indices for
+            each timestep of this init_time.
+        valid_time_indices_seq: Ordered valid_time indices for
+            each timestep.
+        latitude: 1-D latitude coordinate array (degrees).
+        longitude: 1-D longitude coordinate array (degrees).
+        wind_search_radius_gridpts: Neighbourhood radius in
+            grid points for sampling peak wind.
+        search_radius_degrees: Max distance from the expected
+            position to search for SLP minima (degrees).
+
+    Returns:
+        detections list with gap-fill entries appended.
+    """
+    if not detections:
+        return detections
+
+    ts_lookup: dict[tuple[int, int], int] = {}
+    for ts_idx in range(len(lead_time_indices_seq)):
+        key = (
+            int(lead_time_indices_seq[ts_idx]),
+            int(valid_time_indices_seq[ts_idx]),
+        )
+        ts_lookup[key] = ts_idx
+
+    # Group detections by track_id -> [(ts_idx, det), ...]
+    track_timeline: dict[int, list[tuple[int, dict]]] = {}
+    for det in detections:
+        key = (
+            int(det["lead_time_index"]),
+            int(det["valid_time_index"]),
+        )
+        maybe_ts = ts_lookup.get(key)
+        if maybe_ts is not None:
+            track_timeline.setdefault(det["track_id"], []).append((maybe_ts, det))
+
+    new_detections: list[dict] = []
+
+    for tid, ts_dets in track_timeline.items():
+        ts_dets.sort(key=lambda x: x[0])
+        first_ts = ts_dets[0][0]
+        last_ts = ts_dets[-1][0]
+        detected_set = {ts for ts, _ in ts_dets}
+
+        if last_ts - first_ts <= 1:
+            continue
+
+        for ts_idx in range(first_ts + 1, last_ts):
+            if ts_idx in detected_set:
+                continue
+
+            # Find bracketing detections
+            prev_det = next_det = None
+            for ts, det in ts_dets:
+                if ts < ts_idx:
+                    prev_det = (ts, det)
+                if ts > ts_idx:
+                    next_det = (ts, det)
+                    break
+
+            if prev_det is None or next_det is None:
+                continue
+
+            p_ts, p_d = prev_det
+            n_ts, n_d = next_det
+            frac = (ts_idx - p_ts) / (n_ts - p_ts)
+            exp_lat = p_d["latitude"] + frac * (n_d["latitude"] - p_d["latitude"])
+            exp_lon = p_d["longitude"] + frac * (n_d["longitude"] - p_d["longitude"])
+
+            _lt_idx = lead_time_indices_seq[ts_idx]
+            slp_slice = slp_data[_lt_idx]
+            wind_slice = wind_data[_lt_idx]
+
+            # Approx distance in degrees from each grid
+            # point to expected position.
+            dlat = latitude[:, np.newaxis] - exp_lat
+            dlon = longitude[np.newaxis, :] - exp_lon
+            dlon = np.where(dlon > 180, dlon - 360, dlon)
+            dlon = np.where(dlon < -180, dlon + 360, dlon)
+            cos_lat = np.cos(np.radians(exp_lat))
+            dist = np.sqrt(dlat**2 + (dlon * cos_lat) ** 2)
+
+            mask = dist <= search_radius_degrees
+            if not mask.any():
+                continue
+
+            slp_masked = np.where(mask, slp_slice, np.inf)
+
+            r, c = np.unravel_index(np.argmin(slp_masked), slp_masked.shape)
+
+            peak_wind = _neighbourhood_max_wind(
+                wind_slice,
+                r,
+                c,
+                wind_search_radius_gridpts,
+            )
+
+            new_detections.append(
+                {
+                    "lead_time_index": int(_lt_idx),
+                    "valid_time_index": int(valid_time_indices_seq[ts_idx]),
+                    "track_id": tid,
+                    "latitude": float(latitude[r]),
+                    "longitude": float(longitude[c]),
+                    "slp": float(slp_slice[r, c]),
+                    "wind": float(peak_wind),
+                }
+            )
+
+    detections.extend(new_detections)
+    return detections
 
 
 def _convert_detections_to_dataset(

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -1029,9 +1029,7 @@ def _fill_track_gaps_from_fields(
 
         # Mutable map so gap-fills update the "previous"
         # anchor for subsequent gaps.
-        ts_to_det: dict[int, dict] = {
-            ts: d for ts, d in ts_dets
-        }
+        ts_to_det: dict[int, dict] = {ts: d for ts, d in ts_dets}
 
         for ts_idx in range(first_ts + 1, last_ts):
             if ts_idx in ts_to_det:

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1650,6 +1650,8 @@ class LandfallMetric(CompositeMetric):
         forecast_variable: Optional[str | derived.DerivedVariable] = None,
         target_variable: Optional[str | derived.DerivedVariable] = None,
         metrics: Optional[list[Type["LandfallMetric"]]] = None,
+        min_target_separation_hours: float = 0.0,
+        max_time_mismatch_hours: Optional[float] = None,
         *args,
         **kwargs,
     ):
@@ -1676,6 +1678,15 @@ class LandfallMetric(CompositeMetric):
             forecast_variable: The forecast variable to use. Defaults to None.
             target_variable: The target variable to use. Defaults to None.
             metrics: A list of metrics to use as a composite. Defaults to None.
+            min_target_separation_hours: If > 0, pre-filter observed target landfalls
+                so that consecutive retained landfalls are separated by at least this
+                many hours. Removes rapid sequential island/peninsula crossings that
+                models cannot resolve individually. Only applies when approach="next".
+            max_time_mismatch_hours: If set, discard matched forecast–target pairs
+                where the model's predicted landfall time differs from the matched
+                target landfall time by more than this many hours. Prevents pairing
+                a forecast that skips a minor first landfall with the wrong target.
+                Only applies when approach="next" and forecast valid_time is available.
         """
         super().__init__(
             name=name,
@@ -1687,6 +1698,8 @@ class LandfallMetric(CompositeMetric):
         )
         self.approach = approach
         self.exclude_post_landfall = exclude_post_landfall
+        self.min_target_separation_hours = min_target_separation_hours
+        self.max_time_mismatch_hours = max_time_mismatch_hours
         self.metrics = metrics or []
 
         # If metrics provided, instantiate them
@@ -1717,6 +1730,11 @@ class LandfallMetric(CompositeMetric):
             **kwargs: Additional keyword arguments
         """
         return self.compute_metric(forecast, target, **kwargs)
+
+    def _nan_landfall_pair(self):
+        """Return a (NaN, NaN) forecast/target landfall pair."""
+        a = utils._create_nan_dataarray(self.preserve_dims)
+        return (a, a.copy())
 
     def maybe_compute_landfalls(
         self, forecast: xr.DataArray, target: xr.DataArray, **kwargs: Any
@@ -1749,49 +1767,88 @@ class LandfallMetric(CompositeMetric):
         # For "next" approach: get all target landfalls, then filter
         return_next_landfall = self.approach == "next"
 
-        # Get first forecast landfall per init_time
         forecast_landfalls = calc.find_landfalls(forecast)
 
-        # find_landfalls never returns None; an empty array means no landfalls.
         if len(forecast_landfalls) == 0:
-            nan_landfalls = utils._create_nan_dataarray(self.preserve_dims)
-            return (nan_landfalls, nan_landfalls.copy())
+            return self._nan_landfall_pair()
 
-        # Get all target landfalls
         target_landfalls = calc.find_landfalls(target)
 
         if len(target_landfalls) == 0:
-            nan_landfalls = utils._create_nan_dataarray(self.preserve_dims)
-            return (nan_landfalls, nan_landfalls.copy())
+            return self._nan_landfall_pair()
 
         if return_next_landfall:
             max_lead = None
+            track_starts = None
             if "lead_time" in forecast.dims:
                 max_lead = forecast.lead_time.values.max()
                 if not isinstance(max_lead, np.timedelta64):
                     max_lead = np.timedelta64(int(max_lead), "h")
+                track_starts = calc.get_forecast_track_start_times(forecast)
             target_landfalls = calc.find_next_landfall_for_init_time(
                 forecast_landfalls,
                 target_landfalls,
                 max_lead_time=max_lead,
+                min_target_separation_hours=self.min_target_separation_hours,
+                max_time_mismatch_hours=self.max_time_mismatch_hours,
+                track_start_times=track_starts,
             )
             if len(target_landfalls) == 0:
-                nan_landfalls = utils._create_nan_dataarray(self.preserve_dims)
-                return (nan_landfalls, nan_landfalls.copy())
-        else:
-            # First approach: target is (landfall,) with one observed event.
-            # Drop forecast init_times at or after the landfall to prevent
-            # data leakage, then broadcast the single target to (init_time,)
-            # so sub-metrics receive consistent arrays.
-            first_valid_time = (
-                target_landfalls.coords["valid_time"].isel(landfall=0).values
+                return self._nan_landfall_pair()
+            # Reduce to first forecast landfall per init_time so
+            # downstream metrics compare one-to-one instead of
+            # averaging across multiple forecast landfalls.
+            forecast_landfalls = calc.select_first_forecast_landfall_per_init(
+                forecast_landfalls
             )
-            forecast_landfalls = forecast_landfalls.where(
-                forecast_landfalls.init_time < first_valid_time,
-                drop=True,
+        else:
+            # "first" approach: compare to the earliest IBTrACS
+            # landfall that the forecast can actually cover.
+            # If the first landfall has no forecast data (e.g.
+            # tracker misses a Cuba crossing), fall back to the
+            # next landfall with coverage.
+            reduced_forecast = calc.select_first_forecast_landfall_per_init(
+                forecast_landfalls
+            )
+            track_starts = None
+            if "lead_time" in forecast.dims:
+                track_starts = calc.get_forecast_track_start_times(forecast)
+
+            n_targets = target_landfalls.sizes.get("landfall", 1)
+            selected_idx = None
+            for lf_idx in range(n_targets):
+                candidate_vt = (
+                    target_landfalls.coords["valid_time"].isel(landfall=lf_idx).values
+                )
+                candidate_fc = reduced_forecast.where(
+                    reduced_forecast.init_time < candidate_vt,
+                    drop=True,
+                )
+                if len(candidate_fc) == 0:
+                    continue
+                if track_starts is not None:
+                    candidate_fc = calc.filter_inits_by_track_start(
+                        candidate_fc,
+                        candidate_vt,
+                        track_starts,
+                    )
+                if len(candidate_fc) > 0:
+                    selected_idx = lf_idx
+                    forecast_landfalls = candidate_fc
+                    break
+
+            if selected_idx is None:
+                return self._nan_landfall_pair()
+
+            # slice keeps the landfall dim (length 1) so
+            # broadcast_first_target_to_init_times can
+            # .isel(landfall=0) on it.
+            selected_target = target_landfalls.isel(
+                landfall=slice(selected_idx, selected_idx + 1)
             )
             target_landfalls = calc.broadcast_first_target_to_init_times(
-                forecast_landfalls.init_time, target_landfalls
+                forecast_landfalls.init_time,
+                selected_target,
             )
         return forecast_landfalls, target_landfalls
 
@@ -1823,6 +1880,49 @@ class LandfallMetric(CompositeMetric):
         kwargs["preserve_dims"] = self.preserve_dims
 
         return kwargs
+
+    @staticmethod
+    def _attach_landfall_metadata(
+        result: xr.DataArray,
+        forecast_landfall: xr.DataArray,
+        target_landfall: xr.DataArray,
+    ) -> xr.DataArray:
+        """Attach forecast/target landfall coords to a result.
+
+        Adds latitude, longitude, and valid_time for both the
+        forecast and target landfalls as coordinates on the
+        result DataArray. These become extra columns when
+        converted to a DataFrame in the evaluation pipeline.
+        """
+        if "init_time" not in result.dims:
+            return result
+        coord_map = {}
+        for prefix, lf in (
+            ("forecast_landfall", forecast_landfall),
+            ("target_landfall", target_landfall),
+        ):
+            for coord in ("latitude", "longitude", "valid_time"):
+                if coord in lf.coords:
+                    vals = lf.coords[coord].values
+                    if vals.ndim == 0:
+                        vals = np.full(
+                            len(result.init_time),
+                            vals,
+                        )
+                    coord_map[f"{prefix}_{coord}"] = (
+                        "init_time",
+                        vals,
+                    )
+        return result.assign_coords(coord_map)
+
+    @staticmethod
+    def _reduce_landfall_dim(
+        result: xr.DataArray,
+    ) -> xr.DataArray:
+        """Mean over landfall dim if present."""
+        if "landfall" in result.dims:
+            return result.mean(dim="landfall")
+        return result
 
     def _compute_metric(
         self,
@@ -2010,7 +2110,8 @@ class LandfallDisplacement(LandfallMetric):
         )
         if not isinstance(distances, xr.DataArray):
             raise TypeError("haversine_distance returned a scalar; expected DataArray")
-        return distances.where(forecast_landfall.notnull()).mean(dim="landfall")
+        result = distances.where(forecast_landfall.notnull())
+        return self._reduce_landfall_dim(result)
 
     def _compute_metric(
         self, forecast: xr.DataArray, target: xr.DataArray, **kwargs: Any
@@ -2023,10 +2124,15 @@ class LandfallDisplacement(LandfallMetric):
             forecast_landfall
         ) or not utils.is_valid_landfall(target_landfall):
             return utils._create_nan_dataarray(self.preserve_dims)
-        return self.calculate_displacement(
+        result = self.calculate_displacement(
             forecast_landfall,
             target_landfall,
             units=self.units,
+        )
+        return self._attach_landfall_metadata(
+            result,
+            forecast_landfall,
+            target_landfall,
         )
 
 
@@ -2082,7 +2188,8 @@ class LandfallTimeMeanError(LandfallMetric):
         time_diffs = (
             forecast_landfall.valid_time - target_landfall.valid_time
         ) / np.timedelta64(1, "h")
-        return time_diffs.where(forecast_landfall.notnull()).mean(dim="landfall")
+        result = time_diffs.where(forecast_landfall.notnull())
+        return self._reduce_landfall_dim(result)
 
     def _compute_metric(
         self, forecast: xr.DataArray, target: xr.DataArray, **kwargs: Any
@@ -2095,7 +2202,15 @@ class LandfallTimeMeanError(LandfallMetric):
             forecast_landfall
         ) or not utils.is_valid_landfall(target_landfall):
             return utils._create_nan_dataarray(self.preserve_dims)
-        return self.calculate_time_difference(forecast_landfall, target_landfall)
+        result = self.calculate_time_difference(
+            forecast_landfall,
+            target_landfall,
+        )
+        return self._attach_landfall_metadata(
+            result,
+            forecast_landfall,
+            target_landfall,
+        )
 
 
 class LandfallIntensityMeanAbsoluteError(LandfallMetric, MeanAbsoluteError):
@@ -2137,8 +2252,13 @@ class LandfallIntensityMeanAbsoluteError(LandfallMetric, MeanAbsoluteError):
         ) or not utils.is_valid_landfall(target_landfall):
             return utils._create_nan_dataarray(self.preserve_dims)
 
-        return (
-            np.abs(forecast_landfall - target_landfall)
-            .where(forecast_landfall.notnull())
-            .mean(dim="landfall")
+        result = self._reduce_landfall_dim(
+            np.abs(forecast_landfall - target_landfall).where(
+                forecast_landfall.notnull()
+            )
+        )
+        return self._attach_landfall_metadata(
+            result,
+            forecast_landfall,
+            target_landfall,
         )

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1723,7 +1723,7 @@ class LandfallMetric(CompositeMetric):
         """
         return self.compute_metric(forecast, target, **kwargs)
 
-    def _nan_landfall_pair(self):
+    def _nan_landfall_pair(self) -> tuple[xr.DataArray, xr.DataArray]:
         """Return a (NaN, NaN) forecast/target landfall pair."""
         a = utils._create_nan_dataarray(self.preserve_dims)
         return (a, a.copy())
@@ -1795,10 +1795,7 @@ class LandfallMetric(CompositeMetric):
             forecast_landfalls = calc.select_first_forecast_landfall_per_init(
                 forecast_landfalls
             )
-            common = np.intersect1d(
-                forecast_landfalls.init_time.values,
-                target_landfalls.init_time.values,
-            )
+            common = utils.find_common_init_times(forecast_landfalls, target_landfalls)
             if len(common) == 0:
                 return self._nan_landfall_pair()
             forecast_landfalls = forecast_landfalls.sel(init_time=common)

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1652,41 +1652,37 @@ class LandfallMetric(CompositeMetric):
         metrics: Optional[list[Type["LandfallMetric"]]] = None,
         min_target_separation_hours: float = 0.0,
         max_time_mismatch_hours: Optional[float] = None,
+        landfall_time_filter: Optional[tuple[str, float]] = ("window", 24.0),
         *args,
         **kwargs,
     ):
-        """Initialize LandfallMetric.
+        """Configure landfall detection and filtering.
 
-        Landfalls are detected using the calc.find_landfalls function, which utilizes a
-        land geometry and line segments based on coordinates to determine intersections.
-
-        Using approach, "first" will calculate the first detected landfall for an entire
-        forecast, i.e. later landfalls in a multi-landfall event will not be considered.
-        "next" will calculate the next landfall for each init_time.
-        Using Ida as an example (case 220), "first" would only run calculations for the
-        first landfall in Cuba, ignoring the later US landfall. "next" would run
-        calculations for the first landfall in Cuba, then the next landfall in the US,
-        etc. based on the init_time and when landfall occurred.
+        ``approach="first"`` evaluates the first observed
+        landfall only; ``approach="next"`` matches each
+        init_time to the closest future observed landfall.
 
         Args:
-            name: The name of the metric. Defaults to "landfall_metrics" for the base
-                class.
-            preserve_dims: The dimensions to preserve. Defaults to "init_time".
-            approach: The approach to use for landfall detection. Defaults to "first".
-            exclude_post_landfall: Whether to exclude post-landfall data. Defaults to
-                False.
-            forecast_variable: The forecast variable to use. Defaults to None.
-            target_variable: The target variable to use. Defaults to None.
-            metrics: A list of metrics to use as a composite. Defaults to None.
-            min_target_separation_hours: If > 0, pre-filter observed target landfalls
-                so that consecutive retained landfalls are separated by at least this
-                many hours. Removes rapid sequential island/peninsula crossings that
-                models cannot resolve individually. Only applies when approach="next".
-            max_time_mismatch_hours: If set, discard matched forecast–target pairs
-                where the model's predicted landfall time differs from the matched
-                target landfall time by more than this many hours. Prevents pairing
-                a forecast that skips a minor first landfall with the wrong target.
-                Only applies when approach="next" and forecast valid_time is available.
+            name: Metric name.
+            preserve_dims: Dims to keep in the result.
+            approach: ``"first"`` or ``"next"``.
+            exclude_post_landfall: Drop post-landfall data.
+            forecast_variable: Forecast variable name.
+            target_variable: Target variable name.
+            metrics: Sub-metric classes for composite mode.
+            min_target_separation_hours: Min hours between
+                consecutive target landfalls. Filters rapid
+                island crossings. Only for ``"next"``.
+            max_time_mismatch_hours: Max hours between
+                matched forecast/target landfall times.
+                Only for ``"next"``.
+            landfall_time_filter: How to filter paired
+                forecast/target landfalls by timing.
+                ``("window", hours)`` keeps pairs within
+                a fixed ± window.
+                ``("proportional", fraction)`` keeps pairs
+                where timing error < fraction * lead time.
+                ``None`` disables filtering.
         """
         super().__init__(
             name=name,
@@ -1700,24 +1696,20 @@ class LandfallMetric(CompositeMetric):
         self.exclude_post_landfall = exclude_post_landfall
         self.min_target_separation_hours = min_target_separation_hours
         self.max_time_mismatch_hours = max_time_mismatch_hours
+        self.landfall_time_filter = landfall_time_filter
         self.metrics = metrics or []
-
-        # If metrics provided, instantiate them
-        if self.metrics is not None:
-            self._metric_instances = [
-                (
-                    metric_cls(
-                        preserve_dims=self.preserve_dims,
-                        forecast_variable=self.forecast_variable,
-                        target_variable=self.target_variable,
-                    )
-                    if isinstance(metric_cls, type)
-                    else metric_cls
+        self._metric_instances = [
+            (
+                metric_cls(
+                    preserve_dims=self.preserve_dims,
+                    forecast_variable=self.forecast_variable,
+                    target_variable=self.target_variable,
                 )
-                for metric_cls in self.metrics
-            ]
-        else:
-            self._metric_instances = []
+                if isinstance(metric_cls, type)
+                else metric_cls
+            )
+            for metric_cls in self.metrics
+        ]
 
     def __call__(
         self, forecast: xr.DataArray, target: xr.DataArray, **kwargs: Any
@@ -1739,22 +1731,24 @@ class LandfallMetric(CompositeMetric):
     def maybe_compute_landfalls(
         self, forecast: xr.DataArray, target: xr.DataArray, **kwargs: Any
     ) -> tuple[xr.DataArray, xr.DataArray]:
-        """Compute landfalls for a given forecast and target dataarray.
+        """Detect and pair forecast/target landfalls.
 
-        This function computes the landfalls for a given forecast and target dataarray
-        using calc.find_landfalls. Currently, this access pattern doesn't include
-        passing land geometry in, but calc.find_landfalls will use NaturalEarth's 10m
-        land geometry by default.
+        Uses ``calc.find_landfalls`` (NaturalEarth 10m land
+        geometry) then applies approach-specific matching and
+        the configured time filters.
+
+        Pre-computed landfalls can be passed via ``kwargs``
+        keys ``forecast_landfall`` and ``target_landfall``
+        to skip detection.
 
         Args:
-            forecast: The forecast DataArray
-            target: The target DataArray
-            **kwargs: Additional keyword arguments, may include pre-computed
-                forecast_landfall and target_landfall
+            forecast: Forecast DataArray.
+            target: Target DataArray.
+            **kwargs: May include pre-computed landfalls.
 
         Returns:
-            Tuple of (forecast_landfall, target_landfall). If no landfalls are found,
-            returns NaN DataArrays with init_time dimension.
+            ``(forecast_landfall, target_landfall)`` tuple,
+            or NaN arrays if no valid landfalls remain.
         """
         forecast_landfall, target_landfall = (
             kwargs.get("forecast_landfall", None),
@@ -1801,6 +1795,14 @@ class LandfallMetric(CompositeMetric):
             forecast_landfalls = calc.select_first_forecast_landfall_per_init(
                 forecast_landfalls
             )
+            common = np.intersect1d(
+                forecast_landfalls.init_time.values,
+                target_landfalls.init_time.values,
+            )
+            if len(common) == 0:
+                return self._nan_landfall_pair()
+            forecast_landfalls = forecast_landfalls.sel(init_time=common)
+            target_landfalls = target_landfalls.sel(init_time=common)
         else:
             # "first" approach: compare to the earliest IBTrACS
             # landfall that the forecast can actually cover.
@@ -1850,6 +1852,32 @@ class LandfallMetric(CompositeMetric):
                 forecast_landfalls.init_time,
                 selected_target,
             )
+
+        if self.landfall_time_filter is not None:
+            method, value = self.landfall_time_filter
+            if method == "window":
+                forecast_landfalls, target_landfalls = (
+                    calc.filter_by_landfall_time_window(
+                        forecast_landfalls,
+                        target_landfalls,
+                        window_hours=value,
+                    )
+                )
+            elif method == "proportional":
+                forecast_landfalls, target_landfalls = (
+                    calc.filter_by_landfall_time_tolerance(
+                        forecast_landfalls,
+                        target_landfalls,
+                        tolerance_fraction=value,
+                    )
+                )
+            else:
+                raise ValueError(
+                    f'Unknown filter method {method!r}. Use "window" or "proportional".'
+                )
+            if len(forecast_landfalls) == 0:
+                return self._nan_landfall_pair()
+
         return forecast_landfalls, target_landfalls
 
     def maybe_prepare_composite_kwargs(

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1765,9 +1765,15 @@ class LandfallMetric(CompositeMetric):
             return (nan_landfalls, nan_landfalls.copy())
 
         if return_next_landfall:
-            # Find next target landfall for each init_time
+            max_lead = None
+            if "lead_time" in forecast.dims:
+                max_lead = forecast.lead_time.values.max()
+                if not isinstance(max_lead, np.timedelta64):
+                    max_lead = np.timedelta64(int(max_lead), "h")
             target_landfalls = calc.find_next_landfall_for_init_time(
-                forecast_landfalls, target_landfalls
+                forecast_landfalls,
+                target_landfalls,
+                max_lead_time=max_lead,
             )
             if len(target_landfalls) == 0:
                 nan_landfalls = utils._create_nan_dataarray(self.preserve_dims)

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -32,6 +32,15 @@ operators = {
 }
 
 
+def _empty_init_time_array() -> xr.DataArray:
+    """Empty float DataArray with an init_time dimension."""
+    return xr.DataArray(
+        np.array([], dtype=float),
+        dims=["init_time"],
+        coords={"init_time": np.array([], dtype="datetime64[ns]")},
+    )
+
+
 def maybe_get_operator(
     operator_method: Union[Literal[">", ">=", "<", "<=", "==", "!="], Callable],
 ) -> Callable:

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -2282,6 +2282,198 @@ class TestLandfallNextApproach:
         assert isinstance(result, xr.DataArray)
         assert len(result) == 0
 
+    def test_find_next_landfall_max_lead_time(self):
+        """Landfalls beyond the forecast horizon are excluded."""
+        init_times = pd.to_datetime(["2023-09-14 00:00", "2023-09-14 12:00"])
+        forecast_landfalls = xr.DataArray(
+            [35.0, 36.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": (
+                    ["init_time"],
+                    init_times + pd.Timedelta(hours=12),
+                ),
+                "latitude": (["init_time"], [24.0, 24.5]),
+                "longitude": (["init_time"], [280.0, 279.5]),
+            },
+            name="surface_wind_speed",
+        )
+
+        target_times = pd.to_datetime(["2023-09-14 18:00", "2023-09-26 00:00"])
+        target_landfalls = xr.DataArray(
+            [40.0, 45.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0, 1],
+                "valid_time": (["landfall"], target_times),
+                "latitude": (["landfall"], [26.0, 50.0]),
+                "longitude": (["landfall"], [278.0, 300.0]),
+            },
+            name="surface_wind_speed",
+        )
+
+        max_lead = np.timedelta64(240, "h")
+        result = calc.find_next_landfall_for_init_time(
+            forecast_landfalls,
+            target_landfalls,
+            max_lead_time=max_lead,
+        )
+
+        assert isinstance(result, xr.DataArray)
+        assert "init_time" in result.dims
+        vt_vals = np.atleast_1d(result.coords["valid_time"].values)
+        for vt in vt_vals:
+            assert vt == target_times[0]
+
+    def test_find_next_landfall_max_lead_time_all_excluded(self):
+        """All landfalls beyond horizon returns empty."""
+        init_times = pd.to_datetime(["2023-09-01 00:00"])
+        forecast_landfalls = xr.DataArray(
+            [35.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": (
+                    ["init_time"],
+                    init_times + pd.Timedelta(hours=6),
+                ),
+                "latitude": (["init_time"], [24.0]),
+                "longitude": (["init_time"], [280.0]),
+            },
+        )
+
+        target_times = pd.to_datetime(["2023-09-20 00:00"])
+        target_landfalls = xr.DataArray(
+            [40.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0],
+                "valid_time": (["landfall"], target_times),
+                "latitude": (["landfall"], [50.0]),
+                "longitude": (["landfall"], [300.0]),
+            },
+        )
+
+        max_lead = np.timedelta64(240, "h")
+        result = calc.find_next_landfall_for_init_time(
+            forecast_landfalls,
+            target_landfalls,
+            max_lead_time=max_lead,
+        )
+
+        assert isinstance(result, xr.DataArray)
+        assert len(result) == 0
+
+    def test_find_next_landfall_temporal_proximity(self):
+        """Forecast matches the target closest to its predicted time,
+        not the chronologically first target after init."""
+        init_times = pd.to_datetime(["2023-09-14 00:00"])
+
+        # Forecast predicts landfall at day 5 (Sep 19)
+        forecast_landfalls = xr.DataArray(
+            [35.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": (
+                    ["init_time"],
+                    pd.to_datetime(["2023-09-19 00:00"]),
+                ),
+                "latitude": (["init_time"], [30.0]),
+                "longitude": (["init_time"], [270.0]),
+            },
+            name="surface_wind_speed",
+        )
+
+        # Two observed landfalls: one at day 1, one at day 5
+        target_times = pd.to_datetime(["2023-09-15 00:00", "2023-09-19 06:00"])
+        target_landfalls = xr.DataArray(
+            [40.0, 45.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0, 1],
+                "valid_time": (["landfall"], target_times),
+                "latitude": (["landfall"], [25.0, 30.0]),
+                "longitude": (["landfall"], [280.0, 270.0]),
+            },
+            name="surface_wind_speed",
+        )
+
+        result = calc.find_next_landfall_for_init_time(
+            forecast_landfalls,
+            target_landfalls,
+        )
+
+        # Should match target #1 (Sep 19, closest to forecast)
+        # not target #0 (Sep 15, chronologically first).
+        matched_vt = np.atleast_1d(result.coords["valid_time"].values)
+        assert matched_vt[0] == target_times[1]
+
+    def test_find_next_landfall_2d_forecast(self):
+        """Forecast with (init_time, landfall) dims where
+        init_time dim is larger than landfall dim (e.g. after
+        deduplication). Regression test for IndexError."""
+        it1 = np.datetime64("2023-09-14T00:00")
+        it2 = np.datetime64("2023-09-14T12:00")
+        it3 = np.datetime64("2023-09-15T00:00")
+
+        # 2D forecast: 3 init_times, 2 landfalls.
+        # Landfall 0 came from it1, landfall 1 from it2.
+        # it3 has no landfalls (NaN row).
+        forecast_landfalls = xr.DataArray(
+            [[35.0, np.nan], [np.nan, 36.0], [np.nan, np.nan]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [it1, it2, it3],
+                "landfall": [0, 1],
+                "valid_time": (
+                    "landfall",
+                    pd.to_datetime(["2023-09-16 00:00", "2023-09-17 00:00"]),
+                ),
+                "latitude": ("landfall", [25.0, 26.0]),
+                "longitude": ("landfall", [280.0, 279.0]),
+            },
+            name="surface_wind_speed",
+        )
+
+        target_times = pd.to_datetime(
+            ["2023-09-15 06:00", "2023-09-16 06:00", "2023-09-17 06:00"]
+        )
+        target_landfalls = xr.DataArray(
+            [40.0, 42.0, 44.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0, 1, 2],
+                "valid_time": ("landfall", target_times),
+                "latitude": ("landfall", [24.0, 25.0, 26.0]),
+                "longitude": ("landfall", [281.0, 280.0, 279.0]),
+            },
+            name="surface_wind_speed",
+        )
+
+        result = calc.find_next_landfall_for_init_time(
+            forecast_landfalls,
+            target_landfalls,
+        )
+
+        # it1 forecasts landfall at Sep 16 -> closest target
+        # is Sep 16 06:00 (target #1).
+        # it2 forecasts landfall at Sep 17 -> closest target
+        # is Sep 17 06:00 (target #2).
+        # it3 has no forecast landfall -> falls back to
+        # chronologically next after Sep 15, which is
+        # Sep 15 06:00 (target #0).
+        result_vts = {
+            pd.Timestamp(it): pd.Timestamp(
+                result.sel(init_time=it).coords["valid_time"].values
+            )
+            for it in result.init_time.values
+        }
+        assert result_vts[pd.Timestamp(it1)] == target_times[1]
+        assert result_vts[pd.Timestamp(it2)] == target_times[2]
+        assert result_vts[pd.Timestamp(it3)] == target_times[0]
+
 
 class TestLandfallMetricAlignment:
     """Test that landfall metrics properly align forecast and target."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2350,6 +2350,542 @@ class TestLandfallMetrics:
             # Allow some tolerance for floating point calculations
             assert 39.0 < result.values[0] < 41.0
 
+    def test_multi_landfall_displacement_uses_first_per_init(self):
+        """Verify displacement uses only the first forecast landfall per
+        init_time, not an average across multiple forecast landfalls.
+
+        Mimics TC Yagi's pattern: Philippines landfall (~16N, 120E) then
+        Vietnam landfall (~20N, 106E). The target is the Philippines
+        landfall. Without the fix, the displacement would be inflated
+        by averaging in the Vietnam forecast landfall distance (~1500 km).
+        With the fix, only the first (Philippines) forecast landfall
+        is used, giving a small displacement (~15 km).
+        """
+        target = xr.Dataset(
+            {
+                "latitude": (["valid_time"], [16.0]),
+                "longitude": (["valid_time"], [120.0]),
+                "surface_wind_speed": (["valid_time"], [55.0]),
+            },
+            coords={
+                "valid_time": [pd.Timestamp("2024-09-01 12:00")],
+            },
+        )
+
+        forecast = xr.Dataset(
+            {
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [[16.0]],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [[120.0]],
+                ),
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [[52.0]],
+                ),
+            },
+            coords={
+                "lead_time": [24],
+                "valid_time": [
+                    pd.Timestamp("2024-09-01 12:00"),
+                ],
+            },
+        )
+
+        init_ts = pd.Timestamp("2024-08-31 12:00")
+
+        # Target: single observed landfall near Philippines
+        mock_target_landfall = xr.DataArray(
+            [55.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0],
+                "latitude": ("landfall", [16.0]),
+                "longitude": ("landfall", [120.0]),
+                "valid_time": (
+                    "landfall",
+                    [pd.Timestamp("2024-09-01 12:00")],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        # Forecast: TWO landfalls for the same init_time.
+        # Landfall 0 = Philippines (16.1N, 120.1E, close)
+        # Landfall 1 = Vietnam (20N, 106E, ~1500 km away)
+        mock_forecast_landfall = xr.DataArray(
+            [[52.0, 45.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_ts],
+                "landfall": [0, 1],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[16.1, 20.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[120.1, 106.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [
+                        [
+                            pd.Timestamp("2024-09-01 12:00"),
+                            pd.Timestamp("2024-09-07 06:00"),
+                        ]
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mock_find:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target_landfall
+                return mock_forecast_landfall
+
+            mock_find.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="first",
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            assert isinstance(result, xr.DataArray)
+            assert result.dims == ("init_time",)
+            displacement_km = result.values[0]
+            # First forecast landfall is ~15 km from target.
+            # If the bug were present (averaging both landfalls),
+            # the displacement would be ~750 km.
+            assert displacement_km < 50, (
+                f"Displacement {displacement_km:.1f} km is too large; "
+                f"multi-landfall averaging bug is likely present"
+            )
+
+            # Verify landfall metadata is attached
+            expected_coords = [
+                "forecast_landfall_latitude",
+                "forecast_landfall_longitude",
+                "forecast_landfall_valid_time",
+                "target_landfall_latitude",
+                "target_landfall_longitude",
+                "target_landfall_valid_time",
+            ]
+            for coord_name in expected_coords:
+                assert coord_name in result.coords, (
+                    f"Missing metadata coord: {coord_name}"
+                )
+            assert abs(float(result.forecast_landfall_latitude) - 16.1) < 0.01
+            assert abs(float(result.target_landfall_latitude) - 16.0) < 0.01
+
+    def test_first_approach_skips_init_with_late_track_start(self):
+        """Verify approach='first' filters out init_times whose
+        forecast track starts after the first target landfall.
+
+        Mimics TC Debby (case 154): the target's first landfall is
+        Cuba at Aug 3 17Z, but the forecast track for init Aug 2
+        12Z doesn't start until Aug 3 18Z (tracker doesn't detect
+        the TC until then). That init_time should be excluded
+        because the forecast can't predict the Cuba landfall.
+
+        The forecast grid has two init_times sharing the same
+        valid_time column (Aug 3 18Z): init Aug 3 18Z at lt=0
+        and init Aug 2 12Z at lt=30. This tests that the
+        track-start detection scans all cells in the
+        (lead_time, valid_time) grid, not just the first
+        non-NaN per column.
+        """
+        forecast = xr.Dataset(
+            {
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, 40.0],
+                        [np.nan, 35.0],
+                    ],
+                ),
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, 25.0],
+                        [np.nan, 29.0],
+                    ],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, -80.0],
+                        [np.nan, -83.0],
+                    ],
+                ),
+            },
+            coords={
+                "lead_time": [0, 30],
+                "valid_time": [
+                    pd.Timestamp("2024-08-02 12:00"),
+                    pd.Timestamp("2024-08-03 18:00"),
+                ],
+            },
+        )
+
+        target = xr.Dataset(
+            {
+                "surface_wind_speed": (["valid_time"], [55.0]),
+                "latitude": (["valid_time"], [22.0]),
+                "longitude": (["valid_time"], [-79.5]),
+            },
+            coords={
+                "valid_time": [
+                    pd.Timestamp("2024-08-03 17:00"),
+                ],
+            },
+        )
+
+        # Target: Cuba landfall at Aug 3 17Z
+        mock_target_landfall = xr.DataArray(
+            [55.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0],
+                "latitude": ("landfall", [22.0]),
+                "longitude": ("landfall", [-79.5]),
+                "valid_time": (
+                    "landfall",
+                    [pd.Timestamp("2024-08-03 17:00")],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        init_ts = pd.Timestamp("2024-08-02 12:00")
+
+        # Forecast landfall: Florida at Aug 5
+        # (only landfall the tracker can see)
+        mock_forecast_landfall = xr.DataArray(
+            [[35.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_ts],
+                "landfall": [0],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[29.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[-83.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [[pd.Timestamp("2024-08-05 00:00")]],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mock_find:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target_landfall
+                return mock_forecast_landfall
+
+            mock_find.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="first",
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            # The init_time should be filtered out because
+            # the track starts at Aug 3 18Z, AFTER the Cuba
+            # landfall at Aug 3 17Z. Result should be NaN
+            # (no valid init_times remain).
+            assert np.isnan(result.values).all(), (
+                "Init with track starting after target "
+                "landfall should have been filtered out"
+            )
+
+    def test_first_approach_falls_back_to_next_target(self):
+        """When the first IBTrACS landfall has no forecast
+        coverage, fall back to the next one that does.
+
+        Mimics TC Debby: Cuba landfall at Aug 3 17Z has no
+        forecast data (track starts Aug 3 18Z). Florida
+        landfall at Aug 5 15Z does. The metric should compare
+        against the Florida landfall instead of returning NaN.
+        """
+        forecast = xr.Dataset(
+            {
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, 40.0],
+                        [np.nan, 35.0],
+                    ],
+                ),
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, 25.0],
+                        [np.nan, 29.0],
+                    ],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [
+                        [np.nan, -80.0],
+                        [np.nan, -83.0],
+                    ],
+                ),
+            },
+            coords={
+                "lead_time": [0, 30],
+                "valid_time": [
+                    pd.Timestamp("2024-08-02 12:00"),
+                    pd.Timestamp("2024-08-03 18:00"),
+                ],
+            },
+        )
+
+        target = xr.Dataset(
+            {
+                "surface_wind_speed": (
+                    ["valid_time"],
+                    [55.0, 50.0],
+                ),
+                "latitude": (
+                    ["valid_time"],
+                    [22.0, 29.5],
+                ),
+                "longitude": (
+                    ["valid_time"],
+                    [-79.5, -83.5],
+                ),
+            },
+            coords={
+                "valid_time": [
+                    pd.Timestamp("2024-08-03 17:00"),
+                    pd.Timestamp("2024-08-05 15:00"),
+                ],
+            },
+        )
+
+        # Two target landfalls: Cuba (Aug 3 17Z), Florida
+        # (Aug 5 15Z)
+        mock_target_landfall = xr.DataArray(
+            [55.0, 50.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0, 1],
+                "latitude": ("landfall", [22.0, 29.5]),
+                "longitude": (
+                    "landfall",
+                    [-79.5, -83.5],
+                ),
+                "valid_time": (
+                    "landfall",
+                    [
+                        pd.Timestamp("2024-08-03 17:00"),
+                        pd.Timestamp("2024-08-05 15:00"),
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        init_ts = pd.Timestamp("2024-08-02 12:00")
+
+        mock_forecast_landfall = xr.DataArray(
+            [[35.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_ts],
+                "landfall": [0],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[29.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[-83.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [[pd.Timestamp("2024-08-05 00:00")]],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mock_find:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target_landfall
+                return mock_forecast_landfall
+
+            mock_find.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="first",
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            assert isinstance(result, xr.DataArray)
+            assert not np.isnan(result.values).all(), (
+                "Should fall back to Florida landfall, not return NaN"
+            )
+            # Target is Florida (29.5N, -83.5W),
+            # forecast is (29.0N, -83.0W) — close match
+            assert result.values[0] < 100, (
+                f"Displacement {result.values[0]:.1f} km should be small (FL vs FL)"
+            )
+            # Verify metadata uses the Florida target
+            assert abs(float(result.target_landfall_latitude) - 29.5) < 0.01
+
+    def test_multi_landfall_displacement_next_approach(self):
+        """Verify approach='next' also uses first forecast landfall
+        per init_time after matching to the correct target.
+
+        Two target landfalls (Philippines, Vietnam) and two forecast
+        landfalls per init_time. find_next_landfall_for_init_time
+        runs with real logic to match by closest valid_time. Then
+        select_first_forecast_landfall_per_init keeps only the
+        earliest forecast landfall, preventing averaging inflation.
+        """
+        target = xr.Dataset(
+            {
+                "latitude": (["valid_time"], [16.0]),
+                "longitude": (["valid_time"], [120.0]),
+                "surface_wind_speed": (["valid_time"], [55.0]),
+            },
+            coords={
+                "valid_time": [pd.Timestamp("2024-09-01 12:00")],
+            },
+        )
+
+        forecast = xr.Dataset(
+            {
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [[16.0]],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [[120.0]],
+                ),
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [[52.0]],
+                ),
+            },
+            coords={
+                "lead_time": [24],
+                "valid_time": [
+                    pd.Timestamp("2024-09-01 12:00"),
+                ],
+            },
+        )
+
+        init_ts = pd.Timestamp("2024-08-31 12:00")
+
+        # Target: TWO observed landfalls (Philippines then Vietnam)
+        mock_target_landfall = xr.DataArray(
+            [55.0, 48.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0, 1],
+                "latitude": ("landfall", [16.0, 20.0]),
+                "longitude": ("landfall", [120.0, 106.0]),
+                "valid_time": (
+                    "landfall",
+                    [
+                        pd.Timestamp("2024-09-01 12:00"),
+                        pd.Timestamp("2024-09-07 06:00"),
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        # Forecast: TWO landfalls for the same init_time.
+        # Landfall 0 = Philippines (16.1N, 120.1E) at Sep 1
+        # Landfall 1 = Vietnam (20N, 106E) at Sep 7
+        mock_forecast_landfall = xr.DataArray(
+            [[52.0, 45.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_ts],
+                "landfall": [0, 1],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[16.1, 20.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[120.1, 106.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [
+                        [
+                            pd.Timestamp("2024-09-01 12:00"),
+                            pd.Timestamp("2024-09-07 06:00"),
+                        ]
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mock_find:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target_landfall
+                return mock_forecast_landfall
+
+            mock_find.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="next",
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            assert isinstance(result, xr.DataArray)
+            assert result.dims == ("init_time",)
+            displacement_km = result.values[0]
+            # find_next_landfall_for_init_time matches the
+            # forecast (Philippines, Sep 1) to the target
+            # (Philippines, Sep 1) by closest valid_time.
+            # select_first_forecast_landfall_per_init then
+            # keeps only the first forecast landfall (~15 km).
+            # Without the fix, averaging would give ~750 km.
+            assert displacement_km < 50, (
+                f"Displacement {displacement_km:.1f} km is too "
+                f"large; multi-landfall averaging bug is "
+                f"likely present (next approach)"
+            )
+
     def test_landfall_intensity_mae_with_known_values(self):
         """Test LandfallIntensityMeanAbsoluteError with manually calculated expected
         values."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3478,6 +3478,454 @@ class TestLandfallMetrics:
             assert isinstance(forecast_landfall, xr.DataArray)
             assert isinstance(target_landfall, xr.DataArray)
 
+    def test_filter_by_landfall_time_tolerance(self):
+        """Proportional time-tolerance filter on paired landfalls.
+
+        Rule: keep iff
+          abs(fc_vt - tgt_vt) <= 0.5 * (tgt_vt - init_time)
+        """
+        d = np.datetime64
+
+        # init day-1, target day-3, fc day-5 → mismatch 2d,
+        # threshold 0.5*2d=1d → DROP
+        # init day-1, target day-3, fc day-3.5 → mismatch 0.5d,
+        # threshold 1d → KEEP
+        # init day-1, target day-3, fc day-4 → mismatch 1d,
+        # threshold 1d → KEEP (<=)
+        init_times = np.array(
+            [
+                d("2024-08-01"),
+                d("2024-08-01"),
+                d("2024-08-01"),
+            ]
+        )
+        tgt_vts = np.array(
+            [
+                d("2024-08-03"),
+                d("2024-08-03"),
+                d("2024-08-03"),
+            ]
+        )
+        fc_vts = np.array(
+            [
+                d("2024-08-05"),
+                d("2024-08-03T12"),
+                d("2024-08-04"),
+            ]
+        )
+
+        fc = xr.DataArray(
+            [1.0, 2.0, 3.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", fc_vts),
+                "latitude": ("init_time", [25.0, 26.0, 27.0]),
+                "longitude": ("init_time", [-80.0, -81.0, -82.0]),
+            },
+        )
+        tgt = xr.DataArray(
+            [10.0, 20.0, 30.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", tgt_vts),
+                "latitude": ("init_time", [25.5, 26.5, 27.5]),
+                "longitude": ("init_time", [-80.5, -81.5, -82.5]),
+            },
+        )
+
+        fc_out, tgt_out = calc.filter_by_landfall_time_tolerance(fc, tgt)
+
+        assert len(fc_out) == 2
+        np.testing.assert_array_equal(fc_out.values, [2.0, 3.0])
+        np.testing.assert_array_equal(tgt_out.values, [20.0, 30.0])
+
+    def test_filter_by_landfall_time_tolerance_all_dropped(self):
+        """All init_times fail → returns empty arrays."""
+        d = np.datetime64
+        init_times = np.array([d("2024-08-01")])
+        fc = xr.DataArray(
+            [1.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", [d("2024-08-07")]),
+                "latitude": ("init_time", [25.0]),
+                "longitude": ("init_time", [-80.0]),
+            },
+        )
+        tgt = xr.DataArray(
+            [10.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", [d("2024-08-03")]),
+                "latitude": ("init_time", [25.5]),
+                "longitude": ("init_time", [-80.5]),
+            },
+        )
+
+        fc_out, tgt_out = calc.filter_by_landfall_time_tolerance(fc, tgt)
+        assert len(fc_out) == 0
+        assert len(tgt_out) == 0
+
+    def test_filter_by_landfall_time_tolerance_all_pass(self):
+        """All init_times pass → arrays returned unchanged."""
+        d = np.datetime64
+        init_times = np.array([d("2024-08-01")])
+        fc = xr.DataArray(
+            [1.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", [d("2024-08-03")]),
+                "latitude": ("init_time", [25.0]),
+                "longitude": ("init_time", [-80.0]),
+            },
+        )
+        tgt = xr.DataArray(
+            [10.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", [d("2024-08-03")]),
+                "latitude": ("init_time", [25.5]),
+                "longitude": ("init_time", [-80.5]),
+            },
+        )
+
+        fc_out, tgt_out = calc.filter_by_landfall_time_tolerance(fc, tgt)
+        assert len(fc_out) == 1
+        xr.testing.assert_equal(fc_out, fc)
+        xr.testing.assert_equal(tgt_out, tgt)
+
+    def test_filter_by_landfall_time_window(self):
+        """Fixed +-24h window filter on paired landfalls."""
+        d = np.datetime64
+
+        # init day-1, target day-3, fc day-5 → mismatch 48h → DROP
+        # init day-1, target day-3, fc day-3T12 → mismatch 12h → KEEP
+        # init day-1, target day-3, fc day-4 → mismatch 24h → KEEP (<=)
+        init_times = np.array(
+            [
+                d("2024-08-01"),
+                d("2024-08-01"),
+                d("2024-08-01"),
+            ]
+        )
+        tgt_vts = np.array(
+            [
+                d("2024-08-03"),
+                d("2024-08-03"),
+                d("2024-08-03"),
+            ]
+        )
+        fc_vts = np.array(
+            [
+                d("2024-08-05"),
+                d("2024-08-03T12"),
+                d("2024-08-04"),
+            ]
+        )
+
+        fc = xr.DataArray(
+            [1.0, 2.0, 3.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", fc_vts),
+                "latitude": ("init_time", [25.0, 26.0, 27.0]),
+                "longitude": ("init_time", [-80.0, -81.0, -82.0]),
+            },
+        )
+        tgt = xr.DataArray(
+            [10.0, 20.0, 30.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", tgt_vts),
+                "latitude": ("init_time", [25.5, 26.5, 27.5]),
+                "longitude": ("init_time", [-80.5, -81.5, -82.5]),
+            },
+        )
+
+        fc_out, tgt_out = calc.filter_by_landfall_time_window(
+            fc, tgt, window_hours=24.0
+        )
+
+        assert len(fc_out) == 2
+        np.testing.assert_array_equal(fc_out.values, [2.0, 3.0])
+        np.testing.assert_array_equal(tgt_out.values, [20.0, 30.0])
+
+    def test_filter_by_landfall_time_window_custom(self):
+        """Custom 12h window keeps only the closest."""
+        d = np.datetime64
+        init_times = np.array([d("2024-08-01"), d("2024-08-01")])
+        tgt_vts = np.array([d("2024-08-03"), d("2024-08-03")])
+        fc_vts = np.array([d("2024-08-04"), d("2024-08-03T06")])
+
+        fc = xr.DataArray(
+            [1.0, 2.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", fc_vts),
+                "latitude": ("init_time", [25.0, 26.0]),
+                "longitude": ("init_time", [-80.0, -81.0]),
+            },
+        )
+        tgt = xr.DataArray(
+            [10.0, 20.0],
+            dims=["init_time"],
+            coords={
+                "init_time": init_times,
+                "valid_time": ("init_time", tgt_vts),
+                "latitude": ("init_time", [25.5, 26.5]),
+                "longitude": ("init_time", [-80.5, -81.5]),
+            },
+        )
+
+        fc_out, tgt_out = calc.filter_by_landfall_time_window(
+            fc, tgt, window_hours=12.0
+        )
+        assert len(fc_out) == 1
+        np.testing.assert_array_equal(fc_out.values, [2.0])
+
+    def test_landfall_metric_default_filter(self):
+        """LandfallMetric defaults to 24h window filter."""
+        m = metrics.LandfallDisplacement(approach="first")
+        assert m.landfall_time_filter == ("window", 24.0)
+
+    def test_time_window_with_mismatched_init_times_next(self):
+        """approach='next' where forecast has more init_times
+        than target matches.  Regression test for the ValueError
+        caused by shape (N,) vs (M,) when N != M.
+        """
+        ts = pd.Timestamp
+        # 3 init_times, but only the first two have matching
+        # target landfalls (the third forecast init is too late).
+        init_a = ts("2024-08-28 00:00")
+        init_b = ts("2024-08-29 00:00")
+        init_c = ts("2024-08-30 00:00")
+
+        target = xr.Dataset(
+            {
+                "latitude": ("valid_time", [25.0]),
+                "longitude": ("valid_time", [-80.0]),
+                "surface_wind_speed": ("valid_time", [50.0]),
+            },
+            coords={
+                "valid_time": [ts("2024-08-30 06:00")],
+            },
+        )
+
+        forecast = xr.Dataset(
+            {
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [[25.0, 25.0, 25.0]],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [[-80.0, -80.0, -80.0]],
+                ),
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [[50.0, 50.0, 50.0]],
+                ),
+            },
+            coords={
+                "lead_time": [24],
+                "valid_time": [
+                    ts("2024-08-28 00:00"),
+                    ts("2024-08-29 00:00"),
+                    ts("2024-08-30 00:00"),
+                ],
+            },
+        )
+
+        # Target: one observed landfall
+        mock_target = xr.DataArray(
+            [50.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0],
+                "latitude": ("landfall", [25.0]),
+                "longitude": ("landfall", [-80.0]),
+                "valid_time": (
+                    "landfall",
+                    [ts("2024-08-30 06:00")],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        # Forecast: 3 init_times each with one landfall, but
+        # init_c's landfall time is 4 days late so it won't
+        # match any target in find_next_landfall_for_init_time.
+        mock_forecast = xr.DataArray(
+            [[48.0], [49.0], [51.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_a, init_b, init_c],
+                "landfall": [0],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[25.1], [25.05], [30.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[-80.1], [-80.05], [-75.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [
+                        [ts("2024-08-30 06:00")],
+                        [ts("2024-08-30 06:00")],
+                        [ts("2024-09-03 00:00")],
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mf:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target
+                return mock_forecast
+
+            mf.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="next",
+                landfall_time_filter=("window", 24.0),
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            assert isinstance(result, xr.DataArray)
+            assert "init_time" in result.dims
+            # init_c should have been dropped (no target match
+            # or window mismatch), so at most 2 init_times.
+            assert len(result.init_time) <= 2
+
+    def test_time_window_with_first_approach(self):
+        """approach='first' with time window filter succeeds
+        and drops init_times whose forecast landfall is far
+        from the target.
+        """
+        ts = pd.Timestamp
+        init_a = ts("2024-08-28 00:00")
+        init_b = ts("2024-08-29 00:00")
+
+        target = xr.Dataset(
+            {
+                "latitude": ("valid_time", [25.0]),
+                "longitude": ("valid_time", [-80.0]),
+                "surface_wind_speed": ("valid_time", [50.0]),
+            },
+            coords={
+                "valid_time": [ts("2024-08-31 00:00")],
+            },
+        )
+
+        forecast = xr.Dataset(
+            {
+                "latitude": (
+                    ["lead_time", "valid_time"],
+                    [[25.0, 25.0]],
+                ),
+                "longitude": (
+                    ["lead_time", "valid_time"],
+                    [[-80.0, -80.0]],
+                ),
+                "surface_wind_speed": (
+                    ["lead_time", "valid_time"],
+                    [[50.0, 50.0]],
+                ),
+            },
+            coords={
+                "lead_time": [24],
+                "valid_time": [
+                    ts("2024-08-28 00:00"),
+                    ts("2024-08-29 00:00"),
+                ],
+            },
+        )
+
+        # Target: one observed landfall at Aug 31 00Z
+        mock_target = xr.DataArray(
+            [50.0],
+            dims=["landfall"],
+            coords={
+                "landfall": [0],
+                "latitude": ("landfall", [25.0]),
+                "longitude": ("landfall", [-80.0]),
+                "valid_time": (
+                    "landfall",
+                    [ts("2024-08-31 00:00")],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        # Forecast: init_a landfall close to target (Aug 31 12Z
+        # = 12h off), init_b landfall 3 days late (Sep 3).
+        mock_forecast = xr.DataArray(
+            [[48.0], [51.0]],
+            dims=["init_time", "landfall"],
+            coords={
+                "init_time": [init_a, init_b],
+                "landfall": [0],
+                "latitude": (
+                    ["init_time", "landfall"],
+                    [[25.1], [30.0]],
+                ),
+                "longitude": (
+                    ["init_time", "landfall"],
+                    [[-80.1], [-75.0]],
+                ),
+                "valid_time": (
+                    ["init_time", "landfall"],
+                    [
+                        [ts("2024-08-31 12:00")],
+                        [ts("2024-09-03 00:00")],
+                    ],
+                ),
+            },
+            name="surface_wind_speed",
+        )
+
+        with mock.patch.object(calc, "find_landfalls") as mf:
+
+            def side_effect(track_data, **kw):
+                if "lead_time" not in track_data.dims:
+                    return mock_target
+                return mock_forecast
+
+            mf.side_effect = side_effect
+
+            metric = metrics.LandfallDisplacement(
+                approach="first",
+                landfall_time_filter=("window", 24.0),
+            )
+            result = metric._compute_metric(
+                forecast["surface_wind_speed"],
+                target["surface_wind_speed"],
+            )
+
+            assert isinstance(result, xr.DataArray)
+            assert "init_time" in result.dims
+            # init_b's forecast landfall (Sep 3) is 3 days from
+            # target (Aug 31) — exceeds 24h → dropped.
+            assert len(result.init_time) == 1
+            assert result.init_time.values[0] == init_a
+
 
 class TestThresholdMetricComposite:
     """Tests for ThresholdMetric composite functionality."""

--- a/tests/test_tropical_cyclone.py
+++ b/tests/test_tropical_cyclone.py
@@ -1236,12 +1236,12 @@ class TestFillTrackGapsFromFields:
         )
 
         assert len(result) == 4
-        ts2_fill = [
-            d for d in result if d["lead_time_index"] == 2
-        ]
+        ts2_fill = [d for d in result if d["lead_time_index"] == 2]
         assert len(ts2_fill) == 1
         np.testing.assert_allclose(
-            ts2_fill[0]["latitude"], lat[r_ts2], atol=0.5,
+            ts2_fill[0]["latitude"],
+            lat[r_ts2],
+            atol=0.5,
         )
 
     def test_single_detection_no_fill(self):

--- a/tests/test_tropical_cyclone.py
+++ b/tests/test_tropical_cyclone.py
@@ -1095,6 +1095,155 @@ class TestFillTrackGapsFromFields:
         )
         assert result == []
 
+    def test_prefers_closest_candidate_over_deepest(self):
+        """Among low-SLP candidates, pick the one nearest
+        to expected position, not the absolute minimum."""
+        n_lat, n_lon = 31, 31
+        lat = np.linspace(0, 30, n_lat)
+        lon = np.linspace(110, 140, n_lon)
+
+        lt_seq = np.array([0, 1, 2])
+        vt_seq = np.array([0, 1, 2])
+        tid = 42
+
+        detections = [
+            {
+                "lead_time_index": 0,
+                "valid_time_index": 0,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99800.0,
+                "wind": 20.0,
+            },
+            {
+                "lead_time_index": 2,
+                "valid_time_index": 2,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99600.0,
+                "wind": 22.0,
+            },
+        ]
+
+        near_r = np.argmin(np.abs(lat - 15.0))
+        near_c = np.argmin(np.abs(lon - 125.0))
+        far_r = np.argmin(np.abs(lat - 17.0))
+        far_c = np.argmin(np.abs(lon - 127.0))
+
+        slp_all = np.full((3, n_lat, n_lon), 101000.0)
+        # Near candidate: moderate low
+        slp_all[1, near_r, near_c] = 99700.0
+        # Far candidate: deeper low but farther away
+        slp_all[1, far_r, far_c] = 99200.0
+
+        wind_all = np.full((3, n_lat, n_lon), 5.0)
+        wind_all[1, near_r, near_c] = 18.0
+        wind_all[1, far_r, far_c] = 25.0
+
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            detections,
+            slp_all,
+            wind_all,
+            lt_seq,
+            vt_seq,
+            lat,
+            lon,
+            wind_search_radius_gridpts=1,
+        )
+
+        gap = [d for d in result if d["lead_time_index"] == 1]
+        assert len(gap) == 1
+        np.testing.assert_allclose(
+            gap[0]["latitude"],
+            lat[near_r],
+            atol=0.5,
+        )
+        np.testing.assert_allclose(
+            gap[0]["longitude"],
+            lon[near_c],
+            atol=0.5,
+        )
+
+    def test_chaining_uses_filled_points(self):
+        """Successive gap fills should chain through
+        previously filled positions, not always interpolate
+        from the original bracketing detections.
+
+        Setup: endpoints at lat 10 (ts 0) and lat 18 (ts 3).
+        The SLP min at ts 1 sits at lat 14, which becomes
+        the "previous" anchor for ts 2. With chaining, ts 2
+        interpolates between lat 14 and 18 (expect ~16);
+        without chaining it would use 10 and 18 (expect ~14.7).
+        We place the ts 2 SLP min at lat 16 so it is only
+        chosen when the chained anchor shifts the expected
+        position northward."""
+        n_lat, n_lon = 41, 21
+        lat = np.linspace(8, 20, n_lat)
+        lon = np.linspace(123, 127, n_lon)
+
+        lt_seq = np.arange(4)
+        vt_seq = np.arange(4)
+        tid = 99
+
+        detections = [
+            {
+                "lead_time_index": 0,
+                "valid_time_index": 0,
+                "track_id": tid,
+                "latitude": 10.0,
+                "longitude": 125.0,
+                "slp": 99800.0,
+                "wind": 20.0,
+            },
+            {
+                "lead_time_index": 3,
+                "valid_time_index": 3,
+                "track_id": tid,
+                "latitude": 18.0,
+                "longitude": 125.0,
+                "slp": 99600.0,
+                "wind": 22.0,
+            },
+        ]
+
+        slp_all = np.full((4, n_lat, n_lon), 101000.0)
+        wind_all = np.full((4, n_lat, n_lon), 5.0)
+        c_mid = np.argmin(np.abs(lon - 125.0))
+
+        # ts 1: SLP min at lat 14
+        r_ts1 = np.argmin(np.abs(lat - 14.0))
+        slp_all[1, r_ts1, c_mid] = 99700.0
+        wind_all[1, r_ts1, c_mid] = 15.0
+
+        # ts 2: SLP min at lat 16 (only reachable via
+        # chained anchor at lat 14, not via endpoint
+        # midpoint at lat ~14.7)
+        r_ts2 = np.argmin(np.abs(lat - 16.0))
+        slp_all[2, r_ts2, c_mid] = 99700.0
+        wind_all[2, r_ts2, c_mid] = 15.0
+
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            detections,
+            slp_all,
+            wind_all,
+            lt_seq,
+            vt_seq,
+            lat,
+            lon,
+            wind_search_radius_gridpts=1,
+        )
+
+        assert len(result) == 4
+        ts2_fill = [
+            d for d in result if d["lead_time_index"] == 2
+        ]
+        assert len(ts2_fill) == 1
+        np.testing.assert_allclose(
+            ts2_fill[0]["latitude"], lat[r_ts2], atol=0.5,
+        )
+
     def test_single_detection_no_fill(self):
         """A single detection should not trigger gap fill."""
         detections = [

--- a/tests/test_tropical_cyclone.py
+++ b/tests/test_tropical_cyclone.py
@@ -962,3 +962,160 @@ class TestMinTrackTimestepsWindFilter:
         result_fail = self._run(tc_ds, ibt, self.N_WIND_STRONG + 1)
         assert result_pass.sizes.get("valid_time", 0) > 0
         assert result_fail.sizes.get("valid_time", 0) == 0
+
+
+class TestFillTrackGapsFromFields:
+    """Tests for _fill_track_gaps_from_fields SLP fallback."""
+
+    def test_fills_gap_with_slp_minimum(self):
+        """A gap between two detections is filled by finding
+        the SLP minimum near the expected position."""
+        n_lat, n_lon = 31, 31
+        lat = np.linspace(0, 30, n_lat)
+        lon = np.linspace(110, 140, n_lon)
+
+        # 3 timesteps; detection at ts 0 and ts 2, gap at 1
+        lt_seq = np.array([0, 1, 2])
+        vt_seq = np.array([0, 1, 2])
+        tid = 5000
+
+        detections = [
+            {
+                "lead_time_index": 0,
+                "valid_time_index": 0,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99800.0,
+                "wind": 20.0,
+            },
+            {
+                "lead_time_index": 2,
+                "valid_time_index": 2,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99600.0,
+                "wind": 22.0,
+            },
+        ]
+
+        # SLP field at ts 1: minimum at (15, 125)
+        min_r = np.argmin(np.abs(lat - 15.0))
+        min_c = np.argmin(np.abs(lon - 125.0))
+        slp_all = np.full((3, n_lat, n_lon), 101000.0)
+        slp_all[1, min_r, min_c] = 99700.0
+        wind_all = np.full((3, n_lat, n_lon), 5.0)
+        wind_all[1, min_r, min_c] = 18.0
+
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            detections,
+            slp_all,
+            wind_all,
+            lt_seq,
+            vt_seq,
+            lat,
+            lon,
+            wind_search_radius_gridpts=1,
+        )
+
+        # Should now have 3 detections
+        assert len(result) == 3
+        gap_det = [d for d in result if d["lead_time_index"] == 1]
+        assert len(gap_det) == 1
+        assert gap_det[0]["track_id"] == tid
+        np.testing.assert_allclose(gap_det[0]["latitude"], lat[min_r], atol=0.5)
+        np.testing.assert_allclose(gap_det[0]["longitude"], lon[min_c], atol=0.5)
+
+    def test_no_fill_beyond_endpoints(self):
+        """Timesteps outside the first/last detection are
+        NOT filled."""
+        n_lat, n_lon = 11, 11
+        lat = np.linspace(10, 20, n_lat)
+        lon = np.linspace(120, 130, n_lon)
+
+        lt_seq = np.array([0, 1, 2, 3, 4])
+        vt_seq = np.array([0, 1, 2, 3, 4])
+        tid = 100
+
+        detections = [
+            {
+                "lead_time_index": 1,
+                "valid_time_index": 1,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99800.0,
+                "wind": 20.0,
+            },
+            {
+                "lead_time_index": 3,
+                "valid_time_index": 3,
+                "track_id": tid,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99600.0,
+                "wind": 22.0,
+            },
+        ]
+
+        slp_all = np.full((5, n_lat, n_lon), 101000.0)
+        slp_all[:, 5, 5] = 99500.0
+        wind_all = np.full((5, n_lat, n_lon), 5.0)
+
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            detections,
+            slp_all,
+            wind_all,
+            lt_seq,
+            vt_seq,
+            lat,
+            lon,
+            wind_search_radius_gridpts=1,
+        )
+
+        filled_lts = {d["lead_time_index"] for d in result}
+        # ts 0 and ts 4 should NOT be filled
+        assert 0 not in filled_lts
+        assert 4 not in filled_lts
+        # ts 2 should be filled
+        assert 2 in filled_lts
+
+    def test_empty_detections(self):
+        """No detections should return empty list."""
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            [],
+            np.zeros((1, 5, 5)),
+            np.zeros((1, 5, 5)),
+            np.array([0]),
+            np.array([0]),
+            np.linspace(0, 10, 5),
+            np.linspace(0, 10, 5),
+            wind_search_radius_gridpts=1,
+        )
+        assert result == []
+
+    def test_single_detection_no_fill(self):
+        """A single detection should not trigger gap fill."""
+        detections = [
+            {
+                "lead_time_index": 0,
+                "valid_time_index": 0,
+                "track_id": 1,
+                "latitude": 15.0,
+                "longitude": 125.0,
+                "slp": 99800.0,
+                "wind": 20.0,
+            },
+        ]
+        result = tropical_cyclone._fill_track_gaps_from_fields(
+            detections,
+            np.full((3, 5, 5), 101000.0),
+            np.full((3, 5, 5), 5.0),
+            np.array([0, 1, 2]),
+            np.array([0, 1, 2]),
+            np.linspace(0, 10, 5),
+            np.linspace(0, 10, 5),
+            wind_search_radius_gridpts=1,
+        )
+        assert len(result) == 1


### PR DESCRIPTION
# EWB Pull Request

## Description

We ran into a bunch of edge cases on the final runthroughs for the paper. This PR addresses them by adding the following updates:

`tropical_cyclone.py`:

* A track "filler" function `_fill_track_gaps_from_fields` which, if the tracker fails between two points due to something like a missing closed contour warm core but continues enough after it's lost to constitute a valid track, it uses default criteria to find _n_ candidate SLP minima within a range around a linearly interpolated line between the two valid points

`calc.py`:

* A minor landfall filter `_filter_minor_landfalls` which prevents multiple landfalls from being counted within a time window (uses the first)
* Updates `find_next_landfall_for_init_time` where there's now a filter to require the valid time in the model run of a landfall to be within 24 hours of the actual landfall to be considered non-spurious. Also includes `track_start_time` to make sure target landfalls are only considered _after_ the track begins (not after `init_time` of the model run)
* `get_forecast_track_start_times` to do this filtering ^
* Include a new method `filter_by_landfall_time_tolerance` which uses the equation `abs(forecast_valid_time - target_valid-time) <= fraction * (target_valid_time - init_time)` to allow for a different method for filtering landfalls than +- a fixed window

`derived.py`:

* Tighten the minimum SLP criteria to 1010 hPa to avoid spurious SLP minima identification

`evaluate.py`:

* Adds 2 lines to `_ensure_output_schema` to allow for more columns. In this case, to output more landfall metadata with TCs

`metrics.py`:

* Updates `LandfallMetric` as an API to modify the values for changes in `calc.py`

## Type of change

- [x] Refactor
- [x] Bug fix
- [x] New feature
- [x] Chore

## How Has This Been Tested?

We updated all of the tests this impacted and added new ones where relevant. We also looked at the landfall displacement metric as a proxy for the updates. To be considered an improvement, the landfall displacement should maintain an increase with lead time. Prior to these updates, **this did not happen**. With these updates, the new landfall displacement values we tested on AIFS, Graphcast, Pangu, and HRES all produced similar and logical values increasing with lead times.