### PR TITLE
fix: reduce peak metrics per initialization instead of across them

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -747,8 +747,9 @@ def _ensure_output_schema(df: pd.DataFrame, **metadata) -> pd.DataFrame:
     # metric that assesses something in an entire model run, such as the onset error of
     # an event. Lead_time will be present for a metric that assesses something at a
     # specific forecast hour, such as RMSE. If neither are present, the output is
-    # invalid. Both should not be present for one metric. Thus, one should always be
-    # missing, which is intended behavior.
+    # invalid, so a metric supplying only one of them is intended behavior. Peak metrics
+    # supply both, because they reduce over a run and then report against the lead time
+    # at which that run verified against the target's extreme.
     init_time_missing = "init_time" in missing_cols
     lead_time_missing = "lead_time" in missing_cols
 

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1175,6 +1175,12 @@ class MaximumMeanAbsoluteError(MeanAbsoluteError):
     ) -> xr.DataArray:
         """Compute MaximumMeanAbsoluteError.
 
+        The forecast maximum is taken over each initialization's own lead times
+        inside the tolerance window, so every value compared to the target is a
+        genuine maximum over the forecast's diurnal cycle. Results are indexed
+        by the lead time of the target's maximum relative to each
+        initialization.
+
         Args:
             forecast: The forecast DataArray.
             target: The target DataArray.
@@ -1200,19 +1206,12 @@ class MaximumMeanAbsoluteError(MeanAbsoluteError):
         forecast_spatial_mean = utils.reduce_dataarray(
             forecast, method="mean", reduce_dims=reduce_spatial_dims, skipna=True
         )
-        filtered_max_forecast = forecast_spatial_mean.where(
-            (
-                forecast_spatial_mean.valid_time
-                >= maximum_timestep.data
-                - np.timedelta64(self.tolerance_range_hours // 2, "h")
-            )
-            & (
-                forecast_spatial_mean.valid_time
-                <= maximum_timestep.data
-                + np.timedelta64(self.tolerance_range_hours // 2, "h")
-            ),
-            drop=True,
-        ).max("valid_time")
+        filtered_max_forecast = utils.reduce_forecast_over_window_per_init(
+            forecast_spatial_mean,
+            center_time=maximum_timestep,
+            tolerance_range_hours=self.tolerance_range_hours,
+            method="max",
+        )
         return super()._compute_metric(
             forecast=filtered_max_forecast,
             target=maximum_value,
@@ -1262,6 +1261,10 @@ class MinimumMeanAbsoluteError(MeanAbsoluteError):
     ) -> Any:
         """Compute MinimumMeanAbsoluteError.
 
+        As with MaximumMeanAbsoluteError, the forecast minimum is taken over
+        each initialization's own lead times inside the tolerance window rather
+        than across initializations at fixed lead time.
+
         Args:
             forecast: The forecast DataArray.
             target: The target DataArray.
@@ -1285,19 +1288,12 @@ class MinimumMeanAbsoluteError(MeanAbsoluteError):
         minimum_timestep = utils.maybe_get_closest_timestamp_to_center_of_valid_times(
             minimum_timestep, target.valid_time
         )
