### PR TITLE
perf: push LSR case times into parquet reads

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1209,7 +1209,10 @@ def run_pipeline(
     # Gridded: map names, subset case, preprocess, then subset variables so
     # preprocess can add fields such as geopotential thickness. Tabular
     # sources such as IBTrACS need original column names inside preprocess.
-    data = input_data._open_data_from_source()
+    if isinstance(input_data, inputs.LSR):
+        data = input_data._open_data_from_source(case_metadata=case_metadata)
+    else:
+        data = input_data._open_data_from_source()
     is_gridded = isinstance(data, (xr.Dataset, xr.DataArray))
     if not is_gridded:
         data = input_data.preprocess(data)

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -719,11 +719,23 @@ class LSR(TargetBase):
         default_factory=lambda: ["report_type"]
     )
 
-    def _open_data_from_source(self) -> IncomingDataInput:
+    def _open_data_from_source(
+        self, case_metadata: Optional["cases.IndividualCase"] = None
+    ) -> IncomingDataInput:
         # force LSR to use anon token to prevent google reauth issues for users
-        target_data = pd.read_parquet(self.source, storage_options=self.storage_options)
-
-        return target_data
+        kwargs: dict[str, Any] = {"storage_options": self.storage_options}
+        if case_metadata is not None:
+            kwargs["filters"] = [
+                ("valid_time", ">=", pd.Timestamp(case_metadata.start_date)),
+                ("valid_time", "<=", pd.Timestamp(case_metadata.end_date)),
+            ]
+        try:
+            return pd.read_parquet(self.source, **kwargs)
+        except Exception as exc:
+            if "filters" not in kwargs:
+                raise
+            logger.debug("LSR parquet filters failed (%s); reading full file", exc)
+            return pd.read_parquet(self.source, storage_options=self.storage_options)
 
     def subset_data_to_case(
         self,

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1553,6 +1553,28 @@ class TestLSR:
         mock_read_parquet.assert_called_once_with("test.parquet", storage_options={})
         assert result.equals(sample_lsr_dataframe)
 
+    @mock.patch("pandas.read_parquet")
+    def test_lsr_open_data_from_source_with_time_filters(
+        self, mock_read_parquet, sample_lsr_dataframe
+    ):
+        """Case metadata should be pushed into the parquet read as filters."""
+        mock_read_parquet.return_value = sample_lsr_dataframe
+        mock_case = mock.Mock()
+        mock_case.start_date = pd.Timestamp("2021-06-20")
+        mock_case.end_date = pd.Timestamp("2021-06-21")
+        lsr = inputs.LSR(
+            source="test.parquet",
+            variables=["report"],
+            variable_mapping={},
+            storage_options={},
+        )
+        lsr._open_data_from_source(case_metadata=mock_case)
+        kwargs = mock_read_parquet.call_args.kwargs
+        assert kwargs["storage_options"] == {}
+        assert kwargs["filters"] == [
+            ("valid_time", ">=", pd.Timestamp("2021-06-20")),
+            ("valid_time", "<=", pd.Timestamp("2021-06-21")),
+        ]
 
     def test_lsr_subset_data_to_case(self, sample_lsr_dataframe):
         """Test LSR subset_data_to_case."""


### PR DESCRIPTION
## Summary
- Pass case start/end into `LSR._open_data_from_source` as parquet `valid_time` filters.
- Fall back to reading the full file if the store rejects filters.

Stacks on #399. Merge #399 first; this then lands on `feat/xarray-results-output` with the rest of the stack.

## Test plan
- [ ] `pytest tests/test_inputs.py -k lsr`


Made with [Cursor](https://cursor.com)