### PR TITLE
perf: vectorize tropical cyclone spatial masks

### DIFF
--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -71,12 +71,6 @@ def preprocess_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def _geopotential_thickness(ds: xr.Dataset) -> xr.DataArray:
-    """300-500 hPa thickness in meters from geopotential or z."""
-    z = ds["geopotential"] if "geopotential" in ds else ds["z"]
-    return calc.geopotential_thickness(z, top_level=300, bottom_level=500) / 9.81
-
-
 def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """A preprocess function for CIRA icechunk data that includes geopotential thickness
     calculation required for tropical cyclone tracks.
@@ -87,7 +81,10 @@ def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The forecast dataset with geopotential thickness.
     """
-    ds["geopotential_thickness"] = _geopotential_thickness(ds)
+    ds["geopotential_thickness"] = (
+        calc.geopotential_thickness(ds["geopotential"], top_level=300, bottom_level=500)
+        / 9.81
+    )
     return ds
 
 
@@ -174,7 +171,10 @@ def preprocess_cira_kerchunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
         The renamed forecast dataset.
     """
     ds = _set_cira_kerchunk_lead_time(ds)
-    ds["geopotential_thickness"] = _geopotential_thickness(ds)
+    ds["geopotential_thickness"] = (
+        calc.geopotential_thickness(ds["geopotential"], top_level=300, bottom_level=500)
+        / 9.81
+    )
     return ds
 
 

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -71,6 +71,12 @@ def preprocess_heatwave_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
+def _geopotential_thickness(ds: xr.Dataset) -> xr.DataArray:
+    """300-500 hPa thickness in meters from geopotential or z."""
+    z = ds["geopotential"] if "geopotential" in ds else ds["z"]
+    return calc.geopotential_thickness(z, top_level=300, bottom_level=500) / 9.81
+
+
 def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """A preprocess function for CIRA icechunk data that includes geopotential thickness
     calculation required for tropical cyclone tracks.
@@ -81,10 +87,7 @@ def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The forecast dataset with geopotential thickness.
     """
-    # Calculate the geopotential thickness required for tropical cyclone tracks
-    ds["geopotential_thickness"] = (
-        calc.geopotential_thickness(ds["z"], top_level=300, bottom_level=500) / 9.81
-    )
+    ds["geopotential_thickness"] = _geopotential_thickness(ds)
     return ds
 
 
@@ -171,9 +174,7 @@ def preprocess_cira_kerchunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
         The renamed forecast dataset.
     """
     ds = _set_cira_kerchunk_lead_time(ds)
-    ds["geopotential_thickness"] = (
-        calc.geopotential_thickness(ds["z"], top_level=300, bottom_level=500) / 9.81
-    )
+    ds["geopotential_thickness"] = _geopotential_thickness(ds)
     return ds
 
 

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -926,28 +926,25 @@ def _create_spatial_mask(
         Spatial mask as a boolean array
     """
 
-    # Create meshgrid of all lat/lon coordinates
     lat_grid, lon_grid = np.meshgrid(lat_coords, lon_coords, indexing="ij")
+    if nearby_tc_track_data.empty:
+        return np.zeros_like(lat_grid, dtype=bool)
 
-    # Initialize mask
+    tc_lats = nearby_tc_track_data["latitude"].to_numpy(dtype=float)
+    tc_lons = nearby_tc_track_data["longitude"].to_numpy(dtype=float)
     spatial_mask = np.zeros_like(lat_grid, dtype=bool)
-
-    # For each tropical cyclone track data point, compute distances to all grid points
-    # vectorized
-    for _, tc_track_data_row in nearby_tc_track_data.iterrows():
-        tc_track_data_lat = tc_track_data_row["latitude"]
-        tc_track_data_lon = tc_track_data_row["longitude"]
-
-        # Vectorized distance calculation
+    # Chunk track points so (n_tracks, nlat, nlon) stays bounded.
+    for start in range(0, len(tc_lats), 32):
+        stop = start + 32
         distances = calc.haversine_distance(
-            [lat_grid, lon_grid],
-            [tc_track_data_lat, tc_track_data_lon],
+            [lat_grid[np.newaxis], lon_grid[np.newaxis]],
+            [
+                tc_lats[start:stop, np.newaxis, np.newaxis],
+                tc_lons[start:stop, np.newaxis, np.newaxis],
+            ],
             units="degrees",
         )
-
-        # Update mask where distance is within threshold
-        spatial_mask |= distances <= max_distance_degrees
-
+        spatial_mask |= np.any(distances <= max_distance_degrees, axis=0)
     return spatial_mask
 
 

--- a/tests/test_tropical_cyclone.py
+++ b/tests/test_tropical_cyclone.py
@@ -16,7 +16,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from extremeweatherbench import derived
+from extremeweatherbench import calc, derived
 from extremeweatherbench.events import tropical_cyclone
 
 
@@ -296,6 +296,17 @@ class TestUtilityFunctions:
         assert isinstance(mask, np.ndarray)
         assert mask.shape == (3, 3)  # lat x lon
         assert mask.dtype == bool
+
+        lat_grid, lon_grid = np.meshgrid(lat_coords, lon_coords, indexing="ij")
+        expected = np.zeros_like(lat_grid, dtype=bool)
+        for _, row in nearby_ibtracs.iterrows():
+            distances = calc.haversine_distance(
+                [lat_grid, lon_grid],
+                [row["latitude"], row["longitude"]],
+                units="degrees",
+            )
+            expected |= distances <= max_distance
+        np.testing.assert_array_equal(mask, expected)
 
 
 class TestDimensionHandling:


### PR DESCRIPTION
## Summary
- Build the TC spatial mask with a chunked haversine grid instead of a Python loop over IBTrACS points.
- CIRA TC preprocess accepts `geopotential` or `z` so thickness still exists after the pipeline reorder in #399.

Stacks on #399. Merge #399 first; this then lands on `feat/xarray-results-output` with the rest of the stack.

## Test plan
- [ ] `pytest tests/test_tropical_cyclone.py tests/test_defaults.py`


Made with [Cursor](https://cursor.com)