-        filtered_min_forecast = forecast_spatial_mean.where(
-            (
-                forecast_spatial_mean.valid_time
-                >= minimum_timestep.data
-                - np.timedelta64(self.tolerance_range_hours // 2, "h")
-            )
-            & (
-                forecast_spatial_mean.valid_time
-                <= minimum_timestep.data
-                + np.timedelta64(self.tolerance_range_hours // 2, "h")
-            ),
-            drop=True,
-        ).min("valid_time")
+        filtered_min_forecast = utils.reduce_forecast_over_window_per_init(
+            forecast_spatial_mean,
+            center_time=minimum_timestep,
+            tolerance_range_hours=self.tolerance_range_hours,
+            method="min",
+        )
         return super()._compute_metric(
             forecast=filtered_min_forecast,
             target=minimum_value,
@@ -1343,6 +1339,12 @@ class MaximumLowestMeanAbsoluteError(MeanAbsoluteError):
     ) -> Any:
         """Compute MaximumLowestMeanAbsoluteError.
 
+        The target contributes the warmest of its daily minima. Each forecast
+        initialization contributes the lowest value it predicts inside the
+        tolerance window centered on that time, which spans one diurnal
+        minimum, so both sides answer the same question. An initialization is
+        only scored if it covers a full day inside the window.
+
         Args:
             forecast: The forecast DataArray.
             target: The target DataArray.
@@ -1381,32 +1383,18 @@ class MaximumLowestMeanAbsoluteError(MeanAbsoluteError):
                 max_min_target_datetime, target.valid_time
             )
         )
-        subset_forecast = (
-            forecast.where(
-                (
-                    forecast.valid_time
-                    >= (
-                        max_min_target_datetime.data
-                        - np.timedelta64(self.tolerance_range_hours // 2, "h")
-                    )
-                )
-                & (
-                    forecast.valid_time
-                    <= (
-                        max_min_target_datetime.data
-                        + np.timedelta64(self.tolerance_range_hours // 2, "h")
-                    )
-                ),
-                drop=True,
-            )
-            .groupby("valid_time.dayofyear")
-            .map(
-                utils.min_if_all_timesteps_present_forecast,
-                time_resolution_hours=utils.determine_temporal_resolution(forecast),
-            )
-            .min("dayofyear")
+        # Carry the time the target's warmest minimum occurred into the output,
+        # matching the other peak metrics.
+        max_min_target_value = max_min_target_value.assign_coords(
+            valid_time=np.asarray(max_min_target_datetime.values).reshape(-1)[0]
         )
-
+        subset_forecast = utils.reduce_forecast_over_window_per_init(
+            forecast,
+            center_time=max_min_target_datetime,
+            tolerance_range_hours=self.tolerance_range_hours,
+            method="min",
+            required_timesteps=utils.expected_timesteps_per_day(forecast),
+        )
         return super()._compute_metric(
             forecast=subset_forecast,
             target=max_min_target_value,

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1136,9 +1136,9 @@ class EarlySignal(BaseMetric):
 class MaximumMeanAbsoluteError(MeanAbsoluteError):
     """Compute MAE between forecast and target maximum values.
 
-    Extends MeanAbsoluteError to filter forecast to a time window around the
-    target's maximum using tolerance_range_hours. Useful for evaluating peak
-    value timing and magnitude.
+    For each initialization, the forecast maximum is taken over that
+    run's lead times inside tolerance_range_hours of the target's
+    maximum. Useful for evaluating peak value timing and magnitude.
     """
 
     def __init__(
@@ -1222,9 +1222,9 @@ class MaximumMeanAbsoluteError(MeanAbsoluteError):
 class MinimumMeanAbsoluteError(MeanAbsoluteError):
     """Compute MAE between forecast and target minimum values.
 
-    Extends MeanAbsoluteError to filter forecast to a time window around the
-    target's minimum using tolerance_range_hours. Useful for evaluating
-    minimum value timing and magnitude.
+    For each initialization, the forecast minimum is taken over that
+    run's lead times inside tolerance_range_hours of the target's
+    minimum. Useful for evaluating minimum value timing and magnitude.
     """
 
     def __init__(
@@ -1302,11 +1302,11 @@ class MinimumMeanAbsoluteError(MeanAbsoluteError):
 
 
 class MaximumLowestMeanAbsoluteError(MeanAbsoluteError):
-    """Compute MAE of maximum aggregated minimum values for heatwaves.
+    """Compute MAE of the warmest daily minimum for heatwaves.
 
-    Extends MeanAbsoluteError for heatwave evaluation by aggregating daily
-    minimum values and computing MAE between the warmest nighttime (daily
-    minimum) temperature in target and forecast.
+    The target contributes the warmest complete daily minimum. Each
+    forecast initialization contributes its lowest value inside the
+    tolerance window, scored only if that run covers a full day.
     """
 
     def __init__(

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -329,7 +329,8 @@ def expected_timesteps_per_day(forecast: xr.DataArray) -> int:
     Returns:
         The number of lead times spanning 24 hours, at least 1.
     """
-    steps = np.abs(np.diff(forecast.lead_time.values)) / np.timedelta64(1, "h")
+    lead_time = _lead_time_as_timedelta(forecast.lead_time)
+    steps = np.abs(np.diff(lead_time.values)) / np.timedelta64(1, "h")
     steps = steps[steps > 0]
     if steps.size == 0:
         return 1

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -273,20 +273,23 @@ def min_if_all_timesteps_present(
 ) -> xr.DataArray:
     """Return the minimum value of a DataArray if all timesteps of a day are present.
 
+    Counts values that are actually present rather than the length of the time
+    coordinate, so a day padded out with NaNs is correctly rejected as
+    incomplete.
+
     Args:
         da: The input DataArray.
+        time_resolution_hours: The spacing of the data in hours.
 
     Returns:
         The minimum value of the DataArray if all timesteps are present,
-        otherwise the original DataArray.
+        otherwise NaN.
     """
     timesteps_per_day = 24 / time_resolution_hours
-    # .size rather than .values.size: the element count is known from the
-    # shape, so asking for it should not pull a dask-backed day into memory.
-    if da.size == timesteps_per_day:
-        return da.min()
-    else:
-        return xr.DataArray(np.nan)
+    # Comparing lazily rather than in a Python `if` keeps a dask-backed day
+    # out of memory: nothing here is computed until the caller asks for it.
+    timesteps_present = da.notnull().sum()
+    return da.min().where(timesteps_present == timesteps_per_day)
 
 
 def min_if_all_timesteps_present_forecast(
@@ -295,23 +298,98 @@ def min_if_all_timesteps_present_forecast(
     """Return the minimum value of a DataArray if all timesteps of a day are present
     given a dataset with lead_time and valid_time dimensions.
 
+    The completeness check is made per lead time against the number of values
+    actually present. Checking the length of the valid_time coordinate instead
+    would pass for every lead time, because that coordinate is the union over
+    all lead times and is denser than any single lead time's sampling.
+
     Args:
         da: The input DataArray.
+        time_resolution_hours: The spacing of the data in hours.
 
     Returns:
-        The minimum value of the DataArray if all timesteps are present,
-        otherwise the original DataArray.
+        The minimum along valid_time for lead times holding a full day of
+        values, and NaN for the rest.
     """
     timesteps_per_day = 24 / time_resolution_hours
-    if da.valid_time.size == timesteps_per_day:
-        return da.min("valid_time")
-    else:
-        # Return an array with the same lead_time dimension but filled with NaNs
-        return xr.DataArray(
-            np.full(da.lead_time.size, np.nan),
-            coords={"lead_time": da.lead_time},
-            dims=["lead_time"],
-        )
+    timesteps_present = da.notnull().sum("valid_time")
+    return da.min("valid_time").where(timesteps_present == timesteps_per_day)
+
+
+def expected_timesteps_per_day(forecast: xr.DataArray) -> int:
+    """Number of forecast steps that make up one day at the lead_time spacing.
+
+    This is the per-init sampling rate, which is the meaningful one when asking
+    whether a single forecast run covers a full day. It is unrelated to the
+    spacing of the valid_time axis, which is the union over all lead times.
+
+    Args:
+        forecast: A forecast DataArray with a lead_time coordinate.
+
+    Returns:
+        The number of lead times spanning 24 hours, at least 1.
+    """
+    steps = np.abs(np.diff(forecast.lead_time.values)) / np.timedelta64(1, "h")
+    steps = steps[steps > 0]
+    if steps.size == 0:
+        return 1
+    return max(round(24 / steps.min()), 1)
+
+
+def reduce_forecast_over_window_per_init(
+    forecast: xr.DataArray,
+    center_time: Any,
+    tolerance_range_hours: int,
+    method: str = "max",
+    required_timesteps: int = 1,
+) -> xr.DataArray:
+    """Reduce a forecast over a time window separately for each initialization.
+
+    Peak metrics ask what extreme value a forecast predicted near the time the
+    target's extreme occurred. That is a reduction along a single run's
+    trajectory, so it must be taken over lead_time at fixed init_time. Reducing
+    over valid_time at fixed lead_time instead samples a different run at every
+    step, and when the initialization interval is wider than the window it
+    degenerates to a single instantaneous value whose time of day is set by
+    ``lead_time mod 24 h``.
+
+    The result is indexed by the lead time of the target's extreme relative to
+    each initialization, ``center_time - init_time``, and keeps init_time as a
+    coordinate so the provenance of each value survives into the output.
+
+    Args:
+        forecast: Forecast DataArray with lead_time and valid_time dimensions,
+            already reduced over any spatial dimensions.
+        center_time: The target time the window is centered on.
+        tolerance_range_hours: Full width of the window in hours.
+        method: The reduction to apply, e.g. "max" or "min".
+        required_timesteps: Minimum number of values an initialization must
+            contribute inside the window to be scored. Initializations with
+            fewer are dropped rather than scored on partial coverage.
+
+    Returns:
+        A DataArray with a lead_time dimension and an init_time coordinate.
+    """
+    half_window = np.timedelta64(tolerance_range_hours // 2, "h")
+    center = np.ravel(np.asarray(center_time))[0]
+
+    forecast_by_init = convert_valid_time_to_init_time(forecast)
+    windowed = forecast_by_init.where(
+        (forecast_by_init.valid_time >= center - half_window)
+        & (forecast_by_init.valid_time <= center + half_window)
+    )
+    windowed = windowed.where(
+        windowed.notnull().sum("lead_time") >= required_timesteps, drop=True
+    )
+
+    reduced = getattr(windowed, method)("lead_time")
+    reduced = reduced.assign_coords(
+        lead_time=("init_time", (center - reduced.init_time).data)
+    )
+    # A run launched after the target's extreme did not forecast it, and a
+    # negative lead time would be meaningless in the output.
+    reduced = reduced.where(reduced.lead_time >= np.timedelta64(0, "h"), drop=True)
+    return reduced.swap_dims({"init_time": "lead_time"}).sortby("lead_time")
 
 
 def determine_temporal_resolution(

--- a/tests/hypothesis_findings.md
+++ b/tests/hypothesis_findings.md
@@ -126,7 +126,32 @@ that module.
 - `test_maximum_mean_absolute_error_perfect_forecast_is_zero` is the suite's
   first value-level oracle. Everything before it asserted only absence-of-crash
   and output well-formedness, which is structurally blind to a wrong-but-finite
-  answer. See the open findings below for what it pins.
+  answer. See the peak-metric finding below for what it pins.
+
+## Resolved on `fix/peak-metrics`
+
+### The peak metrics aliased the diurnal cycle at coarse init cadences
+
+`MaximumMeanAbsoluteError` took a true maximum on the target side, but on the
+forecast side reduced over a `tolerance_range_hours` window pooled across
+initializations rather than per initialization. At a 72-hour cadence that window
+can hold a single forecast sample, so the "maximum" it compared against was
+whichever lone snapshot happened to land in the window. Because every init is
+00Z, that snapshot's time of day is fixed by `lead_time mod 24 h`, which aliased
+the diurnal cycle straight into the reported error.
+
+The consequence was that a forecast *identical to the target* did not score
+zero. With a target peaking at 283 K at 12Z and a perfect forecast sampled every
+6 hours from 72-hourly 00Z inits, the per-lead errors were 20 K at lead 0, 10 K
+at lead 6, 0 K at lead 12 where the sampling happens to align, then 10 K and
+20 K again. `MinimumMeanAbsoluteError` had the same construction.
+
+`fix/peak-metrics` reduces over `lead_time` at fixed `init_time`, so each
+initialization contributes its own trajectory through the window and the
+reported lead is `peak_time - init_time`.
+`test_maximum_mean_absolute_error_perfect_forecast_is_zero` was written here as
+an `xfail` naming that branch as the resolving change; it now passes and the
+marker is gone.
 
 ## Open findings, not fixed here
 
@@ -144,24 +169,6 @@ Found by cross-checking the rewritten `check_for_spatial_data` against
 of this form, and in every one the new check was right and `mask` was wrong.
 Left alone because `regions.py` was outside the scope of these fixes, but it is
 a real defect and it is now the looser of the two code paths.
-
-### The peak metrics alias the diurnal cycle at coarse init cadences
-
-`MaximumMeanAbsoluteError` takes a true maximum on the target side, but on the
-forecast side reduces over a `tolerance_range_hours` window pooled across
-initializations rather than per initialization. At a 72-hour cadence that window
-can hold a single forecast sample, so the "maximum" it compares against is
-whichever lone snapshot happens to land in the window. Because every init is
-00Z, that snapshot's time of day is fixed by `lead_time mod 24 h`, which aliases
-the diurnal cycle straight into the reported error.
-
-The consequence is that a forecast *identical to the target* does not score
-zero. With a target peaking at 283 K at 12Z and a perfect forecast sampled every
-6 hours from 72-hourly 00Z inits, the per-lead errors are 20 K at lead 0, 10 K
-at lead 6, 0 K at lead 12 where the sampling happens to align, then 10 K and
-20 K again. `test_maximum_mean_absolute_error_perfect_forecast_is_zero` pins
-this as an `xfail` naming `fix/peak-metrics`, which reduces per initialization,
-as the resolving change. `MinimumMeanAbsoluteError` has the same construction.
 
 ### `DurationMeanError` requires an `init_time` coordinate to exist
 
@@ -221,6 +228,10 @@ own; every failure that appeared came later, from removing the narrowings.
 
 `HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py`:
 `18 passed, 1 xfailed` at 300 examples each. `pre-commit run --all-files` clean.
+
+The numbers above are as of this branch. On `fix/peak-metrics`, which landed
+after it, the peak-metric oracle passes and its `xfail` is removed, leaving no
+`xfail` anywhere in the Hypothesis modules.
 
 Coverage widened as intended. `--hypothesis-show-statistics` reports 22 distinct
 rejection categories before the narrowings were removed and 8 after. The nine

--- a/tests/hypothesis_findings.md
+++ b/tests/hypothesis_findings.md
@@ -214,24 +214,23 @@ it for the empty case. Not filed as part of this work.
 
 ## Verification
 
-Full suite `1137 passed, 1 xfailed`
-(`uv run pytest -q --ignore=tests/test_golden.py`), against a base of
-`1130 passed, 5 xfailed`. All five original xfails became real assertions, two
-`check_for_spatial_data` tests were added for the prime-meridian shape, and the
-single remaining xfail is the new peak-metric oracle, which is waiting on
-`fix/peak-metrics`.
+On the parent of `fix/peak-metrics`, the full suite was `1137 passed, 1
+xfailed` (`uv run pytest -q --ignore=tests/test_golden.py`), against a
+base of `1130 passed, 5 xfailed`. All five original xfails became real
+assertions, two `check_for_spatial_data` tests were added for the
+prime-meridian shape, and the remaining xfail was the peak-metric
+oracle, resolved on this branch (see above). No `xfail` remains in the
+Hypothesis modules.
 
 Applying the coercion alone, before any fixture change, left the suite at
 `1130 passed, 5 xfailed`, unchanged. Nothing in the suite had encoded the
 nanosecond misreading as an expectation, so the fix had no blast radius of its
 own; every failure that appeared came later, from removing the narrowings.
 
-`HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py`:
-`18 passed, 1 xfailed` at 300 examples each. `pre-commit run --all-files` clean.
-
-The numbers above are as of this branch. On `fix/peak-metrics`, which landed
-after it, the peak-metric oracle passes and its `xfail` is removed, leaving no
-`xfail` anywhere in the Hypothesis modules.
+`HYPOTHESIS_PROFILE=ewb-sweep uv run pytest tests/test_hypothesis_fixtures.py`
+was `18 passed, 1 xfailed` at 300 examples each on the parent branch;
+the xfail was the same peak-metric oracle. `pre-commit run --all-files`
+clean.
 
 Coverage widened as intended. `--hypothesis-show-statistics` reports 22 distinct
 rejection categories before the narrowings were removed and 8 after. The nine

--- a/tests/test_hypothesis_fixtures.py
+++ b/tests/test_hypothesis_fixtures.py
@@ -283,13 +283,6 @@ def _diurnal_temperature(valid_times, peak_hour=12.0, base=273.0, amplitude=10.0
     return (base + amplitude * np.cos(phase)).reshape(shape)
 
 
-@pytest.mark.xfail(
-    reason="fix/peak-metrics: forecast side reduces the max across inits "
-    "over valid_time instead of per init_time, so with a 72h init cadence "
-    "the tolerance window can hold only one off-peak forecast sample, "
-    "aliasing a perfect forecast into a non-zero error",
-    strict=False,
-)
 def test_maximum_mean_absolute_error_perfect_forecast_is_zero():
     """A forecast identical to the target at every sampled time scores 0."""
     lat = np.array([10.0, 20.0])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -964,6 +964,204 @@ class TestMaximumLowestMeanAbsoluteError:
             assert isinstance(metric, metrics.MaximumLowestMeanAbsoluteError)
 
 
+def _sparse_init_cadence_case(
+    peak_hour_utc: int = 0,
+    init_freq: str = "72h",
+    damping_scale_hours: float = 400.0,
+):
+    """Build a forecast/target pair with a WP-MIP style init cadence.
+
+    Initializations are 00Z only and spaced ``init_freq`` apart, with 6-hourly
+    lead times out to 240 h. The signal is a pure diurnal cycle whose amplitude
+    decays with lead time, so the forecast's peak error grows monotonically
+    with lead time and nothing else does. Because the initializations are
+    sparse, any single lead time is populated only once per ``init_freq``,
+    which is what makes a reduction over valid_time at fixed lead time
+    degenerate to an instantaneous snapshot.
+
+    Args:
+        peak_hour_utc: UTC hour at which the diurnal cycle peaks.
+        init_freq: Spacing between initializations.
+        damping_scale_hours: e-folding scale of the amplitude decay.
+
+    Returns:
+        A (forecast, target) DataArray pair.
+    """
+    inits = pd.date_range("2020-06-01", "2020-06-13", freq=init_freq)
+    lead_times = pd.timedelta_range("0h", "240h", freq="6h")
+    valid_times = pd.date_range("2020-06-08", "2020-06-14", freq="6h")
+    latitudes = np.array([30.0, 31.0])
+    longitudes = np.array([260.0, 261.0])
+
+    def temperature(valid_time, lead_hours):
+        amplitude = 5.0 * np.exp(-lead_hours / damping_scale_hours)
+        phase = 2 * np.pi * (valid_time.hour - peak_hour_utc) / 24
+        return 300.0 + amplitude * np.cos(phase)
+
+    init_set = set(inits)
+    forecast_values = np.full(
+        (len(lead_times), len(valid_times), len(latitudes), len(longitudes)), np.nan
+    )
+    for i, lead_time in enumerate(lead_times):
+        for j, valid_time in enumerate(valid_times):
+            if (valid_time - lead_time) in init_set:
+                forecast_values[i, j] = temperature(
+                    valid_time, lead_time / pd.Timedelta("1h")
+                )
+
+    forecast = xr.DataArray(
+        forecast_values,
+        dims=["lead_time", "valid_time", "latitude", "longitude"],
+        coords={
+            "lead_time": lead_times,
+            "valid_time": valid_times,
+            "latitude": latitudes,
+            "longitude": longitudes,
+        },
+    )
+    target = xr.DataArray(
+        np.stack(
+            [
+                np.full((len(latitudes), len(longitudes)), temperature(v, 0.0))
+                for v in valid_times
+            ]
+        ),
+        dims=["valid_time", "latitude", "longitude"],
+        coords={
+            "valid_time": valid_times,
+            "latitude": latitudes,
+            "longitude": longitudes,
+        },
+    )
+    return forecast, target
+
+
+class TestPeakMetricsWithSparseInitCadence:
+    """Regression tests for peak metrics under a sparse initialization cadence.
+
+    These lock in the per-initialization reduction. Reducing over valid_time at
+    a fixed lead time instead returns a single instantaneous value whose time of
+    day is ``lead_time mod 24 h``, which makes the metric measure the diurnal
+    cycle rather than forecast error.
+    """
+
+    @pytest.mark.parametrize(
+        "metric_class",
+        [metrics.MaximumMeanAbsoluteError, metrics.MaximumLowestMeanAbsoluteError],
+    )
+    def test_error_grows_monotonically_with_lead_time(self, metric_class):
+        """A forecast that only damps with lead time must score worse with lead."""
+        forecast, target = _sparse_init_cadence_case()
+
+        result = metric_class()._compute_metric(forecast, target)
+
+        values = result.sortby("lead_time").values
+        assert len(values) >= 3
+        assert np.all(np.isfinite(values))
+        assert np.all(np.diff(values) > 0), (
+            f"{metric_class.__name__} is not monotonic in lead time: {values}"
+        )
+
+    @pytest.mark.parametrize(
+        "metric_class",
+        [metrics.MaximumMeanAbsoluteError, metrics.MaximumLowestMeanAbsoluteError],
+    )
+    def test_one_value_per_initialization_at_the_derived_lead_time(self, metric_class):
+        """Each init contributes once, at the lead time of the target's extreme."""
+        forecast, target = _sparse_init_cadence_case()
+
+        result = metric_class()._compute_metric(forecast, target)
+
+        assert "init_time" in result.coords
+        init_times = pd.to_datetime(result.init_time.values)
+        assert len(set(init_times)) == len(init_times)
+        # Every init is 00Z and spaced 72 h apart, so the derived lead times
+        # inherit that spacing exactly.
+        lead_hours = result.sortby("lead_time").lead_time / np.timedelta64(1, "h")
+        assert np.all(np.diff(lead_hours.values) == 72)
+        assert np.all(lead_hours.values >= 0)
+
+    def test_maximum_mae_uses_the_forecast_peak_not_a_snapshot(self):
+        """The compared value is each run's window maximum, not one lead's value."""
+        forecast, target = _sparse_init_cadence_case()
+        metric = metrics.MaximumMeanAbsoluteError()
+
+        result = metric._compute_metric(forecast, target)
+
+        target_peak = target.mean(["latitude", "longitude"]).max().item()
+        forecast_by_init = forecast.mean(["latitude", "longitude"])
+        for lead_time, init_time, error in zip(
+            result.lead_time.values, result.init_time.values, result.values
+        ):
+            run = forecast_by_init.where(
+                forecast_by_init.valid_time - forecast_by_init.lead_time == init_time,
+                drop=True,
+            )
+            peak_time = init_time + lead_time
+            window = run.where(
+                (run.valid_time >= peak_time - np.timedelta64(12, "h"))
+                & (run.valid_time <= peak_time + np.timedelta64(12, "h"))
+            )
+            expected = np.nanmax(window.values)
+            assert error == pytest.approx(abs(expected - target_peak), abs=1e-9)
+
+    @pytest.mark.parametrize("peak_hour_utc", [0, 6, 12, 18])
+    def test_maximum_lowest_mae_does_not_depend_on_time_of_day(self, peak_hour_utc):
+        """The metric must not silently drop cases whose peak falls at 00Z or 18Z.
+
+        The previous grouping by UTC calendar day only yielded a complete day
+        for certain peak hours, which filtered cases by longitude.
+        """
+        forecast, target = _sparse_init_cadence_case(peak_hour_utc=peak_hour_utc)
+
+        result = metrics.MaximumLowestMeanAbsoluteError()._compute_metric(
+            forecast, target
+        )
+
+        assert result.sizes["lead_time"] >= 3
+        assert np.all(np.isfinite(result.values))
+
+    def test_denser_init_cadence_yields_the_same_errors(self):
+        """Scores must depend on the forecast, not on how often it is launched."""
+        sparse_forecast, target = _sparse_init_cadence_case(init_freq="72h")
+        dense_forecast, _ = _sparse_init_cadence_case(init_freq="24h")
+        metric = metrics.MaximumMeanAbsoluteError()
+
+        sparse_result = metric._compute_metric(sparse_forecast, target)
+        dense_result = metric._compute_metric(dense_forecast, target)
+
+        shared = np.intersect1d(sparse_result.lead_time, dense_result.lead_time)
+        assert len(shared) >= 3
+        np.testing.assert_allclose(
+            sparse_result.sel(lead_time=shared).values,
+            dense_result.sel(lead_time=shared).values,
+        )
+
+    def test_no_qualifying_initialization_yields_an_empty_result(self):
+        """A case no run covers scores nothing rather than raising."""
+        forecast, target = _sparse_init_cadence_case()
+        # Only lead 0 is populated, so no run spans a full day of the window.
+        forecast = forecast.where(forecast.lead_time == np.timedelta64(0, "h"))
+
+        result = metrics.MaximumLowestMeanAbsoluteError()._compute_metric(
+            forecast, target
+        )
+
+        assert result.sizes["lead_time"] == 0
+        assert "init_time" in result.coords
+        assert len(result.to_dataframe(name="value").reset_index()) == 0
+
+    def test_initializations_after_the_target_extreme_are_dropped(self):
+        """A run launched after the peak did not forecast it."""
+        forecast, target = _sparse_init_cadence_case()
+
+        result = metrics.MaximumMeanAbsoluteError()._compute_metric(forecast, target)
+
+        peak_times = result.init_time.values + result.lead_time.values
+        assert len(set(peak_times)) == 1
+        assert np.all(result.init_time.values <= peak_times[0])
+
+
 class TestDurationMeanError:
     """Tests for the DurationMeanError metric.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -256,6 +256,14 @@ def test_expected_timesteps_per_day():
     assert utils.expected_timesteps_per_day(single) == 1
 
 
+def test_expected_timesteps_per_day_accepts_integer_hour_lead_times():
+    """Integer lead times mean hours, the convention used across the codebase."""
+    da = xr.DataArray(
+        np.zeros(9), dims=["lead_time"], coords={"lead_time": np.arange(0, 54, 6)}
+    )
+    assert utils.expected_timesteps_per_day(da) == 4
+
+
 def _sparse_init_forecast(init_freq="72h"):
     """Forecast on a (lead_time, valid_time) grid with 00Z-only inits."""
     inits = set(pd.date_range("2020-06-01", "2020-06-13", freq=init_freq))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -196,6 +196,151 @@ def test_min_if_all_timesteps_present_forecast():
     assert np.all(np.isnan(result_incomplete.values))
 
 
+def test_min_if_all_timesteps_present_rejects_nan_padded_day():
+    """A day padded out with NaNs is incomplete even if the coordinate is full."""
+    da = xr.DataArray([1.0, np.nan, np.nan, np.nan], dims=["time"])
+
+    result = utils.min_if_all_timesteps_present(da, 6)
+
+    assert np.isnan(result.values)
+
+
+def test_min_if_all_timesteps_present_forecast_counts_values_per_lead():
+    """Completeness is judged per lead time, not from the shared valid_time axis.
+
+    The valid_time coordinate is the union over all lead times, so it is denser
+    than any single lead time's sampling. Counting its length passes every lead
+    time through and lets a single sample masquerade as a daily minimum.
+    """
+    valid_times = pd.date_range("2020-01-01", periods=4, freq="6h")
+    values = np.full((3, 4), np.nan)
+    # One sample per lead time, at a different hour for each: exactly what a
+    # sparse initialization cadence produces on a union valid_time axis.
+    values[0, 0], values[1, 1], values[2, 2] = 5.0, 6.0, 7.0
+    da = xr.DataArray(
+        values,
+        dims=["lead_time", "valid_time"],
+        coords={"lead_time": [0, 6, 12], "valid_time": valid_times},
+    )
+
+    result = utils.min_if_all_timesteps_present_forecast(da, 6)
+
+    assert da.valid_time.size == 4
+    assert np.all(np.isnan(result.values))
+
+    complete = da.copy()
+    complete.values[0, :] = [5.0, 4.0, 3.0, 6.0]
+    result = utils.min_if_all_timesteps_present_forecast(complete, 6)
+    assert result.sel(lead_time=0).item() == 3.0
+    assert np.all(np.isnan(result.sel(lead_time=[6, 12]).values))
+
+
+def test_expected_timesteps_per_day():
+    """Timesteps per day come from the lead_time spacing, not valid_time."""
+    lead_times = pd.timedelta_range("0h", "48h", freq="6h")
+    da = xr.DataArray(
+        np.zeros(len(lead_times)), dims=["lead_time"], coords={"lead_time": lead_times}
+    )
+    assert utils.expected_timesteps_per_day(da) == 4
+
+    hourly = xr.DataArray(
+        np.zeros(3),
+        dims=["lead_time"],
+        coords={"lead_time": pd.timedelta_range("0h", "2h", freq="1h")},
+    )
+    assert utils.expected_timesteps_per_day(hourly) == 24
+
+    single = xr.DataArray(
+        [0.0], dims=["lead_time"], coords={"lead_time": [pd.Timedelta("0h")]}
+    )
+    assert utils.expected_timesteps_per_day(single) == 1
+
+
+def _sparse_init_forecast(init_freq="72h"):
+    """Forecast on a (lead_time, valid_time) grid with 00Z-only inits."""
+    inits = set(pd.date_range("2020-06-01", "2020-06-13", freq=init_freq))
+    lead_times = pd.timedelta_range("0h", "240h", freq="6h")
+    valid_times = pd.date_range("2020-06-08", "2020-06-14", freq="6h")
+
+    values = np.full((len(lead_times), len(valid_times)), np.nan)
+    for i, lead_time in enumerate(lead_times):
+        for j, valid_time in enumerate(valid_times):
+            if (valid_time - lead_time) in inits:
+                values[i, j] = valid_time.hour + lead_time / pd.Timedelta("1h") / 100
+
+    return xr.DataArray(
+        values,
+        dims=["lead_time", "valid_time"],
+        coords={"lead_time": lead_times, "valid_time": valid_times},
+    )
+
+
+def test_reduce_forecast_over_window_per_init_reduces_along_each_run():
+    """Each init contributes one value, reduced over its own lead times."""
+    forecast = _sparse_init_forecast()
+    center = np.datetime64("2020-06-11T00:00:00")
+
+    result = utils.reduce_forecast_over_window_per_init(forecast, center, 24, "max")
+
+    assert result.dims == ("lead_time",)
+    assert "init_time" in result.coords
+    # No lead time has more than one sample inside the window, so a reduction
+    # over valid_time would have had a single value to work with.
+    in_window = forecast.where(
+        (forecast.valid_time >= center - np.timedelta64(12, "h"))
+        & (forecast.valid_time <= center + np.timedelta64(12, "h"))
+    )
+    assert in_window.notnull().sum("valid_time").max().item() == 1
+    # The per-init reduction sees the whole diurnal cycle instead.
+    assert result.sizes["lead_time"] >= 3
+    init_times = pd.to_datetime(result.init_time.values)
+    assert all(t.hour == 0 for t in init_times)
+    lead_hours = result.lead_time / np.timedelta64(1, "h")
+    np.testing.assert_array_equal(
+        lead_hours.values, (center - result.init_time.values) / np.timedelta64(1, "h")
+    )
+
+
+def test_reduce_forecast_over_window_per_init_honors_required_timesteps():
+    """Initializations covering less than the requested window are dropped."""
+    forecast = _sparse_init_forecast()
+    center = np.datetime64("2020-06-11T00:00:00")
+
+    permissive = utils.reduce_forecast_over_window_per_init(
+        forecast, center, 24, "min", required_timesteps=1
+    )
+    strict = utils.reduce_forecast_over_window_per_init(
+        forecast, center, 24, "min", required_timesteps=99
+    )
+
+    assert permissive.sizes["lead_time"] > 0
+    assert strict.sizes["lead_time"] == 0
+    assert "init_time" in strict.coords
+
+
+def test_reduce_forecast_over_window_per_init_drops_negative_lead_times():
+    """Runs launched after the target time are not forecasts of it."""
+    forecast = _sparse_init_forecast(init_freq="24h")
+    center = np.datetime64("2020-06-08T00:00:00")
+
+    result = utils.reduce_forecast_over_window_per_init(forecast, center, 24, "max")
+
+    assert result.sizes["lead_time"] > 0
+    assert np.all(result.lead_time.values >= np.timedelta64(0, "h"))
+
+
+def test_reduce_forecast_over_window_per_init_outside_the_window():
+    """A window with no forecast coverage yields an empty, well-formed result."""
+    forecast = _sparse_init_forecast()
+
+    result = utils.reduce_forecast_over_window_per_init(
+        forecast, np.datetime64("2021-01-01T00:00:00"), 24, "max"
+    )
+
+    assert result.sizes["lead_time"] == 0
+    assert "init_time" in result.coords
+
+
 def test_determine_temporal_resolution():
     """Test determining time resolution in hours."""
     # Create dataset with 6-hourly resolution


### PR DESCRIPTION
## Summary
- Peak metrics (`MaximumMeanAbsoluteError`, `MinimumMeanAbsoluteError`, `MaximumLowestMeanAbsoluteError`) now reduce each forecast initialization over its own `lead_time` window instead of across different model runs at a fixed lead time.
- Completeness guards count present values rather than coordinate slots, so a single sample cannot stand in for a daily minimum.
- Integer-hour lead times are coerced in `expected_timesteps_per_day`, and the Hypothesis perfect-forecast xfail is retired now that a 72-hour 00Z-only perfect forecast scores zero.

## Test plan
- [x] Targeted pytest for per-init reduction, completeness guards, integer-hour lead times, and `test_maximum_mean_absolute_error_perfect_forecast_is_zero`
- [ ] Review the develop-only diff (two peak-metric commits plus the docstring alignment)