### PR TITLE
Add Hypothesis property tests for incoming forecast/target data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 dist/
 __pycache__/
 .pytest_cache
+.hypothesis/
 *.py[oc]
 wheels/
 .python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "types-tqdm>=4.67.0.20250809",
     "python-semantic-release>=10.3.0",
     "twine>=5.1.1",
+    "hypothesis>=6.165.3",
 ]
 docs = [
     "zensical>=0.0.38",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import tempfile
 
@@ -7,6 +8,7 @@ import pytest
 import sparse
 import xarray as xr
 from click import testing
+from hypothesis import HealthCheck, settings
 
 from extremeweatherbench import calc
 
@@ -462,6 +464,18 @@ def sample_sparse_target_dataset():
             "target": make_sample_sparse_target_dataarray(),
         },
     )
+
+
+settings.register_profile(
+    "ewb", max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+settings.register_profile(
+    "ewb-sweep",
+    max_examples=300,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ewb"))
 
 
 def make_cape_pressure_levels() -> np.ndarray:

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,361 @@
+"""Hypothesis strategies for synthetic EWB forecast/target dataset pairs."""
+
+import dataclasses
+import datetime
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from hypothesis import strategies as st
+
+from extremeweatherbench import cases, inputs, regions
+
+INIT_RESOLUTIONS_HOURS = [1, 2, 3, 6, 12, 24, 48]
+LEAD_RESOLUTIONS_HOURS = [1, 2, 3, 6, 12, 24]
+SPATIAL_RESOLUTIONS_DEGREES = [0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
+
+DOMAIN_KINDS = ["mid_latitude", "antimeridian", "polar", "near_global"]
+LONGITUDE_CONVENTIONS = ["0-360", "-180-180"]
+TARGET_TIME_DIMS = ["time", "valid_time"]
+
+COORD_INCONSISTENCY_MODES = [
+    "none",
+    "drop_init_times",
+    "drop_lead_times",
+    "duplicate_init_time",
+    "shuffled_init_time",
+    "offset_outside_window",
+]
+MISSING_DATA_MODES = [
+    "none",
+    "scattered_nan",
+    "all_nan_lead_slab",
+    "all_nan_time_slab",
+    "spatial_hole",
+    "all_nan",
+]
+MISSING_DATA_SIDES = ["forecast", "target", "both"]
+
+# Fixed margins (lat_min, lat_max, lon_min, lon_max) in -180/180 convention,
+# generous enough to cover the grids built for each domain kind below.
+DOMAIN_REGION_BOUNDS = {
+    "mid_latitude": (20.0, 90.0, -130.0, -10.0),
+    "antimeridian": (20.0, 90.0, 150.0, -100.0),
+    "polar": (55.0, 90.0, -180.0, 180.0),
+    "near_global": (-90.0, 90.0, -180.0, 180.0),
+}
+
+
+@dataclasses.dataclass
+class InMemoryERA5(inputs.ERA5):
+    """ERA5 target backed by an in-memory dataset."""
+
+    ds: xr.Dataset | None = None
+    source: str = "memory"
+
+    def _open_data_from_source(self) -> xr.Dataset:
+        return self.ds
+
+
+@dataclasses.dataclass(frozen=True)
+class ForecastTargetCase:
+    """A synthetic forecast/target pair plus matching case metadata."""
+
+    forecast: xr.Dataset
+    target: xr.Dataset
+    case: cases.IndividualCase
+    init_resolution_hours: int
+    lead_resolution_hours: int
+    lead_dtype_is_timedelta: bool
+    forecast_spatial_resolution: float
+    target_spatial_resolution: float
+    domain_kind: str
+    forecast_longitude_convention: str
+    target_longitude_convention: str
+    forecast_latitude_ascending: bool
+    target_latitude_ascending: bool
+    target_time_dim: str
+    coord_inconsistency_mode: str
+    missing_data_mode: str
+    missing_data_side: str
+    case_overlaps: bool
+
+
+def build_latitude(domain_kind: str, resolution: float, n_points: int) -> np.ndarray:
+    """Build a latitude axis for the given domain kind."""
+    if domain_kind == "polar":
+        return np.linspace(60.0, 90.0, n_points)
+    if domain_kind == "near_global":
+        return np.linspace(-85.0, 85.0, n_points)
+    return 20.0 + np.arange(n_points) * resolution
+
+
+def build_longitude(
+    domain_kind: str, resolution: float, n_points: int, convention: str
+) -> np.ndarray:
+    """Build a longitude axis for the given domain kind and convention.
+
+    Coordinates are always monotonic; antimeridian-crossing grids only wrap
+    around the -180/180 seam when that is the requested convention, since a
+    0-360 grid represents the same crossing as a plain interior value.
+    """
+    if domain_kind == "antimeridian":
+        raw = 170.0 + np.arange(n_points) * resolution
+        if convention == "0-360":
+            return raw % 360.0
+        return ((raw + 180.0) % 360.0) - 180.0
+    if domain_kind in ("near_global", "polar"):
+        if convention == "0-360":
+            return np.linspace(1.0, 359.0, n_points)
+        return np.linspace(-179.0, 179.0, n_points)
+    raw = -100.0 + np.arange(n_points) * resolution
+    return raw % 360.0 if convention == "0-360" else raw
+
+
+def build_case_location(domain_kind: str) -> regions.Region:
+    """Build a Region overlapping the grids generated for domain_kind."""
+    lat_min, lat_max, lon_min, lon_max = DOMAIN_REGION_BOUNDS[domain_kind]
+    return regions.BoundingBoxRegion(
+        latitude_min=lat_min,
+        latitude_max=lat_max,
+        longitude_min=lon_min,
+        longitude_max=lon_max,
+    )
+
+
+def build_lead_time(
+    n_lead: int, lead_resolution_hours: int, is_timedelta: bool
+) -> np.ndarray:
+    """Build a lead_time axis, either timedelta64[ns] or plain int hours."""
+    hours = np.arange(n_lead) * lead_resolution_hours
+    if is_timedelta:
+        return hours.astype("timedelta64[h]").astype("timedelta64[ns]")
+    return hours
+
+
+def build_forecast_dataset(
+    rng: np.random.Generator,
+    init_time: pd.DatetimeIndex,
+    lead_time: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+) -> xr.Dataset:
+    """Build a small synthetic forecast dataset."""
+    shape = (len(init_time), len(lead_time), len(latitude), len(longitude))
+    data = 273.0 + 10.0 * rng.standard_normal(shape)
+    return xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                data,
+            )
+        },
+        coords={
+            "init_time": init_time,
+            "lead_time": lead_time,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+    )
+
+
+def build_target_dataset(
+    rng: np.random.Generator,
+    time: pd.DatetimeIndex,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+    time_dim: str,
+) -> xr.Dataset:
+    """Build a small synthetic gridded target dataset."""
+    shape = (len(time), len(latitude), len(longitude))
+    data = 273.0 + 10.0 * rng.standard_normal(shape)
+    return xr.Dataset(
+        {"2m_temperature": ([time_dim, "latitude", "longitude"], data)},
+        coords={time_dim: time, "latitude": latitude, "longitude": longitude},
+    )
+
+
+def apply_coord_inconsistency(
+    forecast: xr.Dataset, mode: str, rng: np.random.Generator
+) -> xr.Dataset:
+    """Apply an irregular/duplicate/shuffled init_time or lead_time pattern."""
+    n_init = forecast.sizes["init_time"]
+    n_lead = forecast.sizes["lead_time"]
+    if mode == "drop_init_times" and n_init > 1:
+        keep = np.sort(rng.choice(n_init, size=n_init - 1, replace=False))
+        forecast = forecast.isel(init_time=keep)
+    elif mode == "drop_lead_times" and n_lead > 1:
+        keep = np.sort(rng.choice(n_lead, size=n_lead - 1, replace=False))
+        forecast = forecast.isel(lead_time=keep)
+    elif mode == "duplicate_init_time":
+        forecast = xr.concat([forecast, forecast.isel(init_time=[0])], dim="init_time")
+    elif mode == "shuffled_init_time":
+        order = rng.permutation(n_init)
+        forecast = forecast.isel(init_time=order)
+    elif mode == "offset_outside_window":
+        offset_init_time = forecast.init_time.values.copy()
+        offset_init_time[-1] = offset_init_time[-1] + np.timedelta64(30, "D")
+        forecast = forecast.assign_coords(init_time=offset_init_time)
+    return forecast
+
+
+def apply_missing_data(
+    dataset: xr.Dataset, variable: str, mode: str, rng: np.random.Generator
+) -> xr.Dataset:
+    """Introduce NaNs into a data variable according to mode."""
+    if mode == "none":
+        return dataset
+    data = dataset[variable].values
+    dims = dataset[variable].dims
+    if mode == "all_nan":
+        data[...] = np.nan
+    elif mode == "scattered_nan":
+        flat = data.reshape(-1)
+        n_missing = max(1, flat.size // 10)
+        idx = rng.choice(flat.size, size=n_missing, replace=False)
+        flat[idx] = np.nan
+    elif mode == "spatial_hole":
+        lat_dim = dims.index("latitude")
+        lon_dim = dims.index("longitude")
+        index = [slice(None)] * data.ndim
+        index[lat_dim] = slice(0, max(1, data.shape[lat_dim] // 3))
+        index[lon_dim] = slice(0, max(1, data.shape[lon_dim] // 3))
+        data[tuple(index)] = np.nan
+    elif mode == "all_nan_lead_slab" and "lead_time" in dims:
+        index = [slice(None)] * data.ndim
+        index[dims.index("lead_time")] = 0
+        data[tuple(index)] = np.nan
+    elif mode == "all_nan_time_slab":
+        time_dim = next(
+            (d for d in ("init_time", "time", "valid_time") if d in dims), None
+        )
+        if time_dim is not None:
+            index = [slice(None)] * data.ndim
+            index[dims.index(time_dim)] = 0
+            data[tuple(index)] = np.nan
+    return dataset
+
+
+@st.composite
+def forecast_target_case(draw) -> ForecastTargetCase:
+    """Draw a synthetic forecast/target dataset pair plus matching case."""
+    seed = draw(st.integers(min_value=0, max_value=2**31 - 1))
+    rng = np.random.default_rng(seed)
+
+    init_resolution_hours = draw(st.sampled_from(INIT_RESOLUTIONS_HOURS))
+    n_init = draw(st.integers(min_value=2, max_value=4))
+    lead_resolution_hours = draw(st.sampled_from(LEAD_RESOLUTIONS_HOURS))
+    n_lead = draw(st.integers(min_value=2, max_value=6))
+    lead_dtype_is_timedelta = draw(st.sampled_from([True, True, True, False]))
+
+    forecast_spatial_resolution = draw(st.sampled_from(SPATIAL_RESOLUTIONS_DEGREES))
+    target_spatial_resolution = draw(st.sampled_from(SPATIAL_RESOLUTIONS_DEGREES))
+    n_forecast_lat = draw(st.integers(min_value=3, max_value=14))
+    n_forecast_lon = draw(st.integers(min_value=3, max_value=14))
+    n_target_lat = draw(st.integers(min_value=3, max_value=14))
+    n_target_lon = draw(st.integers(min_value=3, max_value=14))
+    n_target_time = draw(st.integers(min_value=3, max_value=10))
+
+    domain_kind = draw(st.sampled_from(DOMAIN_KINDS))
+    forecast_longitude_convention = draw(st.sampled_from(LONGITUDE_CONVENTIONS))
+    target_longitude_convention = draw(st.sampled_from(LONGITUDE_CONVENTIONS))
+    forecast_latitude_ascending = draw(st.booleans())
+    target_latitude_ascending = draw(st.booleans())
+    target_time_dim = draw(st.sampled_from(TARGET_TIME_DIMS))
+
+    coord_inconsistency_mode = draw(st.sampled_from(COORD_INCONSISTENCY_MODES))
+    missing_data_mode = draw(st.sampled_from(MISSING_DATA_MODES))
+    missing_data_side = draw(st.sampled_from(MISSING_DATA_SIDES))
+    case_overlaps = draw(st.sampled_from([True, True, True, False]))
+
+    init_time = pd.date_range(
+        "2021-06-20", periods=n_init, freq=f"{init_resolution_hours}h"
+    )
+    lead_time = build_lead_time(n_lead, lead_resolution_hours, lead_dtype_is_timedelta)
+    target_time = pd.date_range(
+        "2021-06-20", periods=n_target_time, freq=f"{lead_resolution_hours}h"
+    )
+
+    lead_deltas = (
+        lead_time if lead_dtype_is_timedelta else lead_time.astype("timedelta64[h]")
+    )
+    forecast_valid_times = (init_time.values[:, None] + lead_deltas[None, :]).ravel()
+    all_times = np.concatenate([forecast_valid_times, target_time.values])
+    nominal_start = pd.Timestamp(all_times.min())
+    nominal_end = pd.Timestamp(all_times.max())
+
+    forecast_latitude = build_latitude(
+        domain_kind, forecast_spatial_resolution, n_forecast_lat
+    )
+    forecast_longitude = build_longitude(
+        domain_kind,
+        forecast_spatial_resolution,
+        n_forecast_lon,
+        forecast_longitude_convention,
+    )
+    target_latitude = build_latitude(
+        domain_kind, target_spatial_resolution, n_target_lat
+    )
+    target_longitude = build_longitude(
+        domain_kind,
+        target_spatial_resolution,
+        n_target_lon,
+        target_longitude_convention,
+    )
+    if not forecast_latitude_ascending:
+        forecast_latitude = forecast_latitude[::-1]
+    if not target_latitude_ascending:
+        target_latitude = target_latitude[::-1]
+
+    forecast = build_forecast_dataset(
+        rng, init_time, lead_time, forecast_latitude, forecast_longitude
+    )
+    target = build_target_dataset(
+        rng, target_time, target_latitude, target_longitude, target_time_dim
+    )
+
+    forecast = apply_coord_inconsistency(forecast, coord_inconsistency_mode, rng)
+
+    if missing_data_side in ("forecast", "both"):
+        forecast = apply_missing_data(
+            forecast, "surface_air_temperature", missing_data_mode, rng
+        )
+    if missing_data_side in ("target", "both"):
+        target = apply_missing_data(target, "2m_temperature", missing_data_mode, rng)
+
+    if case_overlaps:
+        start_date = (nominal_start - pd.Timedelta(hours=1)).to_pydatetime()
+        end_date = (nominal_end + pd.Timedelta(hours=1)).to_pydatetime()
+    else:
+        start_date = datetime.datetime(2000, 1, 1)
+        end_date = datetime.datetime(2000, 1, 3)
+
+    case = cases.IndividualCase(
+        case_id_number=draw(st.integers(min_value=1, max_value=10_000)),
+        title="synthetic hypothesis case",
+        start_date=start_date,
+        end_date=end_date,
+        location=build_case_location(domain_kind),
+        event_type="synthetic",
+    )
+
+    return ForecastTargetCase(
+        forecast=forecast,
+        target=target,
+        case=case,
+        init_resolution_hours=init_resolution_hours,
+        lead_resolution_hours=lead_resolution_hours,
+        lead_dtype_is_timedelta=lead_dtype_is_timedelta,
+        forecast_spatial_resolution=forecast_spatial_resolution,
+        target_spatial_resolution=target_spatial_resolution,
+        domain_kind=domain_kind,
+        forecast_longitude_convention=forecast_longitude_convention,
+        target_longitude_convention=target_longitude_convention,
+        forecast_latitude_ascending=forecast_latitude_ascending,
+        target_latitude_ascending=target_latitude_ascending,
+        target_time_dim=target_time_dim,
+        coord_inconsistency_mode=coord_inconsistency_mode,
+        missing_data_mode=missing_data_mode,
+        missing_data_side=missing_data_side,
+        case_overlaps=case_overlaps,
+    )

--- a/tests/test_hypothesis_fixtures.py
+++ b/tests/test_hypothesis_fixtures.py
@@ -1,0 +1,303 @@
+"""Hypothesis property tests driving strategies.py through real EWB code."""
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, note, settings
+
+from extremeweatherbench import cases, evaluate, inputs, metrics, utils
+
+from . import strategies
+
+pytestmark = pytest.mark.slow
+
+
+def _note_case(case: strategies.ForecastTargetCase) -> None:
+    note(
+        f"init_res={case.init_resolution_hours} lead_res={case.lead_resolution_hours} "
+        f"lead_is_timedelta={case.lead_dtype_is_timedelta} "
+        f"domain={case.domain_kind} "
+        f"fc_lon={case.forecast_longitude_convention} "
+        f"tg_lon={case.target_longitude_convention} "
+        f"fc_lat_asc={case.forecast_latitude_ascending} "
+        f"tg_lat_asc={case.target_latitude_ascending} "
+        f"target_time_dim={case.target_time_dim} "
+        f"coord_mode={case.coord_inconsistency_mode} "
+        f"missing_mode={case.missing_data_mode} "
+        f"missing_side={case.missing_data_side} "
+        f"overlaps={case.case_overlaps}"
+    )
+
+
+def _build_case_operator(
+    case: strategies.ForecastTargetCase, metric: "metrics.BaseMetric"
+) -> "cases.CaseOperator":
+    return cases.CaseOperator(
+        case_metadata=case.case,
+        metric_list=[metric],
+        target=strategies.InMemoryERA5(
+            ds=case.target,
+            name="t",
+            variables=["2m_temperature"],
+            variable_mapping={"time": "valid_time"},
+        ),
+        forecast=inputs.XarrayForecast(
+            ds=case.forecast,
+            name="f",
+            variables=["surface_air_temperature"],
+            variable_mapping={},
+        ),
+    )
+
+
+def _forecast_missing_data_applied(case: strategies.ForecastTargetCase) -> bool:
+    return case.missing_data_mode != "none" and case.missing_data_side in (
+        "forecast",
+        "both",
+    )
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_convert_init_time_to_valid_time_matches_init_plus_lead(case):
+    """Every output valid_time equals init_time + lead_time."""
+    _note_case(case)
+    assume(case.lead_dtype_is_timedelta)
+    assume(case.coord_inconsistency_mode != "duplicate_init_time")
+    assume(not _forecast_missing_data_applied(case))
+    result = utils.convert_init_time_to_valid_time(case.forecast)
+    for lead in case.forecast.lead_time.values:
+        expected = np.sort(case.forecast.init_time.values + lead)
+        da = result["surface_air_temperature"].sel(lead_time=lead)
+        actual = np.sort(da.dropna("valid_time", how="all").valid_time.values)
+        np.testing.assert_array_equal(actual, expected)
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_convert_valid_time_to_init_time_roundtrip(case):
+    """Converting to valid_time and back recovers the original init_times."""
+    _note_case(case)
+    assume(case.lead_dtype_is_timedelta)
+    assume(case.coord_inconsistency_mode != "duplicate_init_time")
+    assume(not _forecast_missing_data_applied(case))
+    valid_time_ds = utils.convert_init_time_to_valid_time(case.forecast)
+    roundtripped = utils.convert_valid_time_to_init_time(
+        valid_time_ds["surface_air_temperature"]
+    )
+    for lead in case.forecast.lead_time.values:
+        expected = np.sort(case.forecast.init_time.values)
+        da = roundtripped.sel(lead_time=lead)
+        actual = np.sort(da.dropna("init_time", how="all").init_time.values)
+        np.testing.assert_array_equal(actual, expected)
+
+
+@given(strategies.forecast_target_case())
+def test_determine_temporal_resolution(case):
+    """Returns None or the minimum positive spacing in hours."""
+    _note_case(case)
+    target = (
+        case.target
+        if case.target_time_dim == "valid_time"
+        else case.target.rename({case.target_time_dim: "valid_time"})
+    )
+    resolution = utils.determine_temporal_resolution(target)
+    if resolution is not None:
+        assert resolution > 0
+        diffs = np.diff(case.target[case.target_time_dim].values)
+        diffs = diffs.astype("timedelta64[h]").astype(int)
+        diffs = diffs[diffs != 0]
+        assert resolution == diffs.min()
+
+
+@given(strategies.forecast_target_case())
+def test_derive_indices_from_init_time_and_lead_time(case):
+    """Every returned index pair maps to a valid time inside the case window."""
+    _note_case(case)
+    assume(case.lead_dtype_is_timedelta)
+    init_idx, lead_idx = utils.derive_indices_from_init_time_and_lead_time(
+        case.forecast, case.case.start_date, case.case.end_date
+    )
+    init_time = case.forecast.init_time.values
+    lead_time = case.forecast.lead_time.values
+    start = np.datetime64(case.case.start_date)
+    end = np.datetime64(case.case.end_date)
+    for i, j in zip(init_idx, lead_idx):
+        valid_time = init_time[i] + lead_time[j]
+        assert start <= valid_time <= end
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_xarray_forecast_subset_data_to_case(case):
+    """Output valid_times and lat/lon fall inside the case window and region."""
+    _note_case(case)
+    assume(case.lead_dtype_is_timedelta)
+    assume(case.coord_inconsistency_mode != "duplicate_init_time")
+    forecast = inputs.XarrayForecast(
+        ds=case.forecast, variables=[], variable_mapping={}
+    )
+    result = forecast.subset_data_to_case(case.forecast, case.case)
+    if result.sizes.get("valid_time", 0) == 0:
+        assume(not case.case_overlaps)
+        return
+    start = np.datetime64(case.case.start_date)
+    end = np.datetime64(case.case.end_date)
+    assert (result.valid_time.values >= start).all()
+    assert (result.valid_time.values <= end).all()
+    bounds = case.case.location.as_geopandas().total_bounds
+    assert (result.latitude.values >= bounds[1]).all()
+    assert (result.latitude.values <= bounds[3]).all()
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_xarray_forecast_subset_data_to_case_non_overlapping_is_empty(case):
+    """A non-overlapping case yields an empty result instead of raising."""
+    _note_case(case)
+    assume(not case.case_overlaps)
+    forecast = inputs.XarrayForecast(
+        ds=case.forecast, variables=[], variable_mapping={}
+    )
+    result = forecast.subset_data_to_case(case.forecast, case.case)
+    assert result.sizes.get("valid_time", 0) == 0
+
+
+@given(strategies.forecast_target_case())
+def test_zarr_target_subsetter(case):
+    """Same time/space containment on the target side, for both time namings."""
+    _note_case(case)
+    result = inputs.zarr_target_subsetter(
+        case.target, case.case, time_variable=case.target_time_dim
+    )
+    if result.sizes.get(case.target_time_dim, 0) == 0:
+        assume(not case.case_overlaps)
+        return
+    start = np.datetime64(case.case.start_date)
+    end = np.datetime64(case.case.end_date)
+    times = result[case.target_time_dim].values
+    assert (times >= start).all()
+    assert (times <= end).all()
+    bounds = case.case.location.as_geopandas().total_bounds
+    assert (result.latitude.values >= bounds[1]).all()
+    assert (result.latitude.values <= bounds[3]).all()
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_align_forecast_to_target(case):
+    """Aligned forecast lat/lon exactly equal target lat/lon; no new dims."""
+    _note_case(case)
+    assume(case.lead_dtype_is_timedelta)
+    # In production, XarrayForecast.subset_data_to_case dedups init_time
+    # before this function ever sees the data; calling it directly here
+    # skips that step, so duplicate_init_time is out of scope too.
+    assume(case.coord_inconsistency_mode != "duplicate_init_time")
+    forecast = case.forecast.rename(init_time="valid_time")
+    target = case.target
+    if case.target_time_dim == "time":
+        target = target.rename({"time": "valid_time"})
+    aligned_forecast, aligned_target = inputs.align_forecast_to_target(forecast, target)
+    assert set(aligned_forecast.dims) <= set(forecast.dims) | set(target.dims)
+    np.testing.assert_array_equal(
+        aligned_forecast.latitude.values, aligned_target.latitude.values
+    )
+    np.testing.assert_array_equal(
+        aligned_forecast.longitude.values, aligned_target.longitude.values
+    )
+
+
+METRIC_FACTORIES = {
+    "MeanAbsoluteError": lambda: metrics.MeanAbsoluteError(),
+    "RootMeanSquaredError": lambda: metrics.RootMeanSquaredError(),
+    "MeanError": lambda: metrics.MeanError(),
+    "MaximumMeanAbsoluteError": lambda: metrics.MaximumMeanAbsoluteError(),
+    "MinimumMeanAbsoluteError": lambda: metrics.MinimumMeanAbsoluteError(),
+    "DurationMeanError": lambda: metrics.DurationMeanError(threshold_criteria=273.0),
+    "EarlySignal": lambda: metrics.EarlySignal(forecast_threshold=273.0),
+    "CriticalSuccessIndex": lambda: metrics.CriticalSuccessIndex(
+        forecast_threshold=273.0, target_threshold=273.0
+    ),
+}
+
+
+CONTINUOUS_METRICS = {"MeanAbsoluteError", "RootMeanSquaredError", "MeanError"}
+# Confirmed defect: idxmax/idxmin crash on a degenerate (all-NaN, or emptied
+# by alignment) target valid_time axis instead of returning NaN. Pinned in
+# tests/test_hypothesis_regressions.py.
+IDXMINMAX_METRICS = {"MaximumMeanAbsoluteError", "MinimumMeanAbsoluteError"}
+
+
+def _assume_pipeline_supported(case: strategies.ForecastTargetCase) -> None:
+    assume(case.lead_dtype_is_timedelta)
+    assume(
+        case.domain_kind != "antimeridian"
+        or case.forecast_longitude_convention == "0-360"
+    )
+    assume(
+        case.domain_kind != "antimeridian"
+        or case.target_longitude_convention == "0-360"
+    )
+
+
+@pytest.mark.parametrize("metric_name", list(METRIC_FACTORIES))
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_metric_result_is_well_formed(metric_name, case):
+    """Result is a DataArray, preserve_dims survives, and it is never inf."""
+    _note_case(case)
+    _assume_pipeline_supported(case)
+    target_is_all_nan = case.missing_data_mode == "all_nan" and (
+        case.missing_data_side in ("target", "both")
+    )
+    assume(metric_name not in IDXMINMAX_METRICS or not target_is_all_nan)
+    # Confirmed defect: dropping an init_time can leave the aligned data with
+    # a zero-length valid_time axis, which crashes DurationMeanError. Pinned
+    # in tests/test_hypothesis_regressions.py.
+    assume(
+        metric_name != "DurationMeanError"
+        or case.coord_inconsistency_mode != "drop_init_times"
+    )
+    metric = METRIC_FACTORIES[metric_name]()
+    operator = _build_case_operator(case, metric)
+    if metric_name in IDXMINMAX_METRICS:
+        try:
+            result_df = evaluate.compute_case_operator(operator)
+        except (KeyError, ValueError):
+            return
+    else:
+        result_df = evaluate.compute_case_operator(operator)
+    if result_df.empty:
+        return
+    assert not np.isinf(result_df["value"].to_numpy(dtype=float)).any()
+    all_nan_everywhere = metric_name in CONTINUOUS_METRICS and (
+        case.missing_data_mode == "all_nan"
+        and case.missing_data_side in ("forecast", "both", "target")
+    )
+    if all_nan_everywhere:
+        assert result_df["value"].isna().all()
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_compute_case_operator_output_schema(case):
+    """Output columns are exactly OUTPUT_COLUMNS, with numeric value."""
+    _note_case(case)
+    _assume_pipeline_supported(case)
+    metric = metrics.MeanAbsoluteError()
+    operator = _build_case_operator(case, metric)
+    result_df = evaluate.compute_case_operator(operator)
+    assert list(result_df.columns) == evaluate.OUTPUT_COLUMNS
+    if not result_df.empty:
+        assert result_df["value"].dtype.kind in "fc"
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(strategies.forecast_target_case())
+def test_compute_case_operator_no_overlap_is_empty(case):
+    """Zero temporal overlap returns an empty DataFrame, not an exception."""
+    _note_case(case)
+    assume(not case.case_overlaps)
+    metric = metrics.MeanAbsoluteError()
+    operator = _build_case_operator(case, metric)
+    result_df = evaluate.compute_case_operator(operator)
+    assert result_df.empty

--- a/tests/test_hypothesis_regressions.py
+++ b/tests/test_hypothesis_regressions.py
@@ -1,0 +1,115 @@
+"""Deterministic repros for defects found by test_hypothesis_fixtures.py."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from extremeweatherbench import metrics, regions, utils
+from extremeweatherbench.sources import xarray_dataset
+
+
+@pytest.mark.xfail(
+    reason="int lead_time is added to init_time as nanoseconds, not hours",
+    strict=False,
+)
+def test_convert_init_time_to_valid_time_int_lead_time_is_misread():
+    init_time = pd.date_range("2021-06-20", periods=2, freq="6h")
+    lead_time = np.array([0, 6, 12])
+    ds = xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["init_time", "lead_time"],
+                np.arange(6.0).reshape(2, 3),
+            )
+        },
+        coords={"init_time": init_time, "lead_time": lead_time},
+    )
+    result = utils.convert_init_time_to_valid_time(ds)
+    lead_hours = pd.to_timedelta(lead_time, unit="h").to_numpy()
+    expected = np.sort((init_time.values[:, None] + lead_hours[None, :]).ravel())
+    actual = np.sort(result.valid_time.values)
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.xfail(
+    reason="check_for_spatial_data .sel() needs a monotonic longitude index, "
+    "which an antimeridian-crossing -180/180 axis is not",
+    strict=False,
+)
+def test_check_for_spatial_data_crashes_on_antimeridian_seam():
+    longitude = np.array([170.0, 175.0, -180.0, -175.0, -170.0])
+    latitude = np.array([20.0, 30.0, 40.0])
+    ds = xr.Dataset(
+        {"v": (["latitude", "longitude"], np.zeros((3, 5)))},
+        coords={"latitude": latitude, "longitude": longitude},
+    )
+    region = regions.BoundingBoxRegion(
+        latitude_min=20.0,
+        latitude_max=40.0,
+        longitude_min=150.0,
+        longitude_max=-100.0,
+    )
+    assert xarray_dataset.check_for_spatial_data(ds, region)
+
+
+def _build_forecast_target(target_values: np.ndarray) -> tuple:
+    valid_time = pd.date_range("2021-06-20", periods=3, freq="6h")
+    lat = np.array([10.0, 20.0])
+    lon = np.array([100.0, 110.0])
+    forecast = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2),
+        dims=["valid_time", "latitude", "longitude"],
+        coords={"valid_time": valid_time, "latitude": lat, "longitude": lon},
+    )
+    target = xr.DataArray(
+        target_values,
+        dims=["valid_time", "latitude", "longitude"],
+        coords={"valid_time": valid_time, "latitude": lat, "longitude": lon},
+    )
+    return forecast, target
+
+
+@pytest.mark.xfail(
+    reason="idxmax on an all-NaN target returns NaT, then .sel(valid_time=NaT) "
+    "raises instead of yielding NaN",
+    strict=False,
+)
+def test_maximum_mean_absolute_error_crashes_on_all_nan_target():
+    forecast, target = _build_forecast_target(np.full((3, 2, 2), np.nan))
+    metric = metrics.MaximumMeanAbsoluteError()
+    metric.compute_metric(forecast, target)
+
+
+@pytest.mark.xfail(
+    reason="idxmin on an all-NaN target returns NaT, then .sel(valid_time=NaT) "
+    "raises instead of yielding NaN",
+    strict=False,
+)
+def test_minimum_mean_absolute_error_crashes_on_all_nan_target():
+    forecast, target = _build_forecast_target(np.full((3, 2, 2), np.nan))
+    metric = metrics.MinimumMeanAbsoluteError()
+    metric.compute_metric(forecast, target)
+
+
+@pytest.mark.xfail(
+    reason="_calculate_event_duration builds a length-1 gap array against a "
+    "zero-length valid_time coordinate when passed empty input",
+    strict=False,
+)
+def test_duration_mean_error_crashes_on_empty_valid_time_axis():
+    valid_time = pd.DatetimeIndex([], dtype="datetime64[ns]")
+    lat = np.array([10.0, 20.0])
+    lon = np.array([100.0, 110.0])
+    forecast = xr.DataArray(
+        np.empty((0, 2, 2)),
+        dims=["valid_time", "latitude", "longitude"],
+        coords={"valid_time": valid_time, "latitude": lat, "longitude": lon},
+    )
+    target = xr.DataArray(
+        np.empty((0, 2, 2)),
+        dims=["valid_time", "latitude", "longitude"],
+        coords={"valid_time": valid_time, "latitude": lat, "longitude": lon},
+    )
+    metric = metrics.DurationMeanError(threshold_criteria=273.0)
+    metric.compute_metric(forecast, target)

--- a/uv.lock
+++ b/uv.lock
@@ -1243,6 +1243,7 @@ complete = [
 ]
 dev = [
     { name = "deptry" },
+    { name = "hypothesis" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "isort" },
@@ -1314,6 +1315,7 @@ requires-dist = [
 complete = [{ name = "extremeweatherbench", extras = ["data-prep"], editable = "." }]
 dev = [
     { name = "deptry", specifier = ">=0.23.0" },
+    { name = "hypothesis", specifier = ">=6.165.3" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipywidgets", specifier = ">=8.1.5" },
     { name = "isort", specifier = ">=6.0.1" },
@@ -1966,6 +1968,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.165.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3a/b840ea8b26e0c4795584dc93c832c5d1a9ff37db1818cc91b2ee8110f757/hypothesis-6.165.5.tar.gz", hash = "sha256:0df7fdefd2e10bbfe7d690eb22c7181a739e8040026907207faa305d86e6e4db", size = 503056 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/46/fba332db906bb26f3c27285d17f5210bee54c3d7e1545e4d1bcae08ec437/hypothesis-6.165.5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e9ee79ccf2de7b185821ed8364eccfea7300b52b30a8c626f6b7213f3b38e5d5", size = 782500 },
+    { url = "https://files.pythonhosted.org/packages/cd/68/f3cd7814a571ecf58c97a40686c97814c9f6be95dd258d9144d909f0900e/hypothesis-6.165.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b732ea0c758e9c587eea8bb89ea27c985cb7609304e484ff8e5ffdb890f56ae5", size = 778047 },
+    { url = "https://files.pythonhosted.org/packages/85/a4/e0825ff8e353bf92b77f9b990c3e0e1160a0f2953feb95647cf2ced0b1a0/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb08b192ea64a75e82dcc0b49e515f9ca86e4523c678bf8035c993f3bf7323f", size = 1107271 },
+    { url = "https://files.pythonhosted.org/packages/63/85/1005fece1e0f59f8974c2e4be3fae1d0436a77b9fbee9a6203d7b250536d/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb74178189e0a8451e0b7cde4a236f4c8bee848ce01d42df968623ac11a4671a", size = 1135836 },
+    { url = "https://files.pythonhosted.org/packages/8d/8a/6f51cf111f590b883f5fcdb21b54345beeab516ad9c07d4256b731d66ef4/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a970cfb945f31b3115b013ede9fe3f0d68b37ff5b86499cc44ccec3d3fe1eeaa", size = 1156825 },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/fbf54b49173d118681576259acdec61e045b825d516ca1fd5155f7a14ac1/hypothesis-6.165.5-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:569a7cd8b737019420a5530584ee28fba9dfa3ed877621764a2627f804e983c6", size = 1112117 },
+    { url = "https://files.pythonhosted.org/packages/d2/95/98bd41c67215950f73f8df711b7d13e40f0fad21c1ff61271b676abc4e19/hypothesis-6.165.5-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:61f30a43dc377ba94885e1990be785434686d76a8f37605336dd697c696dad4c", size = 1148864 },
+    { url = "https://files.pythonhosted.org/packages/0b/07/9dac0e757abc9dd0500b173adbfe018b1742af5ab35c46169cea290bbf65/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6a25168ab05d52a084e216f8f033472a8bd18167e0e8fc25a8774722db884be2", size = 1282719 },
+    { url = "https://files.pythonhosted.org/packages/62/9a/0dcce83dfa414427c2632be45a2338edb5b80e2b9b1c7d88c70c2478c90d/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:6984a5b7e62b19ddd78643d954dfa90ec8dabbdac4df43a4e63f60fa06514eb2", size = 1409219 },
+    { url = "https://files.pythonhosted.org/packages/31/8f/82ed9fe9dae7cb79714c5de9cbccd5c4847348971e4ee61c5ad2013417d9/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:77b57c6c5154357955d724a5ba198aa421f1273a9f88a6ae24d23a1c6d1c91b8", size = 1281995 },
+    { url = "https://files.pythonhosted.org/packages/b9/4b/06ca1631cce0a9a9806ef15535b9502967751a066dfd620876ff4b8e1eaf/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d77557a13f3cfbabc9b96909fc985563e474627208d981689e4925dc4708722f", size = 1324044 },
+    { url = "https://files.pythonhosted.org/packages/b0/d7/ac8ae1cf829faa5204a743db0e06880ff71bdd105927592b504e34368391/hypothesis-6.165.5-cp310-abi3-win32.whl", hash = "sha256:7c5fd96d54f63fca065cbc21579be0e9b75190af48ff77d5cb759111fe5edae0", size = 668283 },
+    { url = "https://files.pythonhosted.org/packages/1c/62/77acaaea919da21dbf9e76b78a87f9ac66fb44dc2e95afce07dad6da1185/hypothesis-6.165.5-cp310-abi3-win_amd64.whl", hash = "sha256:bcc3f34121b046e6091b35901b77e24dd1c674fc234b6e09b102e5efb03afa11", size = 674433 },
+    { url = "https://files.pythonhosted.org/packages/e6/d0/176ea6d8480d35a1a4fc2ffb1a61126441b2ac067216737052358581d5a7/hypothesis-6.165.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1f330c91d532810bc2ac849e4d0d44a5a4f72508b4c92f1af91b7f2c90c4379a", size = 784074 },
+    { url = "https://files.pythonhosted.org/packages/3e/0c/3d128243dfc0ae059935c6607869f244efdc5676bb6e0006a2795cfebaeb/hypothesis-6.165.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:331e8026a380629c8b3b01850f0504a5191617694fe8703ffbb7de32cfbb370e", size = 775642 },
+    { url = "https://files.pythonhosted.org/packages/6f/40/e80bb810b26fe5807f7c8e3c3c5c3c7556d7128a195e0a57f2480b8a78e2/hypothesis-6.165.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4ebe628c589b512a0e20b99aa3799e2331ba2c590dadf411d3bee95f9edb914", size = 1106103 },
+    { url = "https://files.pythonhosted.org/packages/a6/1c/14648fa3d821bfe4f132e5482837320f191bc60f38a4bd2b687096adf6e5/hypothesis-6.165.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:397685c7e74e6c489bab521bf437c7aba366e275e54f8bb03a6f4571df71faa8", size = 1156164 },
+    { url = "https://files.pythonhosted.org/packages/59/59/74718a2b859e3b6673589f1591785dd15cdec2ff02b7c8d18f3fc0a42ed2/hypothesis-6.165.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ed071268fb878d206ff3172dfef29681cda4982c2752d57e3ad1cf70aa3d7535", size = 1280047 },
+    { url = "https://files.pythonhosted.org/packages/72/5f/1de655e95992c4657f302ec0eca0dd2cfb6bfaaa3b698836432daedac992/hypothesis-6.165.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:381bb61f342c47d0bbfed6af7fecc93f1a8d4778e0c12e7415bdfe0f9bdc9121", size = 1323384 },
+    { url = "https://files.pythonhosted.org/packages/52/e9/1f265bf5f575396e8097010c39b11c2c4dd905064c694a0f53dffff58445/hypothesis-6.165.5-cp312-cp312-win_amd64.whl", hash = "sha256:92f2dfb1417bfaf93fdbe654261c68dbbfd573b74473a570895bf81958c045e7", size = 671570 },
+    { url = "https://files.pythonhosted.org/packages/f1/af/2c3357cda375d8ba1276dec4d0a7b51404f86cc6855f1541b424cf99d5f7/hypothesis-6.165.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:55b907b33ece350a8b69890a7f09b22b6a93761a8724c3ed12a9cd71b2a03eb1", size = 783966 },
+    { url = "https://files.pythonhosted.org/packages/0b/64/71cbfa9e741a0d657570af6b42f5f81ca795fdd0bddca44bc89309b46e16/hypothesis-6.165.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2cf1a6b2ccaf36e0a2b1f95515edec4db6db14a4e7afd9c36ff477552ffc0f11", size = 775594 },
+    { url = "https://files.pythonhosted.org/packages/ac/1f/ccb8f0034c8e17f488bc60d74ac21ac0e8945f507ed0b6e8634b67da925e/hypothesis-6.165.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5faa41aca389826d21f311ae5e59b36eb8bb38933a88bc07ad08bd868af6daae", size = 1106007 },
+    { url = "https://files.pythonhosted.org/packages/13/9d/64f7f7e1398fb04286816b9770138a35d730f008ac45b44b6425dcc0dd61/hypothesis-6.165.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a194f401e5d0345ef459f5aa80a50676a64e146c4f57474d70f7ccbe11c886c7", size = 1155990 },
+    { url = "https://files.pythonhosted.org/packages/21/e9/4bc808417bac59e9c154cbfb38705613adba4f1f37a815607211ab9ee0ab/hypothesis-6.165.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dd2acd36004b990504125c4e679cf98addf3ca2ce873b38a52f71c66716cc7a6", size = 1280030 },
+    { url = "https://files.pythonhosted.org/packages/7b/ff/dd0de28497f64ca01c059e32eca7e06a69c39f50ab614969ae636b7ceb3f/hypothesis-6.165.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:709d61590c8cd627479fb4255e085239b91b29a4d386e83f910c5117cfe5b25b", size = 1323111 },
+    { url = "https://files.pythonhosted.org/packages/45/45/756e1050f26041f6c3aeae2b7e41b10160b2560de0ec46fd3341f6a3cb52/hypothesis-6.165.5-cp313-cp313-win_amd64.whl", hash = "sha256:de4b6d24a0e6adfdd99b2ee1f8d9f43e6ba6146b3860a643e8bce6b41fcebdc6", size = 671569 },
+    { url = "https://files.pythonhosted.org/packages/63/5e/e4178b39d5e7307d3658ec54733f3b7d953df12a38681b91ab1929b740cb/hypothesis-6.165.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f877ace8cb1bc0af9e3c83bf2a63f0a29f54f99ec813d1ecc9c3224b514c036", size = 784066 },
+    { url = "https://files.pythonhosted.org/packages/7b/f1/9c338484238ef0169f77ae7fdd28e34d1dacc0501f003cf7b0009f1f1f58/hypothesis-6.165.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f9d0b87ba2fa7ae53c09650e07cb74a117b383d7ab4839415341ac802596d1e5", size = 775741 },
+    { url = "https://files.pythonhosted.org/packages/a8/79/4502ccc73f5dbaa29c9cc1f33af0337aa28cc03c86ae289530bb70c0fc73/hypothesis-6.165.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:842481f603ef919c2594784bfbaa600916250a35e9d54cc4260e27d415eacc0a", size = 1106541 },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/10575fe56720cc6be25f7bc8cef708ee1b6e6669ca0b7fd16f7dbf460190/hypothesis-6.165.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1ecee1a9241db6c2d51ebbe58aa2575364f4fa21583f5d22ac2a8885bbe9490", size = 1156172 },
+    { url = "https://files.pythonhosted.org/packages/c1/3e/b89e390f580d55b2d65bf726d7602a80f7725cc414bd60526bed0caf507b/hypothesis-6.165.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c108e99e4029318ed85ec5c39f5687c36604606394de3ff4da6e42356a2cceff", size = 1280392 },
+    { url = "https://files.pythonhosted.org/packages/9a/81/b33b5c0aedf35c298011748c679d652839a86b55ea616ca7561b85ac233f/hypothesis-6.165.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a811fe1f763e725692fa730c8b27ee3909f652f9c885dd89ee06f2583fd80944", size = 1323482 },
+    { url = "https://files.pythonhosted.org/packages/f2/8f/0361d9fce27af669ae936f535ad8275c35736cccf7d9ed66275f3eca874d/hypothesis-6.165.5-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:38353c9aaf946f76fd2d7d5e59c1564eac93ad362e98c7d6ffa705aa0e38974d", size = 615638 },
+    { url = "https://files.pythonhosted.org/packages/2d/fa/f49d197e125db4dd6725f248a838c1a8230e50d91889237fbf21705b6d45/hypothesis-6.165.5-cp314-cp314-win_amd64.whl", hash = "sha256:377af80792d187cc222bb2666e979c7e559ebb0f1b312c5376d7216f9c91bbf1", size = 671380 },
+    { url = "https://files.pythonhosted.org/packages/28/90/f939079a65499cad6352f566c3c632da5292f80e2253a72cc9bf6684d4bb/hypothesis-6.165.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e2c423f947be24a7a7324962bf4984bc2231d61c01a4ce4d794e5c7e72b918f3", size = 782526 },
+    { url = "https://files.pythonhosted.org/packages/51/55/8afa60314542179289b2ef7eb6623cc8d9a6405488d2f3266e7610e003d4/hypothesis-6.165.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:05e7e8288b2f5fbb34a30b45c9df72a5ce9da0d5ce90705c76b28dda75aac984", size = 774157 },
+    { url = "https://files.pythonhosted.org/packages/6b/83/93ba4b711c0bfa5a2acc200d60f6fb3c947ea1a4b7f6ef0dacc02ac90de0/hypothesis-6.165.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3837b9e586a78f961aa7c0eedb979fa1cf3dcc8302103ac1e75c2520e943555f", size = 1104748 },
+    { url = "https://files.pythonhosted.org/packages/57/b9/c0b04ab66762526855fc97c18ecafe038fb1b428f48b2234e3c17b75b4ad/hypothesis-6.165.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8fac650e976dfe4d48682f902224a70e2e64ec0716a8822818fa958b456053", size = 1154827 },
+    { url = "https://files.pythonhosted.org/packages/4c/9b/9368493ef62fba5a3ae8b09164466c3ad166b329ae2df01c897dfc3f3790/hypothesis-6.165.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a5004c3fe761b642ca556abf4551bc9a94d190320bcf7ce118cf8b792eaf71c", size = 1278417 },
+    { url = "https://files.pythonhosted.org/packages/6f/21/5eef54851cb51f47ebe123312c4c737934cb6469f6af38bd6e052037f89c/hypothesis-6.165.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:df05b18c2dcb1701532044d4d119cecc08b7d91fcf72e78a17b03257053cc6e9", size = 1322104 },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/9ed7f0b7c6b0a5d0d6aa0e0a5c05420db8ce21de6c96ce17139c0dbd8d2c/hypothesis-6.165.5-cp314-cp314t-win_amd64.whl", hash = "sha256:56f3a5b0b21695cdc6c8ccb7cf8da63f5822de4691cf23b9d95b5931b042af00", size = 671372 },
 ]
 
 [[package]]


### PR DESCRIPTION
# EWB Pull Request

## Description

The shared fixtures are all fixed-shape, so realistic input variation never got
exercised: sub-6h init and lead resolutions, mismatched forecast/target grid
spacing, alternate longitude conventions, irregular or duplicated coordinates,
and missing data combined with any of those.

Adds `tests/strategies.py`, which generates forecast/target/case bundles across
those axes, and `tests/test_hypothesis_fixtures.py`, which drives them through
`utils`, `inputs`, and the full `compute_case_operator` pipeline.

**Tests only, no `src/` changes.** Four defects surfaced. Each is pinned as a
deterministic `xfail` repro in `tests/test_hypothesis_regressions.py` and
written up in `tests/hypothesis_findings.md`:

- Integer `lead_time` is added to `init_time` as nanoseconds instead of hours,
  silently collapsing `valid_time` onto `init_time`
- Antimeridian grids in `-180/180` crash `check_for_spatial_data`
- The peak metrics raise instead of returning NaN on a degenerate target axis
- `DurationMeanError` raises on a zero-length `valid_time` axis

The fixes are in #387, which targets this branch and turns all five xfails into
real assertions. Keeping them separate makes this PR just "do these properties
describe the intended behavior?".

Adds `hypothesis>=6.165.3` as a dev dependency. Already merged with current
`develop`, so the `uv.lock` diff is only hypothesis and its dependencies.

## Type of change

- [ ] Refactor
- [ ] Bug fix
- [ ] New feature
- [x] Chore

### If this PR is a breaking change, please explain:

Not breaking. The diff against `develop` is purely additive.

## How Has This Been Tested?

```bash
source .venv/bin/activate
uv run pytest -q --ignore=tests/test_golden.py
HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py -q
uv run pre-commit run --all-files
```

Full suite `1130 passed, 5 xfailed`, unchanged by the merge with `develop`. The
five xfails are the pinned repros above. The `ewb-sweep` profile runs each
property at 300 examples: `18 passed`. Pre-commit clean.

Made with [Cursor](https://cursor.com)