### PR TITLE
Fix the four defects the Hypothesis suite uncovered

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1454,10 +1454,13 @@ def _calculate_event_duration(
     Returns:
         DataArray with valid_time reduced out, values in hours.
     """
+    if mask.valid_time.size == 0:
+        return utils._create_nan_dataarray(preserve_dims)
     expected_gap = np.timedelta64(int(time_resolution_hours), "h")
     mask = mask.fillna(False).astype(bool)
     vt = mask.valid_time.values
-    gaps = np.concatenate([[False], (vt[1:] - vt[:-1]) == expected_gap])
+    gaps = np.zeros(vt.size, dtype=bool)
+    gaps[1:] = (vt[1:] - vt[:-1]) == expected_gap
     is_expected_gap = xr.DataArray(gaps, dims=["valid_time"], coords={"valid_time": vt})
     # When init_time is only a coordinate (not a dim) and lead_time is a dim,
     # consecutive timesteps within one forecast run follow the diagonal of the

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1470,7 +1470,7 @@ def _calculate_event_duration(
     # that the predecessor cell has the same init_time (vt - lead = const).
     # For daily targets aligned to a 6 h lead_time grid this is 24h/6h = 4.
     if "lead_time" in mask.dims and preserve_dims not in mask.dims:
-        lt_step = np.unique(np.diff(mask.lead_time.values))
+        lt_step = np.unique(np.diff(utils._lead_time_as_timedelta(mask.lead_time)))
         n_lead_steps = (
             max(1, int(expected_gap / lt_step[0]))
             if len(lt_step) == 1 and lt_step[0] > np.timedelta64(0)

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1186,6 +1186,10 @@ class MaximumMeanAbsoluteError(MeanAbsoluteError):
         target_spatial_mean = utils.reduce_dataarray(
             target, method="mean", reduce_dims=reduce_spatial_dims, skipna=True
         )
+        if target_spatial_mean.valid_time.size == 0 or bool(
+            target_spatial_mean.isnull().all()
+        ):
+            return utils._create_nan_dataarray(self.preserve_dims)
         maximum_timestep = target_spatial_mean.idxmax("valid_time")
         maximum_value = target_spatial_mean.sel(valid_time=maximum_timestep)
 
@@ -1268,6 +1272,10 @@ class MinimumMeanAbsoluteError(MeanAbsoluteError):
         target_spatial_mean = utils.reduce_dataarray(
             target, method="mean", reduce_dims=self.reduce_spatial_dims, skipna=True
         )
+        if target_spatial_mean.valid_time.size == 0 or bool(
+            target_spatial_mean.isnull().all()
+        ):
+            return utils._create_nan_dataarray(self.preserve_dims)
         minimum_timestep = target_spatial_mean.idxmin("valid_time")
         minimum_value = target_spatial_mean.sel(valid_time=minimum_timestep)
         forecast_spatial_mean = utils.reduce_dataarray(

--- a/src/extremeweatherbench/sources/xarray_dataset.py
+++ b/src/extremeweatherbench/sources/xarray_dataset.py
@@ -109,26 +109,22 @@ def check_for_spatial_data(data: xr.Dataset, location: "regions.Region") -> bool
 
     if lat_dim is None or lon_dim is None:
         return False
-    coords = location.as_geopandas().total_bounds
-    # Get location bounds
-    lat_min, lat_max = coords[1], coords[3]
-    lon_min, lon_max = coords[0], coords[2]
-
-    # Check if reversing the latitude range still returns no data
-    if len(data[lat_dim].sel({lat_dim: slice(lat_min, lat_max)})) == 0:
-        if len(data[lat_dim].sel({lat_dim: slice(lat_max, lat_min)})) == 0:
-            # If reversing the latitude range still returns no data, return False
-            return False
-        else:
-            # If latitude has data, check longitude
-            data = data[[lat_dim, lon_dim]].sel(
-                {lat_dim: slice(lat_max, lat_min), lon_dim: slice(lon_min, lon_max)}
-            )
-    else:
-        # Check longitude if latitude > 0
-        data = data[[lat_dim, lon_dim]].sel(
-            {lat_dim: slice(lat_min, lat_max), lon_dim: slice(lon_min, lon_max)}
+    lat = data[lat_dim].values
+    lon = data[lon_dim].values % 360.0
+    # explode() splits antimeridian MultiPolygons into non-wrapping lobes,
+    # since their combined total_bounds would span the full globe.
+    bounds = location.as_geopandas().geometry.explode(index_parts=False).bounds
+    for lon_min, lat_min, lon_max, lat_max in bounds.itertuples(index=False):
+        if not ((lat >= lat_min) & (lat <= lat_max)).any():
+            continue
+        if lon_max - lon_min >= 360.0:
+            return True
+        lon_min, lon_max = lon_min % 360.0, lon_max % 360.0
+        lon_hit = (
+            (lon >= lon_min) & (lon <= lon_max)
+            if lon_min <= lon_max
+            else (lon >= lon_min) | (lon <= lon_max)
         )
-
-    # Check if any data remains after spatial filtering
-    return sum(data.sizes.values()) > 0
+        if lon_hit.any():
+            return True
+    return False

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -349,6 +349,13 @@ def determine_temporal_resolution(
     return np.min(num_timesteps).astype(float)
 
 
+def _lead_time_as_timedelta(lead_time: xr.DataArray) -> xr.DataArray:
+    """Coerce an integer-hours lead_time to timedelta64."""
+    if np.issubdtype(lead_time.dtype, np.timedelta64):
+        return lead_time
+    return lead_time.copy(data=pd.to_timedelta(lead_time.values, unit="h"))
+
+
 def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
     """Convert the init_time coordinate to a valid_time coordinate.
 
@@ -358,9 +365,10 @@ def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The dataset with a valid_time coordinate.
     """
+    lead_time = _lead_time_as_timedelta(ds.lead_time)
     valid_time = xr.DataArray(
         ds.init_time, coords={"init_time": ds.init_time}
-    ) + xr.DataArray(ds.lead_time, coords={"lead_time": ds.lead_time})
+    ) + xr.DataArray(lead_time, coords={"lead_time": ds.lead_time})
     ds = ds.assign_coords(valid_time=valid_time)
     return xr.concat(
         [
@@ -383,9 +391,10 @@ def convert_valid_time_to_init_time(da: xr.DataArray) -> xr.DataArray:
     Returns:
         The dataarray with an init_time dimension.
     """
+    lead_time = _lead_time_as_timedelta(da.lead_time)
     init_time = xr.DataArray(
         da.valid_time, coords={"valid_time": da.valid_time}
-    ) - xr.DataArray(da.lead_time, coords={"lead_time": da.lead_time})
+    ) - xr.DataArray(lead_time, coords={"lead_time": da.lead_time})
     da = da.assign_coords(init_time=init_time)
     return xr.concat(
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,9 @@ def make_sample_point_obs_df():
 
 def make_sample_forecast_dataset():
     init_time = pd.date_range("2021-06-20", periods=5)
-    lead_time = range(0, 241, 6)
+    lead_time = np.array([i for i in range(0, 241, 6)], dtype="timedelta64[h]").astype(
+        "timedelta64[ns]"
+    )
     data = np.random.RandomState(21897820).standard_normal(
         size=(len(init_time), 181, 360, len(lead_time)),
     )
@@ -106,7 +108,7 @@ def make_sample_forecast_dataset():
     dataset["surface_air_temperature"].loc[
         dict(
             init_time="2021-06-21 00:00",
-            lead_time=42,
+            lead_time=np.timedelta64(42, "h"),
             latitude=slice(40, 45),
             longitude=slice(100, 105),
         )
@@ -115,7 +117,7 @@ def make_sample_forecast_dataset():
     dataset["surface_air_temperature"].loc[
         dict(
             init_time="2021-06-20 00:00",
-            lead_time=42,
+            lead_time=np.timedelta64(42, "h"),
             latitude=slice(40, 45),
             longitude=slice(100, 105),
         )

--- a/tests/hypothesis_findings.md
+++ b/tests/hypothesis_findings.md
@@ -1,0 +1,231 @@
+# Hypothesis fixture findings
+
+The Hypothesis suite in `tests/test_hypothesis_fixtures.py` found four genuine
+defects, all fixed across two stacked branches: defects 2, 3 and 4 on
+`fix/spatial-check-and-metric-edge-cases`, defect 1 here. Each fix flipped its
+deterministic repro in `tests/test_hypothesis_regressions.py` from `xfail` to a
+real assertion, and removed the `assume()` narrowing that had been hiding it,
+so the property tests now cover the axis that exposed it. No `xfail` remains in
+that module.
+
+## Resolved defects
+
+### 1. Integer `lead_time` silently misread as nanoseconds
+
+- **Axis combination**: `lead_dtype_is_timedelta=False` (any other axes).
+- **Symptom**: `utils.convert_init_time_to_valid_time` added `lead_time` to
+  `init_time` with no dtype coercion, so an integer array of hours was read as
+  nanoseconds and `valid_time` collapsed onto `init_time` (lead `6` became
+  `6 ns`, not 6 hours). No exception was raised.
+  `utils.convert_valid_time_to_init_time` had the same uncoerced subtraction.
+- **Root cause**: `utils.py`, `xr.DataArray(ds.init_time) + xr.DataArray(
+  ds.lead_time)`. Integer-means-hours is the convention everywhere else in the
+  codebase (`utils.py` `pd.to_timedelta(..., unit="h")`, `calc.py` and
+  `metrics.py` `np.timedelta64(int(...), "h")`), so these two were the
+  outliers.
+- **Resolution**: `utils._lead_time_as_timedelta`, applied in both directions.
+  It returns the input untouched when it is already `timedelta64`, which is the
+  production path, so real runs pay nothing. The int-hour `lead_time` fixtures
+  in `tests/conftest.py` and `tests/test_evaluate.py` were migrated to
+  `timedelta64[ns]` to match what the CIRA preprocess hooks in `defaults.py`
+  actually produce; the `lead_dtype_is_timedelta=False` strategy axis keeps the
+  coercion path covered.
+
+  Removing the six `assume(case.lead_dtype_is_timedelta)` narrowings exposed two
+  further places that assumed `timedelta64` lead times. Both are fixed here:
+
+  - `metrics._calculate_event_duration` derived its lead-time step with
+    `np.diff(mask.lead_time.values)`. With integer hours, `expected_gap /
+    lt_step[0]` yields a `datetime.timedelta` rather than a ratio and the
+    surrounding `int()` raises `TypeError`. It now coerces through the same
+    helper, which makes both dtypes behave identically.
+  - `test_convert_init_time_to_valid_time_matches_init_plus_lead` and
+    `test_derive_indices_from_init_time_and_lead_time` computed their *expected*
+    values with raw `init_time + lead` arithmetic, reproducing the very bug
+    under test. The first failed outright once the narrowing was gone; the
+    second passed vacuously, because a nanosecond-collapsed valid_time still
+    falls inside the case window. Both now use a local `_lead_as_offset` helper
+    that spells out the integer-means-hours convention independently of the
+    production implementation, so the assertion is not tautological.
+
+### 2. Antimeridian-crossing `-180/180` grids crash the pre-flight spatial check
+
+- **Axis combination**: `domain_kind="antimeridian"` with either
+  `forecast_longitude_convention` or `target_longitude_convention` set to
+  `"-180-180"`.
+- **Symptom**: `KeyError: 180.0` from `.sel(longitude=slice(...))` on a
+  seam-crossing longitude axis, raised inside
+  `sources/xarray_dataset.py::check_for_spatial_data` before any metric ran.
+- **Root cause**: `.sel()` with a `slice` requires a monotonic index, which a
+  seam-crossing axis is not in the region's frame.
+- **Resolution**: the slice-based block is replaced with boolean comparisons on
+  the 1-D coordinate arrays, which are monotonicity- and order-agnostic. That
+  made the reversed-latitude retry dead, so it is gone. The check now reads only
+  coordinates and never indexes a data variable, so it stays lazy-safe.
+
+  Two details are worth recording, because both were non-obvious:
+
+  - `Region.as_geopandas().total_bounds` **cannot** express an antimeridian
+    region. The geometry is a `MultiPolygon` split at the seam, so its combined
+    bounds always collapse to the full globe, `[-180, lat_min, 180, lat_max]`.
+    The fix therefore uses `geometry.explode(...).bounds` to recover the two
+    real lobes and reports a hit if any lobe matches. Using the collapsed bounds
+    instead would make the longitude test vacuous for every antimeridian region.
+  - The `% 360` normalisation inverts any lobe straddling longitude 0, so a
+    plain region like 30W-30E normalises to `(330.0, 30.0)`. Longitude matching
+    keeps two branches for this: `AND` when the normalised bounds are ordered,
+    `OR` when they wrap. Both branches are reachable, and the wrap branch is
+    about the prime meridian, not the antimeridian. `tests/test_sources.py`
+    covers it, since no `domain_kind` in `strategies.py` generates that shape.
+
+  The new check is stricter than the old one in one respect: the old code
+  returned `sum(data.sizes.values()) > 0`, which summed the latitude and
+  longitude sizes and so reported data whenever *latitude* matched. It is now a
+  true `AND` over both axes. No existing test depended on the loose behavior.
+
+### 3. `MaximumMeanAbsoluteError` / `MinimumMeanAbsoluteError` crash on a
+   degenerate target time axis instead of returning NaN
+
+- **Axis combination**: `missing_data_mode="all_nan"` with `missing_data_side`
+  in `("target", "both")`, or any `coord_inconsistency_mode` that leaves the
+  aligned target with a zero-length `valid_time` axis.
+- **Symptom**: with an all-NaN target, `idxmax`/`idxmin` return `NaT` and the
+  following `.sel(valid_time=NaT)` raises `KeyError` instead of the metric
+  yielding NaN, which is what every other metric does for all-NaN input. With a
+  zero-length axis, `idxmax`/`idxmin` raise `ValueError` from
+  `nanargmax`/`nanargmin`.
+- **Resolution**: an early return in both `_compute_metric` methods, matching
+  the idiom the landfall metrics already use, returning
+  `utils._create_nan_dataarray(self.preserve_dims)`. The size test is ordered
+  before `.isnull().all()` so the reduction, which forces a compute on dask
+  input, is only reached when the axis is non-empty. The guard also short
+  circuits ahead of the forecast-side reduction, the more expensive half.
+
+### 4. `DurationMeanError` crashes on a zero-length `valid_time` axis
+
+- **Axis combination**: `coord_inconsistency_mode="drop_init_times"`. Dropping
+  an init_time can leave the aligned data with a zero-length `valid_time` axis
+  even when `case_overlaps=True` at the unaligned level.
+- **Symptom**: `metrics._calculate_event_duration` built its gap mask with
+  `np.concatenate([[False], ...])`, which yields a length-1 array from the
+  leading `[False]` even for empty input, against a length-0 `valid_time`
+  coordinate. `xr.DataArray` then raised `CoordinateValidationError`.
+- **Resolution**: the mask is preallocated with `np.zeros(vt.size, dtype=bool)`,
+  correct at sizes 0 and 1 and cheaper than concatenating. An early return for a
+  zero-length axis was added on top, because a second failure surfaces once the
+  gap construction is fixed: the downstream `groupby(preserve_dims)` raises
+  `KeyError('init_time')` on empty input. Empty input now yields NaN.
+
+## Strategy and coverage extensions
+
+- `INIT_RESOLUTIONS_HOURS` gained `72`, so the strategies can generate the
+  72-hour 00Z-only production cadence documented in `HEAT_METRIC_QC.md`. The
+  rejection rate is unchanged at 300 examples (47.36% to 47.59%), because the
+  case window is derived from the generated valid-time range and so scales with
+  whatever cadence is drawn.
+- `test_maximum_mean_absolute_error_perfect_forecast_is_zero` is the suite's
+  first value-level oracle. Everything before it asserted only absence-of-crash
+  and output well-formedness, which is structurally blind to a wrong-but-finite
+  answer. See the open findings below for what it pins.
+
+## Open findings, not fixed here
+
+### `Region.mask` does not filter longitude for antimeridian regions
+
+`Region.get_adjusted_bounds` derives its bounds from
+`as_geopandas().total_bounds`, which for a seam-crossing `MultiPolygon`
+collapses to `[-180, lat_min, 180, lat_max]` (see defect 2). `Region.mask` then
+detects the `MultiPolygon` and takes its wrap branch, `lon >= -180 OR
+lon <= 180`, which every longitude satisfies. So an antimeridian region masks on
+latitude only and keeps the entire longitude axis.
+
+Found by cross-checking the rewritten `check_for_spatial_data` against
+`Region.mask` over 400 random region/grid pairs. The five disagreements were all
+of this form, and in every one the new check was right and `mask` was wrong.
+Left alone because `regions.py` was outside the scope of these fixes, but it is
+a real defect and it is now the looser of the two code paths.
+
+### The peak metrics alias the diurnal cycle at coarse init cadences
+
+`MaximumMeanAbsoluteError` takes a true maximum on the target side, but on the
+forecast side reduces over a `tolerance_range_hours` window pooled across
+initializations rather than per initialization. At a 72-hour cadence that window
+can hold a single forecast sample, so the "maximum" it compares against is
+whichever lone snapshot happens to land in the window. Because every init is
+00Z, that snapshot's time of day is fixed by `lead_time mod 24 h`, which aliases
+the diurnal cycle straight into the reported error.
+
+The consequence is that a forecast *identical to the target* does not score
+zero. With a target peaking at 283 K at 12Z and a perfect forecast sampled every
+6 hours from 72-hourly 00Z inits, the per-lead errors are 20 K at lead 0, 10 K
+at lead 6, 0 K at lead 12 where the sampling happens to align, then 10 K and
+20 K again. `test_maximum_mean_absolute_error_perfect_forecast_is_zero` pins
+this as an `xfail` naming `fix/peak-metrics`, which reduces per initialization,
+as the resolving change. `MinimumMeanAbsoluteError` has the same construction.
+
+### `DurationMeanError` requires an `init_time` coordinate to exist
+
+`_calculate_event_duration` raises `ValueError: You are requesting to preserve a
+dimension which does not appear in your data` whenever forecast and target lack
+an `init_time` coordinate entirely, regardless of `valid_time` length. This is
+distinct from defect 4 and predates it; the empty-axis early return only hides
+it for the empty case. Not filed as part of this work.
+
+## Strategy artifacts, not defects
+
+- **Forecast-side `all_nan` modes combined with a structural "which valid_times
+  survived `convert_init_time_to_valid_time`" check**: distinguishing "this
+  valid_time was never produced by this lead" (an artifact of the outer-join
+  reindex) from "this valid_time was produced but is NaN because the strategy
+  blanked it" is ambiguous from values alone. Narrowed with
+  `assume(not _forecast_missing_data_applied(case))` in the two conversion
+  property tests.
+- **`coord_inconsistency_mode="duplicate_init_time"` fed directly to
+  `align_forecast_to_target`**: in production,
+  `ForecastBase.subset_data_to_case` deduplicates `init_time` before this
+  function runs. Calling it directly on undeduplicated data, as the unit test
+  does, produces a duplicate `valid_time` index that `xr.align` rejects.
+  Narrowed with `assume(coord_inconsistency_mode != "duplicate_init_time")`.
+- **`DurationMeanError` / `CriticalSuccessIndex` returning `0` rather than `NaN`
+  on all-NaN input**: both are threshold-based and mask NaN to "no event" /
+  `False` instead of propagating it. The masking is explicit in the
+  implementation, so it is deliberate, but it is documented in neither
+  docstring. The "all-NaN yields NaN" property is therefore asserted only for
+  the plain continuous metrics. Still worth a maintainer's confirmation: a
+  duration error of exactly `0` is indistinguishable from "no data at all".
+
+## Pre-existing infrastructure notes
+
+- `pyproject.toml` declares `[tool.pytest]`, not `[tool.pytest.ini_options]`.
+  Pytest only reads the latter, so the `addopts`/`markers` configured there,
+  including the `slow` marker this module uses, are silently inert. Recorded,
+  not fixed.
+- `tests/conftest.py::make_sample_forecast_dataset` used plain `int` hours,
+  exactly the shape that triggers defect 1, while production preprocessing
+  produces `timedelta64`. That fixture had been silently exercising the buggy
+  path. Migrated here.
+
+## Verification
+
+Full suite `1137 passed, 1 xfailed`
+(`uv run pytest -q --ignore=tests/test_golden.py`), against a base of
+`1130 passed, 5 xfailed`. All five original xfails became real assertions, two
+`check_for_spatial_data` tests were added for the prime-meridian shape, and the
+single remaining xfail is the new peak-metric oracle, which is waiting on
+`fix/peak-metrics`.
+
+Applying the coercion alone, before any fixture change, left the suite at
+`1130 passed, 5 xfailed`, unchanged. Nothing in the suite had encoded the
+nanosecond misreading as an expectation, so the fix had no blast radius of its
+own; every failure that appeared came later, from removing the narrowings.
+
+`HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py`:
+`18 passed, 1 xfailed` at 300 examples each. `pre-commit run --all-files` clean.
+
+Coverage widened as intended. `--hypothesis-show-statistics` reports 22 distinct
+rejection categories before the narrowings were removed and 8 after. The nine
+`_assume_pipeline_supported` categories, which had been discarding 7-29% of
+examples on every metric and schema test, are gone entirely, as is
+`test_derive_indices_from_init_time_and_lead_time`'s only narrowing. What
+remains is the deliberate strategy artifacts below plus the case-overlap
+filters, which are inherent to the no-overlap tests.

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 
 from extremeweatherbench import cases, inputs, regions
 
-INIT_RESOLUTIONS_HOURS = [1, 2, 3, 6, 12, 24, 48]
+INIT_RESOLUTIONS_HOURS = [1, 2, 3, 6, 12, 24, 48, 72]
 LEAD_RESOLUTIONS_HOURS = [1, 2, 3, 6, 12, 24]
 SPATIAL_RESOLUTIONS_DEGREES = [0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -166,7 +166,7 @@ def sample_case_operator(
 def sample_forecast_dataset():
     """Create a sample forecast dataset."""
     init_time = pd.date_range("2021-06-20", periods=3)
-    lead_time = [0, 6, 12]
+    lead_time = np.array([0, 6, 12], dtype="timedelta64[h]").astype("timedelta64[ns]")
     latitudes = np.linspace(40, 50, 11)
     longitudes = np.linspace(-125, -115, 11)
 

--- a/tests/test_hypothesis_fixtures.py
+++ b/tests/test_hypothesis_fixtures.py
@@ -56,17 +56,23 @@ def _forecast_missing_data_applied(case: strategies.ForecastTargetCase) -> bool:
     )
 
 
+def _lead_as_offset(lead) -> np.timedelta64:
+    """An integer lead_time means hours, matching the rest of the codebase."""
+    if isinstance(lead, np.timedelta64):
+        return lead
+    return np.timedelta64(int(lead), "h")
+
+
 @settings(suppress_health_check=[HealthCheck.filter_too_much])
 @given(strategies.forecast_target_case())
 def test_convert_init_time_to_valid_time_matches_init_plus_lead(case):
     """Every output valid_time equals init_time + lead_time."""
     _note_case(case)
-    assume(case.lead_dtype_is_timedelta)
     assume(case.coord_inconsistency_mode != "duplicate_init_time")
     assume(not _forecast_missing_data_applied(case))
     result = utils.convert_init_time_to_valid_time(case.forecast)
     for lead in case.forecast.lead_time.values:
-        expected = np.sort(case.forecast.init_time.values + lead)
+        expected = np.sort(case.forecast.init_time.values + _lead_as_offset(lead))
         da = result["surface_air_temperature"].sel(lead_time=lead)
         actual = np.sort(da.dropna("valid_time", how="all").valid_time.values)
         np.testing.assert_array_equal(actual, expected)
@@ -77,7 +83,6 @@ def test_convert_init_time_to_valid_time_matches_init_plus_lead(case):
 def test_convert_valid_time_to_init_time_roundtrip(case):
     """Converting to valid_time and back recovers the original init_times."""
     _note_case(case)
-    assume(case.lead_dtype_is_timedelta)
     assume(case.coord_inconsistency_mode != "duplicate_init_time")
     assume(not _forecast_missing_data_applied(case))
     valid_time_ds = utils.convert_init_time_to_valid_time(case.forecast)
@@ -113,7 +118,6 @@ def test_determine_temporal_resolution(case):
 def test_derive_indices_from_init_time_and_lead_time(case):
     """Every returned index pair maps to a valid time inside the case window."""
     _note_case(case)
-    assume(case.lead_dtype_is_timedelta)
     init_idx, lead_idx = utils.derive_indices_from_init_time_and_lead_time(
         case.forecast, case.case.start_date, case.case.end_date
     )
@@ -122,7 +126,7 @@ def test_derive_indices_from_init_time_and_lead_time(case):
     start = np.datetime64(case.case.start_date)
     end = np.datetime64(case.case.end_date)
     for i, j in zip(init_idx, lead_idx):
-        valid_time = init_time[i] + lead_time[j]
+        valid_time = init_time[i] + _lead_as_offset(lead_time[j])
         assert start <= valid_time <= end
 
 
@@ -131,7 +135,6 @@ def test_derive_indices_from_init_time_and_lead_time(case):
 def test_xarray_forecast_subset_data_to_case(case):
     """Output valid_times and lat/lon fall inside the case window and region."""
     _note_case(case)
-    assume(case.lead_dtype_is_timedelta)
     assume(case.coord_inconsistency_mode != "duplicate_init_time")
     forecast = inputs.XarrayForecast(
         ds=case.forecast, variables=[], variable_mapping={}
@@ -187,7 +190,6 @@ def test_zarr_target_subsetter(case):
 def test_align_forecast_to_target(case):
     """Aligned forecast lat/lon exactly equal target lat/lon; no new dims."""
     _note_case(case)
-    assume(case.lead_dtype_is_timedelta)
     # In production, XarrayForecast.subset_data_to_case dedups init_time
     # before this function ever sees the data; calling it directly here
     # skips that step, so duplicate_init_time is out of scope too.
@@ -221,22 +223,6 @@ METRIC_FACTORIES = {
 
 
 CONTINUOUS_METRICS = {"MeanAbsoluteError", "RootMeanSquaredError", "MeanError"}
-# Confirmed defect: idxmax/idxmin crash on a degenerate (all-NaN, or emptied
-# by alignment) target valid_time axis instead of returning NaN. Pinned in
-# tests/test_hypothesis_regressions.py.
-IDXMINMAX_METRICS = {"MaximumMeanAbsoluteError", "MinimumMeanAbsoluteError"}
-
-
-def _assume_pipeline_supported(case: strategies.ForecastTargetCase) -> None:
-    assume(case.lead_dtype_is_timedelta)
-    assume(
-        case.domain_kind != "antimeridian"
-        or case.forecast_longitude_convention == "0-360"
-    )
-    assume(
-        case.domain_kind != "antimeridian"
-        or case.target_longitude_convention == "0-360"
-    )
 
 
 @pytest.mark.parametrize("metric_name", list(METRIC_FACTORIES))
@@ -245,27 +231,9 @@ def _assume_pipeline_supported(case: strategies.ForecastTargetCase) -> None:
 def test_metric_result_is_well_formed(metric_name, case):
     """Result is a DataArray, preserve_dims survives, and it is never inf."""
     _note_case(case)
-    _assume_pipeline_supported(case)
-    target_is_all_nan = case.missing_data_mode == "all_nan" and (
-        case.missing_data_side in ("target", "both")
-    )
-    assume(metric_name not in IDXMINMAX_METRICS or not target_is_all_nan)
-    # Confirmed defect: dropping an init_time can leave the aligned data with
-    # a zero-length valid_time axis, which crashes DurationMeanError. Pinned
-    # in tests/test_hypothesis_regressions.py.
-    assume(
-        metric_name != "DurationMeanError"
-        or case.coord_inconsistency_mode != "drop_init_times"
-    )
     metric = METRIC_FACTORIES[metric_name]()
     operator = _build_case_operator(case, metric)
-    if metric_name in IDXMINMAX_METRICS:
-        try:
-            result_df = evaluate.compute_case_operator(operator)
-        except (KeyError, ValueError):
-            return
-    else:
-        result_df = evaluate.compute_case_operator(operator)
+    result_df = evaluate.compute_case_operator(operator)
     if result_df.empty:
         return
     assert not np.isinf(result_df["value"].to_numpy(dtype=float)).any()
@@ -282,7 +250,6 @@ def test_metric_result_is_well_formed(metric_name, case):
 def test_compute_case_operator_output_schema(case):
     """Output columns are exactly OUTPUT_COLUMNS, with numeric value."""
     _note_case(case)
-    _assume_pipeline_supported(case)
     metric = metrics.MeanAbsoluteError()
     operator = _build_case_operator(case, metric)
     result_df = evaluate.compute_case_operator(operator)

--- a/tests/test_hypothesis_fixtures.py
+++ b/tests/test_hypothesis_fixtures.py
@@ -1,10 +1,14 @@
 """Hypothesis property tests driving strategies.py through real EWB code."""
 
+import datetime
+
 import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
 from hypothesis import HealthCheck, assume, given, note, settings
 
-from extremeweatherbench import cases, evaluate, inputs, metrics, utils
+from extremeweatherbench import cases, evaluate, inputs, metrics, regions, utils
 
 from . import strategies
 
@@ -268,3 +272,89 @@ def test_compute_case_operator_no_overlap_is_empty(case):
     operator = _build_case_operator(case, metric)
     result_df = evaluate.compute_case_operator(operator)
     assert result_df.empty
+
+
+def _diurnal_temperature(valid_times, peak_hour=12.0, base=273.0, amplitude=10.0):
+    """24h-periodic temperature, peaking at peak_hour on every day."""
+    shape = np.asarray(valid_times).shape
+    idx = pd.DatetimeIndex(np.asarray(valid_times).ravel())
+    hours = idx.hour.to_numpy() + idx.minute.to_numpy() / 60.0
+    phase = 2 * np.pi * (hours - peak_hour) / 24.0
+    return (base + amplitude * np.cos(phase)).reshape(shape)
+
+
+@pytest.mark.xfail(
+    reason="fix/peak-metrics: forecast side reduces the max across inits "
+    "over valid_time instead of per init_time, so with a 72h init cadence "
+    "the tolerance window can hold only one off-peak forecast sample, "
+    "aliasing a perfect forecast into a non-zero error",
+    strict=False,
+)
+def test_maximum_mean_absolute_error_perfect_forecast_is_zero():
+    """A forecast identical to the target at every sampled time scores 0."""
+    lat = np.array([10.0, 20.0])
+    lon = np.array([100.0, 110.0])
+
+    target_time = pd.date_range("2021-06-20", periods=24 * 10, freq="1h")
+    target_grid = np.repeat(
+        _diurnal_temperature(target_time)[:, None, None], 4, axis=1
+    ).reshape(len(target_time), 2, 2)
+    target_ds = xr.Dataset(
+        {"2m_temperature": (["time", "latitude", "longitude"], target_grid)},
+        coords={"time": target_time, "latitude": lat, "longitude": lon},
+    )
+
+    init_time = pd.date_range("2021-06-20", periods=3, freq="72h")
+    lead_time = np.arange(0, 169, 6).astype("timedelta64[h]").astype("timedelta64[ns]")
+    valid_times = init_time.values[:, None] + lead_time[None, :]
+    forecast_grid = np.repeat(
+        _diurnal_temperature(valid_times)[:, :, None, None], 4, axis=2
+    ).reshape(len(init_time), len(lead_time), 2, 2)
+    forecast_ds = xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                forecast_grid,
+            )
+        },
+        coords={
+            "init_time": init_time,
+            "lead_time": lead_time,
+            "latitude": lat,
+            "longitude": lon,
+        },
+    )
+
+    case = cases.IndividualCase(
+        case_id_number=1,
+        title="diurnal perfect forecast",
+        start_date=datetime.datetime(2021, 6, 20),
+        end_date=datetime.datetime(2021, 6, 30),
+        location=regions.BoundingBoxRegion(
+            latitude_min=5.0,
+            latitude_max=25.0,
+            longitude_min=90.0,
+            longitude_max=120.0,
+        ),
+        event_type="synthetic",
+    )
+    operator = cases.CaseOperator(
+        case_metadata=case,
+        metric_list=[metrics.MaximumMeanAbsoluteError()],
+        target=strategies.InMemoryERA5(
+            ds=target_ds,
+            name="t",
+            variables=["2m_temperature"],
+            variable_mapping={"time": "valid_time"},
+        ),
+        forecast=inputs.XarrayForecast(
+            ds=forecast_ds,
+            name="f",
+            variables=["surface_air_temperature"],
+            variable_mapping={},
+        ),
+    )
+    result_df = evaluate.compute_case_operator(operator)
+    errors = result_df["value"].dropna().to_numpy()
+    assert errors.size > 0
+    np.testing.assert_allclose(errors, 0.0)

--- a/tests/test_hypothesis_regressions.py
+++ b/tests/test_hypothesis_regressions.py
@@ -79,12 +79,7 @@ def test_minimum_mean_absolute_error_returns_nan_on_all_nan_target():
     assert bool(result.isnull().all())
 
 
-@pytest.mark.xfail(
-    reason="_calculate_event_duration builds a length-1 gap array against a "
-    "zero-length valid_time coordinate when passed empty input",
-    strict=False,
-)
-def test_duration_mean_error_crashes_on_empty_valid_time_axis():
+def test_duration_mean_error_returns_nan_on_empty_valid_time_axis():
     valid_time = pd.DatetimeIndex([], dtype="datetime64[ns]")
     lat = np.array([10.0, 20.0])
     lon = np.array([100.0, 110.0])
@@ -99,4 +94,5 @@ def test_duration_mean_error_crashes_on_empty_valid_time_axis():
         coords={"valid_time": valid_time, "latitude": lat, "longitude": lon},
     )
     metric = metrics.DurationMeanError(threshold_criteria=273.0)
-    metric.compute_metric(forecast, target)
+    result = metric.compute_metric(forecast, target)
+    assert bool(result.isnull().all())

--- a/tests/test_hypothesis_regressions.py
+++ b/tests/test_hypothesis_regressions.py
@@ -2,18 +2,14 @@
 
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
 
 from extremeweatherbench import metrics, regions, utils
 from extremeweatherbench.sources import xarray_dataset
 
 
-@pytest.mark.xfail(
-    reason="int lead_time is added to init_time as nanoseconds, not hours",
-    strict=False,
-)
-def test_convert_init_time_to_valid_time_int_lead_time_is_misread():
+def test_convert_init_time_to_valid_time_coerces_int_lead_time_to_hours():
+    """Int-hours lead_time is added to init_time as hours, not nanoseconds."""
     init_time = pd.date_range("2021-06-20", periods=2, freq="6h")
     lead_time = np.array([0, 6, 12])
     ds = xr.Dataset(
@@ -27,7 +23,10 @@ def test_convert_init_time_to_valid_time_int_lead_time_is_misread():
     )
     result = utils.convert_init_time_to_valid_time(ds)
     lead_hours = pd.to_timedelta(lead_time, unit="h").to_numpy()
-    expected = np.sort((init_time.values[:, None] + lead_hours[None, :]).ravel())
+    # Overlapping init_time/lead_time combinations share a valid_time slot,
+    # so the result axis is the unique set of combined times, not all pairs.
+    combos = (init_time.values[:, None] + lead_hours[None, :]).ravel()
+    expected = np.sort(np.unique(combos))
     actual = np.sort(result.valid_time.values)
     np.testing.assert_array_equal(actual, expected)
 

--- a/tests/test_hypothesis_regressions.py
+++ b/tests/test_hypothesis_regressions.py
@@ -65,26 +65,18 @@ def _build_forecast_target(target_values: np.ndarray) -> tuple:
     return forecast, target
 
 
-@pytest.mark.xfail(
-    reason="idxmax on an all-NaN target returns NaT, then .sel(valid_time=NaT) "
-    "raises instead of yielding NaN",
-    strict=False,
-)
-def test_maximum_mean_absolute_error_crashes_on_all_nan_target():
+def test_maximum_mean_absolute_error_returns_nan_on_all_nan_target():
     forecast, target = _build_forecast_target(np.full((3, 2, 2), np.nan))
     metric = metrics.MaximumMeanAbsoluteError()
-    metric.compute_metric(forecast, target)
+    result = metric.compute_metric(forecast, target)
+    assert bool(result.isnull().all())
 
 
-@pytest.mark.xfail(
-    reason="idxmin on an all-NaN target returns NaT, then .sel(valid_time=NaT) "
-    "raises instead of yielding NaN",
-    strict=False,
-)
-def test_minimum_mean_absolute_error_crashes_on_all_nan_target():
+def test_minimum_mean_absolute_error_returns_nan_on_all_nan_target():
     forecast, target = _build_forecast_target(np.full((3, 2, 2), np.nan))
     metric = metrics.MinimumMeanAbsoluteError()
-    metric.compute_metric(forecast, target)
+    result = metric.compute_metric(forecast, target)
+    assert bool(result.isnull().all())
 
 
 @pytest.mark.xfail(

--- a/tests/test_hypothesis_regressions.py
+++ b/tests/test_hypothesis_regressions.py
@@ -32,12 +32,7 @@ def test_convert_init_time_to_valid_time_int_lead_time_is_misread():
     np.testing.assert_array_equal(actual, expected)
 
 
-@pytest.mark.xfail(
-    reason="check_for_spatial_data .sel() needs a monotonic longitude index, "
-    "which an antimeridian-crossing -180/180 axis is not",
-    strict=False,
-)
-def test_check_for_spatial_data_crashes_on_antimeridian_seam():
+def test_check_for_spatial_data_handles_antimeridian_seam():
     longitude = np.array([170.0, 175.0, -180.0, -175.0, -170.0])
     latitude = np.array([20.0, 30.0, 40.0])
     ds = xr.Dataset(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -976,3 +976,61 @@ class TestXarrayDatasetModule:
 
         result = xarray_dataset.check_for_spatial_data(ds, region)
         assert result is False
+
+    def test_check_for_spatial_data_prime_meridian_crossing_region(self):
+        """Test check_for_spatial_data for a region straddling longitude 0."""
+        from extremeweatherbench.regions import BoundingBoxRegion
+
+        # Region spans -30 to 30, a single lobe that straddles 0/360.
+        region = BoundingBoxRegion(
+            latitude_min=20.0,
+            latitude_max=40.0,
+            longitude_min=-30.0,
+            longitude_max=30.0,
+        )
+
+        # -180/180 axis with values on both sides of 0.
+        data = np.random.randn(3, 3)  # 3x3 spatial grid
+        ds_180 = xr.Dataset(
+            {"temperature": (["latitude", "longitude"], data)},
+            coords={
+                "latitude": [25.0, 30.0, 35.0],
+                "longitude": [-10.0, 0.0, 10.0],
+            },
+        )
+        assert xarray_dataset.check_for_spatial_data(ds_180, region) is True
+
+        # 0-360 axis with values on both sides of the 360/0 wrap.
+        data = np.random.randn(3, 2)  # 3x2 spatial grid
+        ds_0360 = xr.Dataset(
+            {"temperature": (["latitude", "longitude"], data)},
+            coords={
+                "latitude": [25.0, 30.0, 35.0],
+                "longitude": [350.0, 5.0],
+            },
+        )
+        assert xarray_dataset.check_for_spatial_data(ds_0360, region) is True
+
+    def test_check_for_spatial_data_lobe_ending_at_prime_meridian(self):
+        """Test check_for_spatial_data for a lobe ending exactly at longitude 0."""
+        from extremeweatherbench.regions import BoundingBoxRegion
+
+        # Region spans -100 to 0, so the lobe's upper bound is exactly 0.
+        region = BoundingBoxRegion(
+            latitude_min=20.0,
+            latitude_max=40.0,
+            longitude_min=-100.0,
+            longitude_max=0.0,
+        )
+
+        data = np.random.randn(3, 1)  # 3x1 spatial grid
+        ds = xr.Dataset(
+            {"temperature": (["latitude", "longitude"], data)},
+            coords={
+                "latitude": [25.0, 30.0, 35.0],
+                "longitude": [-50.0],
+            },
+        )
+
+        result = xarray_dataset.check_for_spatial_data(ds, region)
+        assert result is True


### PR DESCRIPTION
# EWB Pull Request

## Description

The Hypothesis property tests added in `test/hypothesis-fixtures` found four
genuine defects, each pinned there as an `xfail` repro and narrowed out of the
property tests with an `assume()`. This PR fixes all four. Every fix turns its
repro into a real assertion and removes the matching narrowing, so the property
tests now cover the axis that exposed it. No `xfail` remains in
`tests/test_hypothesis_regressions.py`.

**1. `check_for_spatial_data` crashed on antimeridian-crossing grids.** The
slice-based `.sel()` needs a monotonic index, so a seam-crossing `-180/180`
longitude axis raised `KeyError: 180.0` before any metric ran. It now compares
against the 1-D coordinate arrays, which is order- and monotonicity-agnostic and
makes the reversed-latitude retry unnecessary.

Two details are worth a reviewer's attention. Region bounds come from the
exploded geometry rather than `total_bounds`, because a seam-crossing
`MultiPolygon` always collapses to the whole globe and would leave the longitude
test vacuous for every antimeridian region. And the longitude test keeps two
branches: `% 360` inverts the bounds of any lobe straddling longitude 0, so a
plain 30W-30E region normalises to `(330, 30)`. No `domain_kind` in
`strategies.py` generates that shape, so `tests/test_sources.py` covers it.

**2 and 3. The peak metrics and `DurationMeanError` crashed on degenerate time
axes** instead of returning NaN the way every other metric does. `idxmax`/
`idxmin` returned `NaT` on an all-NaN target and the following `.sel()` raised;
`_calculate_event_duration` built a length-1 gap array against a length-0
coordinate.

**4. Integer `lead_time` was silently misread as nanoseconds.**
`convert_init_time_to_valid_time` added `lead_time` to `init_time` with no
coercion, so lead `6` added 6 ns instead of 6 hours and `valid_time` collapsed
onto `init_time` with no error raised. Integer-means-hours is the convention
everywhere else in the codebase, so this was the outlier. The int-hour fixtures
move to `timedelta64[ns]`, matching what the CIRA preprocess hooks produce.

Removing the narrowings also exposed two tests that computed their *expected*
values with the same raw arithmetic the fix corrects, one of which had been
passing vacuously. Both now spell out the convention independently of the
production helper.

Also included: a 72-hour init cadence in the strategies, matching the production
cadence documented in `HEAT_METRIC_QC.md`, and the suite's first value-level
oracle. Everything before it asserted only absence-of-crash and well-formedness,
which is blind to a wrong-but-finite answer. It asserts that a forecast
identical to the target scores zero error. That holds on a dense direct call but
not through the pipeline at a 72h cadence, so it lands as an `xfail` naming
`fix/peak-metrics` as the resolving change.

`tests/hypothesis_findings.md` records all of the above, plus two open findings
this work surfaced but did not fix. The more significant one: `Region.mask`
derives its bounds from the same collapsing `total_bounds`, then takes its wrap
branch and evaluates `lon >= -180 OR lon <= 180`, which everything satisfies, so
**antimeridian regions currently mask on latitude only and keep the entire
longitude axis.** Found by cross-checking the rewritten `check_for_spatial_data`
against `Region.mask` over 400 random region/grid pairs; all five disagreements
were of that form and the new check was right in every one.

## Type of change

- [ ] Refactor
- [x] Bug fix
- [ ] New feature
- [ ] Chore

### If this PR is a breaking change, please explain:

Not breaking, but two behavior changes are worth noting.

`check_for_spatial_data` is stricter: it previously returned
`sum(data.sizes.values()) > 0`, which summed the latitude and longitude sizes and
so reported data whenever *latitude* matched. It is now a true `AND` over both
axes. No existing test depended on the loose behavior.

The peak metrics and `DurationMeanError` now return NaN for degenerate input
where they previously raised.

## How Has This Been Tested?

```bash
source .venv/bin/activate
uv run pytest -q --ignore=tests/test_golden.py
HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py -q
uv run pre-commit run --all-files
```

Full suite `1137 passed, 1 xfailed`, against a base of `1130 passed, 5 xfailed`.
All five original xfails became real assertions, two `check_for_spatial_data`
tests were added for the prime-meridian shape, and the single remaining xfail is
the new oracle. The 300-example sweep is `18 passed, 1 xfailed`. Pre-commit clean.

Applying the `lead_time` coercion alone, before any fixture change, left the
suite unchanged at `1130 passed, 5 xfailed`, so that fix had no blast radius of
its own.

Coverage widened as intended: `--hypothesis-show-statistics` reports 22 distinct
rejection categories before the narrowings were removed and 8 after, with the
nine `_assume_pipeline_supported` categories, which had been discarding 7-29% of
examples on every metric and schema test, gone entirely.

The history is worth reviewing commit by commit. Each of the four fix commits
carries its own regression test flip, so running
`tests/test_hypothesis_regressions.py` at each commit walks the xfail count down
4 to 2 to 1 to 0 as the fixes land, with no test regressing along the way.

Made with [Cursor](https://cursor.com)