### PR TITLE
perf: avoid full-year climatology work in temperature metrics

### DIFF
--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1556,6 +1556,11 @@ class DurationMeanError(MeanError):
         if isinstance(threshold_criteria, xr.DataArray):
             # Climatology case, convert from dayofyear/hour to valid_time.
             # Note that unintended behavior may occur if the case spans multiple years.
+            days = np.intersect1d(
+                forecast.valid_time.dt.dayofyear, threshold_criteria.dayofyear
+            )
+            if days.size:
+                threshold_criteria = threshold_criteria.sel(dayofyear=days)
             threshold_criteria = utils.convert_day_yearofday_to_time(
                 threshold_criteria, forecast.valid_time.dt.year.values[0]
             )

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -784,19 +784,13 @@ def convert_day_yearofday_to_time(
     Returns:
         The dataset or dataarray with a new time coordinate.
     """
-    # Create a new time coordinate by combining dayofyear and hour
-    time_dim = pd.date_range(
-        start=f"{year}-01-01",
-        periods=len(dataset["dayofyear"]) * len(dataset["hour"]),
-        freq="6h",
+    stacked = dataset.stack(valid_time=("dayofyear", "hour"))
+    times = pd.to_datetime(
+        year * 1000 + stacked.dayofyear.values.astype(int), format="%Y%j"
+    ) + pd.to_timedelta(stacked.hour.values.astype(int), unit="h")
+    return stacked.reset_index("valid_time", drop=True).assign_coords(
+        valid_time=("valid_time", times)
     )
-    dataset = dataset.stack(valid_time=("dayofyear", "hour")).drop_vars(
-        ["dayofyear", "hour"]
-    )
-    # Assign the new time coordinate to the dataset
-    dataset = dataset.assign_coords(valid_time=time_dim)
-
-    return dataset
 
 
 def interp_climatology_to_target(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1193,6 +1193,15 @@ class TestConvertDayYearofDayToTime:
         # Should still be a DataArray
         assert isinstance(result, xr.DataArray)
 
+    def test_non_january_dayofyear(self):
+        """Times come from dayofyear and hour, not a Jan 1 date_range."""
+        ds = xr.Dataset(
+            {"temperature": (["dayofyear", "hour"], [[1.0], [2.0]])},
+            coords={"dayofyear": [171, 172], "hour": [0]},
+        )
+        result = utils.convert_day_yearofday_to_time(ds, year=2021)
+        assert result.valid_time.values[0] == np.datetime64("2021-06-20")
+        assert result.valid_time.values[1] == np.datetime64("2021-06-21")
 
     def test_dataarray_preserves_data_values(self):
         """Test that DataArray data values are preserved."""


### PR DESCRIPTION
## Summary
- `DurationMeanError` (heatwave and freeze) keeps only the case dayofyear slice of climatology before stacking to valid_time.
- `convert_day_yearofday_to_time` builds timestamps from actual dayofyear/hour instead of a January 1 date_range.

Stacks on #399. Merge #399 first; this then lands on `feat/xarray-results-output` with the rest of the stack.

## Test plan
- [x] `pytest tests/test_utils.py tests/test_metrics.py -k "DurationMeanError or convert_day"`


Made with [Cursor](https://cursor.com)