### PR TITLE
perf: label atmospheric rivers without a 4D connected-component scan

### DIFF
--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -450,34 +450,8 @@ class AtmosphericRiverVariables(DerivedVariable):
     def derive_variable(self, data: xr.Dataset, *args, **kwargs) -> xr.Dataset:
         """Derive the atmospheric river mask and land intersection."""
 
-        # Subset the data to the top pressure level
         data = data.sel(level=data.level[data.level >= self.top_pressure_level])
-
-        # Generate IVT
-        ivt_data = ar.integrated_vapor_transport(
-            specific_humidity=data["specific_humidity"],
-            eastward_wind=data["eastward_wind"],
-            northward_wind=data["northward_wind"],
-        )
-
-        # Compute IVT Laplacian
-        ivt_laplacian = ar.integrated_vapor_transport_laplacian(ivt=ivt_data, sigma=3)
-
-        # Compute AR mask with default parameters
-        ar_mask_result = ar.atmospheric_river_mask(
-            ivt=ivt_data, ivt_laplacian=ivt_laplacian
-        )
-
-        # Compute land intersection
-        land_intersection = calc.find_land_intersection(ar_mask_result)
-
-        return xr.Dataset(
-            {
-                "atmospheric_river_mask": ar_mask_result,
-                "atmospheric_river_land_intersection": land_intersection,
-                "integrated_vapor_transport": ivt_data,
-            }
-        )
+        return ar.build_atmospheric_river_mask_and_land_intersection(data)
 
 
 def maybe_derive_variables(

--- a/src/extremeweatherbench/events/atmospheric_river.py
+++ b/src/extremeweatherbench/events/atmospheric_river.py
@@ -1,8 +1,90 @@
+from collections.abc import Sequence
+
 import numpy as np
+import numpy.typing as npt
 import xarray as xr
 from scipy import ndimage
 
 from extremeweatherbench import calc
+
+
+def _label_time_linked_tyx(mask_tyx: npt.NDArray[np.bool_]) -> npt.NDArray[np.int32]:
+    """Label a (time, lat, lon) mask with 6-connectivity.
+
+    2D connected components plus union-find across consecutive times.
+    Matches ndimage.label with generate_binary_structure(3, 1).
+    """
+    n_t = mask_tyx.shape[0]
+    labeled = np.empty(mask_tyx.shape, dtype=np.int32)
+    n_feat = np.empty(n_t, dtype=np.int32)
+    for t in range(n_t):
+        labeled[t], n_feat[t] = ndimage.label(mask_tyx[t])
+    total = int(n_feat.sum())
+    if total == 0:
+        return labeled
+
+    glob = np.where(
+        labeled > 0, labeled + (np.cumsum(n_feat) - n_feat)[:, None, None], 0
+    ).astype(np.int32)
+    parent = np.arange(total + 1, dtype=np.int32)
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = int(parent[x])
+        return x
+
+    for t in range(n_t - 1):
+        both = (glob[t] > 0) & (glob[t + 1] > 0)
+        if not both.any():
+            continue
+        pairs = np.unique(np.stack((glob[t][both], glob[t + 1][both]), axis=1), axis=0)
+        for a, b in pairs:
+            ra, rb = find(int(a)), find(int(b))
+            if ra != rb:
+                parent[rb] = ra
+
+    remap = np.zeros(total + 1, dtype=np.int32)
+    n = 0
+    for i in range(1, total + 1):
+        root = find(i)
+        if remap[root] == 0:
+            n += 1
+            remap[root] = n
+        remap[i] = remap[root]
+    return remap[glob]
+
+
+def _label_objects_time_linked(
+    mask: npt.NDArray[np.bool_],
+    dims: Sequence[str],
+    time_dimension: str,
+) -> npt.NDArray[np.int32]:
+    """Label True pixels, linking through time but not across other dims."""
+    keep = {time_dimension, "latitude", "longitude"}
+    if not keep <= set(dims):
+        labeled, _ = ndimage.label(mask)
+        return np.asarray(labeled, dtype=np.int32)
+
+    order = (
+        [dims.index(time_dimension)]
+        + [i for i, name in enumerate(dims) if name not in keep]
+        + [dims.index("latitude"), dims.index("longitude")]
+    )
+    moved = np.transpose(mask, order)
+    n_t, *extra, n_y, n_x = moved.shape
+    n_extra = int(np.prod(extra, initial=1))
+    moved = moved.reshape(n_t, n_extra, n_y, n_x)
+    out = np.empty_like(moved, dtype=np.int32)
+    next_id = 1
+    for i in range(n_extra):
+        lab = _label_time_linked_tyx(moved[:, i])
+        n_lab = int(lab.max())
+        if n_lab:
+            lab = np.where(lab, lab + (next_id - 1), 0)
+            next_id += n_lab
+        out[:, i] = lab
+    return np.transpose(out.reshape(n_t, *extra, n_y, n_x), np.argsort(order))
 
 
 def atmospheric_river_mask(
@@ -66,8 +148,12 @@ def atmospheric_river_mask(
     # Combine conditions without tropical restriction initially
     initial_intersection = xr.where(dilated_laplacian & has_high_ivt, 1, 0)
 
-    # Label connected components and get their sizes
-    labeled_array, _ = ndimage.label(initial_intersection)
+    # Label 2D slices and merge across consecutive valid_time only.
+    labeled_array = _label_objects_time_linked(
+        np.asarray(initial_intersection, dtype=bool),
+        list(initial_intersection.dims),
+        time_dimension,
+    )
     unique_labels, label_counts = np.unique(labeled_array, return_counts=True)
 
     # Filter by size first (excluding background label 0)
@@ -82,11 +168,11 @@ def atmospheric_river_mask(
     lat_shape = [1] * labeled_array.ndim
     lat_shape[lat_axis] = len(latitudes)
     lat_grid = np.broadcast_to(latitudes.reshape(lat_shape), labeled_array.shape)
-    valid_labels = [
-        label
-        for label in size_valid_labels
-        if abs(lat_grid[labeled_array == label].mean()) > 15
-    ]
+    if size_valid_labels.size == 0:
+        valid_labels = size_valid_labels
+    else:
+        mean_lat = ndimage.mean(lat_grid, labels=labeled_array, index=size_valid_labels)
+        valid_labels = size_valid_labels[np.abs(mean_lat) > 15]
 
     # Create final mask using valid features
     feature_mask = np.isin(labeled_array, valid_labels)

--- a/tests/test_atmospheric_river.py
+++ b/tests/test_atmospheric_river.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from scipy import ndimage
 
 from extremeweatherbench import calc
 from extremeweatherbench.events import atmospheric_river
@@ -1009,3 +1010,52 @@ class TestBuildMaskAndLandIntersection:
 
         # Values should be 0 or 1 (boolean mask)
         assert set(ar_mask.values.flatten()).issubset({0, 1})
+
+
+def _assert_same_cc_partition(a: np.ndarray, b: np.ndarray) -> None:
+    """True pixels must form the same connected components in a and b."""
+    a, b = np.asarray(a), np.asarray(b)
+    np.testing.assert_array_equal(a > 0, b > 0)
+    for lab in np.unique(a[a > 0]):
+        assert len(np.unique(b[a == lab])) == 1
+    for lab in np.unique(b[b > 0]):
+        assert len(np.unique(a[b == lab])) == 1
+
+
+class TestTimeLinkedLabeling:
+    """Tests for 2D labels plus union-find across valid_time."""
+
+    def test_3d_matches_ndimage_label_partition(self):
+        """3D (valid_time, lat, lon) matches scipy 6-connectivity labeling."""
+        rng_local = np.random.default_rng(0)
+        mask = rng_local.random((8, 12, 10)) > 0.65
+        mask[2:6, 4, 5] = True
+        expected, _ = ndimage.label(mask)
+        got = atmospheric_river._label_objects_time_linked(
+            mask, ["valid_time", "latitude", "longitude"], "valid_time"
+        )
+        _assert_same_cc_partition(expected, got)
+
+    def test_init_time_does_not_merge_across_inits(self):
+        """Objects at the same lat/lon in adjacent inits stay separate."""
+        mask = np.zeros((2, 3, 5, 5), dtype=bool)
+        mask[:, 0, 2, 2] = True
+        mask[:, 0, 2, 3] = True
+        labeled = atmospheric_river._label_objects_time_linked(
+            mask,
+            ["init_time", "valid_time", "latitude", "longitude"],
+            "valid_time",
+        )
+        labs0 = set(np.unique(labeled[0][labeled[0] > 0]))
+        labs1 = set(np.unique(labeled[1][labeled[1] > 0]))
+        assert labs0 and labs1
+        assert labs0.isdisjoint(labs1)
+
+    def test_time_adjacent_pixels_are_linked(self):
+        """The same grid cell at consecutive times is one object."""
+        mask = np.zeros((4, 3, 3), dtype=bool)
+        mask[:, 1, 1] = True
+        labeled = atmospheric_river._label_objects_time_linked(
+            mask, ["valid_time", "latitude", "longitude"], "valid_time"
+        )
+        assert len(np.unique(labeled[labeled > 0])) == 1


### PR DESCRIPTION
## Summary
- Replace `ndimage.label` over 4D with 2D labels plus union-find across consecutive `valid_time` (6-connectivity). Extra dims (`init_time`, `lead_time`) stay isolated.
- Tropical filter uses `|mean(lat)| > 15`. Size and tropical filters are otherwise unchanged.
- `AtmosphericRiverVariables` now calls `build_atmospheric_river_mask_and_land_intersection`.

Stacks on #399. Merge #399 first; this then lands on `feat/xarray-results-output` with the rest of the stack.

## Test plan
- [ ] `pytest tests/test_atmospheric_river.py`


Made with [Cursor](https://cursor.com)