### PR TITLE
feat(evaluate): add optional xarray evaluation results output

### DIFF
--- a/docs/events/case_studies.md
+++ b/docs/events/case_studies.md
@@ -1,6 +1,6 @@
 # Case Studies
 
-EWB includes 337 curated cases spanning five extreme weather categories, covering
+EWB includes 329 curated cases spanning five extreme weather categories, covering
 events worldwide from 2020 to 2024. Each category page describes how cases were
 selected, the bounding box methodology, and the source for each individual event.
 

--- a/docs/recipes/multi_model_evaluation.md
+++ b/docs/recipes/multi_model_evaluation.md
@@ -137,8 +137,8 @@ outputs = runner.run_evaluation(parallel_config=parallel_config)
 ```
 
 > **Detailed Explanation**: Each `(case, EvaluationObject)` pair becomes
-> a `CaseOperator` that EWB can execute in parallel. With four models and
-> 337 cases you have up to 1 348 operators. Memory scales with `n_jobs`
+> a `CaseOperator` that EWB can execute in parallel. Case counts live in
+> [Case Studies](../events/case_studies.md). Memory scales with `n_jobs`
 > since each worker holds its own copy of the forecast slice for the
 > active case. Set `n_jobs` to the number of CPU cores available and
 > adjust downward if you run out of memory. On a cloud VM with a fast

--- a/docs/recipes/one_forecast_two_targets.md
+++ b/docs/recipes/one_forecast_two_targets.md
@@ -79,10 +79,11 @@ ghcn_results = outputs[outputs["target_source"] == "GHCN"]
 ```
 
 > **Detailed Explanation**: Each `EvaluationObject` expands into one
-> `CaseOperator` per case. With two `EvaluationObjects` and 337 cases
-> you get 674 operators; they share the forecast source, so IO is not
-> doubled. However, GHCN and ERA5 alignment happens independently for
-> each target — GHCN uses nearest-neighbour interpolation to match
+> `CaseOperator` per case. Two `EvaluationObjects` share the forecast
+> source, so IO is not doubled. Case counts live in
+> [Case Studies](../events/case_studies.md). GHCN and ERA5 alignment
+> happens independently for each target — GHCN uses nearest-neighbour
+> interpolation to match
 > station locations, while ERA5 uses spatial regridding to the forecast
 > grid. The `target_source` column is set from the `name` attribute on
 > the target object.

--- a/docs/recipes/single_case.md
+++ b/docs/recipes/single_case.md
@@ -1,6 +1,6 @@
 # Single Case
 
-Running EWB across all 337 default cases is the standard workflow, but
+Running EWB across all default cases is the standard workflow, but
 sometimes you only need to evaluate one specific event — to debug a
 result, inspect a forecast failure, or prototype a new metric. This
 recipe shows two approaches: filtering from the default case list, and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,9 +4,10 @@
 
 There are two main ways to use ExtremeWeatherBench, by script or by command line.
 
-To run the Brightband-based evaluation on an existing AIWP model (FCN v2), which 
-includes the default 337 cases for heat waves, freezes, severe convection, 
-tropical cyclones, and atmospheric rivers:
+To run the Brightband-based evaluation on an existing AIWP model (FCN v2), which
+includes the default cases for heat waves, freezes, severe convection,
+tropical cyclones, and atmospheric rivers (see
+[Case Studies](events/case_studies.md)):
 
 
 ```python
@@ -66,6 +67,11 @@ ewb.cases.load_cases()
 # Defaults (pre-built targets, forecasts, and helpers)
 ewb.defaults.era5_heatwave_target
 ewb.defaults.get_climatology(quantile=0.85)
+
+# Outputs (optional xarray Dataset helpers; pandas remains the default)
+ewb.outputs.results_to_dataset(...)
+ewb.outputs.write_results(...)
+ewb.outputs.drop_empty_slices(...)
 ```
 ## Running an Evaluation for a Single Event Type
 
@@ -207,7 +213,7 @@ Dimensions:                  (lead_time: 4, init_time: 3, metric: 2,
                               forecast_source: 1, target_source: 1,
                               case_id_number: 1)
 Coordinates:
-  * lead_time                (lead_time) float64 32B 0.0 6.0 12.0 nan
+  * lead_time                (lead_time) timedelta64[ns] 32B 00:00:00 ... NaT
   * init_time                (init_time) datetime64[ns] 24B 2021-06-25 ... NaT
   * metric                   (metric) <U20 160B 'OnsetError' 'RootMeanSquared...
   * forecast_source          (forecast_source) <U11 44B 'my_forecast'
@@ -251,7 +257,7 @@ array([[       nan,        nan,        nan,        nan],
        [0.41520745, 0.48798442, 0.4550809 ,        nan]])
 Coordinates:
   * init_time        (init_time) datetime64[ns] 24B 2021-06-25 2021-06-26 NaT
-  * lead_time        (lead_time) float64 32B 0.0 6.0 12.0 nan
+  * lead_time        (lead_time) timedelta64[ns] 32B 00:00:00 06:00:00 ... NaT
     ...
 ```
 
@@ -261,15 +267,13 @@ entirely missing, then drops any dimension left with only a single
 placeholder label remaining.
 
 ```python
-from extremeweatherbench import outputs as ewb_outputs
-
-ewb_outputs.drop_empty_slices(rmse)
+ewb.outputs.drop_empty_slices(rmse)
 ```
 ```
 <xarray.DataArray 'surface_air_temperature' (lead_time: 3)> Size: 24B
 array([0.41520745, 0.48798442, 0.4550809 ])
 Coordinates:
-  * lead_time        (lead_time) float64 24B 0.0 6.0 12.0
+  * lead_time        (lead_time) timedelta64[ns] 24B 00:00:00 06:00:00 12:00:00
     ...
 ```
 
@@ -323,10 +327,8 @@ to `"netcdf"` or `"zarr"`; `"csv"` needs the raw results list or a
 DataFrame instead, since a flat cube doesn't round-trip to CSV:
 
 ```python
-from extremeweatherbench import outputs as ewb_outputs
-
-ewb_outputs.write_results(outputs, "results.nc", output_format="netcdf")
-ewb_outputs.write_results(outputs, "results.zarr", output_format="zarr")
+ewb.outputs.write_results(outputs, "results.nc", output_format="netcdf")
+ewb.outputs.write_results(outputs, "results.zarr", output_format="zarr")
 ```
 
 The CLI exposes the same choices with `--output-format {csv,netcdf,zarr}`
@@ -346,7 +348,7 @@ import extremeweatherbench as ewb
 
 ewb.inputs.ERA5(...)
 
-from extremeweatherbench import inputs, metrics, cases, evaluate
+from extremeweatherbench import inputs, metrics, cases, evaluate, outputs
 from extremeweatherbench.inputs import ERA5
 from extremeweatherbench.evaluate import ExtremeWeatherBench
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -181,6 +181,162 @@ Running locally is feasible but is typically bottlenecked heavily by IO and netw
 
 The outputs are returned as a pandas DataFrame and can be manipulated in the script, a notebook, etc.
 
+## Xarray Output
+
+`run_evaluation()` defaults to the long-form pandas DataFrame shown above
+(`output_format="pandas"`). Pass `output_format="xarray"` instead to get an
+`xarray.Dataset` with the same information, unflattened:
+
+```python
+outputs = runner.run_evaluation(output_format="xarray")
+```
+
+The Dataset has one dimension per metadata field (`case_id_number`,
+`metric`, `forecast_source`, `target_source`), plus whatever dimensions
+the metrics themselves preserved (`lead_time`, `init_time`, and/or
+spatial dims such as `latitude`, `longitude`, `level`). There is one
+data variable per forecast/target variable pair, named after the
+variable if the forecast and target names match, or
+`f"{forecast_variable}_vs_{target_variable}"` otherwise. `event_type`
+rides along as a non-dim coordinate on `case_id_number` rather than a
+dimension of its own:
+
+```
+<xarray.Dataset> Size: 532B
+Dimensions:                  (lead_time: 4, init_time: 3, metric: 2,
+                              forecast_source: 1, target_source: 1,
+                              case_id_number: 1)
+Coordinates:
+  * lead_time                (lead_time) float64 32B 0.0 6.0 12.0 nan
+  * init_time                (init_time) datetime64[ns] 24B 2021-06-25 ... NaT
+  * metric                   (metric) <U20 160B 'OnsetError' 'RootMeanSquared...
+  * forecast_source          (forecast_source) <U11 44B 'my_forecast'
+  * target_source            (target_source) <U9 36B 'my_target'
+  * case_id_number           (case_id_number) int64 8B 1
+    event_type               (case_id_number) <U9 36B ...
+Data variables:
+    surface_air_temperature  (case_id_number, metric, forecast_source, target_source, init_time, lead_time) float64 ...
+```
+
+### Placeholder labels
+
+Metrics reduce to different dimensions: an RMSE-like metric preserves
+`lead_time`, while a metric like onset or duration error preserves
+`init_time` instead. A flat cube needs a slot for both, so
+`results_to_dataset` pads whichever dimension a given metric's result
+lacks with a single out-of-band placeholder label (`NaT` for
+datetime/timedelta dimensions, `NaN` otherwise). That's why the
+`lead_time` and `init_time` coordinates above each carry one extra,
+otherwise-unused label: it's where results lacking that dimension get
+parked. Peak metrics (e.g. `MaximumMeanAbsoluteError`) are the
+exception: they reduce over a run but report against the lead time at
+which it verified, so their values genuinely occupy both `init_time`
+and `lead_time` rather than needing either one padded. The values are
+correct, and this mirrors the CSV, where an RMSE row already has an
+empty `init_time` column, but selecting a single metric leaves that
+placeholder label behind as an awkward extra row:
+
+```python
+rmse = outputs["surface_air_temperature"].sel(
+    metric="RootMeanSquaredError",
+    forecast_source="my_forecast",
+    target_source="my_target",
+    case_id_number=1,
+)
+```
+```
+<xarray.DataArray 'surface_air_temperature' (init_time: 3, lead_time: 4)> Size: 96B
+array([[       nan,        nan,        nan,        nan],
+       [       nan,        nan,        nan,        nan],
+       [0.41520745, 0.48798442, 0.4550809 ,        nan]])
+Coordinates:
+  * init_time        (init_time) datetime64[ns] 24B 2021-06-25 2021-06-26 NaT
+  * lead_time        (lead_time) float64 32B 0.0 6.0 12.0 nan
+    ...
+```
+
+Use `drop_empty_slices` to collapse it back down to the clean series
+you'd expect: it drops every label along a dimension where the data is
+entirely missing, then drops any dimension left with only a single
+placeholder label remaining.
+
+```python
+from extremeweatherbench import outputs as ewb_outputs
+
+ewb_outputs.drop_empty_slices(rmse)
+```
+```
+<xarray.DataArray 'surface_air_temperature' (lead_time: 3)> Size: 24B
+array([0.41520745, 0.48798442, 0.4550809 ])
+Coordinates:
+  * lead_time        (lead_time) float64 24B 0.0 6.0 12.0
+    ...
+```
+
+`drop_empty_slices` is meant to be used after selecting down to a
+single metric (and typically a single case); on the full, unselected
+Dataset every dimension mixes real and placeholder labels, so nothing
+is entirely missing and it is close to a no-op.
+
+### `sparse=True`
+
+For unaggregated spatial results (e.g. a metric that preserves
+`latitude`/`longitude` per case), the dense, padded hypercube can
+become unmanageably large: every case ends up padding out to the union
+of every other case's spatial grid. Pass `sparse=True` to back the
+Dataset's floating-point and datetime/timedelta data variables with
+`sparse.COO` arrays instead of densifying them:
+
+```python
+outputs = runner.run_evaluation(output_format="xarray", sparse=True)
+```
+
+This also covers a run whose metrics preserve different dimensions on
+the same variable (e.g. `RootMeanSquaredError`'s `lead_time` alongside
+`DurationMeanError`'s `init_time`): `results_to_dataset` builds each
+sparse data variable directly, without materializing the padded
+hypercube or routing `sparse.COO` arrays through `xr.merge`.
+
+Data variables that aren't floating-point, datetime64, or timedelta64
+can't be given a well-defined `sparse.COO` fill value, so they stay
+densely backed even under `sparse=True`. In practice this only
+matters for non-dim coords promoted to data variables by metrics like
+landfall displacement: `forecast_landfall_latitude`/`_longitude`/
+`_valid_time` and the `target_landfall_*` equivalents are float or
+datetime64 and do sparsify (with a `NaN`/`NaT` fill, respectively);
+anything with an incompatible dtype would not.
+
+`results_to_dataset` also logs a warning (without requiring
+`sparse=True`) when the estimated dense element count for a run passes
+a threshold, as a hint to reach for it. The limitations: `sparse.COO`
+isn't a netCDF/zarr-representable format, so writing a sparse Dataset
+to disk densifies it first (`sparse=True` only helps while the Dataset
+stays in memory), and `drop_empty_slices` can't operate directly on
+`sparse.COO`-backed input -- densify a selection first, e.g. with
+`utils.maybe_densify_dataarray`, before calling it.
+
+### Saving results
+
+`write_results` writes a list of annotated results, or an
+already-converted DataFrame/Dataset, to disk. A Dataset can be written
+to `"netcdf"` or `"zarr"`; `"csv"` needs the raw results list or a
+DataFrame instead, since a flat cube doesn't round-trip to CSV:
+
+```python
+from extremeweatherbench import outputs as ewb_outputs
+
+ewb_outputs.write_results(outputs, "results.nc", output_format="netcdf")
+ewb_outputs.write_results(outputs, "results.zarr", output_format="zarr")
+```
+
+The CLI exposes the same choices with `--output-format {csv,netcdf,zarr}`
+(default `csv`) and `--sparse` (valid only alongside `--output-format
+netcdf` or `zarr`):
+
+```bash
+ewb --default --output-format zarr --sparse
+```
+
 ## Import Patterns
 
 All of the following import styles work:

--- a/src/extremeweatherbench/__init__.py
+++ b/src/extremeweatherbench/__init__.py
@@ -25,6 +25,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
         "evaluate",
         "inputs",
         "metrics",
+        "outputs",
         "progress",
         "regions",
         "utils",

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -4,12 +4,10 @@ from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
-import regionmask
 import shapely
 import xarray as xr
 from numba import float64, guvectorize
 from scipy import ndimage
-from scores import categorical
 from skimage import filters
 
 from extremeweatherbench import utils

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -385,15 +385,11 @@ def find_land_intersection(
         a mask of points where AR overlaps with land
     """
     if land_mask is None:
-        land_mask = regionmask.defined_regions.natural_earth_v5_0_0.land_110.mask(
-            mask.longitude, mask.latitude
-        )
+        land_mask = utils.regionmask_land_110(mask.latitude, mask.longitude)
         land_mask = land_mask.where(np.isnan(land_mask), 1).where(land_mask == 0, 0)
 
-    # Use the scores.categorical library to compute the binary mask (true positives)
-    contingency_manager = categorical.BinaryContingencyManager(mask, land_mask)
-    # return the true positive mask, where mask is true and land is true
-    return contingency_manager.tp
+    overlap = mask.astype(bool) & land_mask.astype(bool)
+    return xr.where(overlap, 1, 0)
 
 
 def dewpoint_from_specific_humidity(pressure: float, specific_humidity: float) -> float:

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -95,9 +95,7 @@ def _maybe_add_specific_humidity(ds: xr.Dataset) -> xr.Dataset:
     """
     if "specific_humidity" in ds.variables or "q" in ds.variables:
         return ds
-    air_temperature = (
-        ds["air_temperature"] if "air_temperature" in ds else ds["t"]
-    )
+    air_temperature = ds["air_temperature"] if "air_temperature" in ds else ds["t"]
     relative_humidity = (
         ds["relative_humidity"] if "relative_humidity" in ds else ds["r"]
     )

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -81,9 +81,9 @@ def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The forecast dataset with geopotential thickness.
     """
-    # Calculate the geopotential thickness required for tropical cyclone tracks
     ds["geopotential_thickness"] = (
-        calc.geopotential_thickness(ds["z"], top_level=300, bottom_level=500) / 9.81
+        calc.geopotential_thickness(ds["geopotential"], top_level=300, bottom_level=500)
+        / 9.81
     )
     return ds
 
@@ -172,7 +172,8 @@ def preprocess_cira_kerchunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """
     ds = _set_cira_kerchunk_lead_time(ds)
     ds["geopotential_thickness"] = (
-        calc.geopotential_thickness(ds["z"], top_level=300, bottom_level=500) / 9.81
+        calc.geopotential_thickness(ds["geopotential"], top_level=300, bottom_level=500)
+        / 9.81
     )
     return ds
 

--- a/src/extremeweatherbench/defaults.py
+++ b/src/extremeweatherbench/defaults.py
@@ -88,6 +88,27 @@ def preprocess_cira_icechunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
+def _maybe_add_specific_humidity(ds: xr.Dataset) -> xr.Dataset:
+    """Add specific humidity from temperature and RH if it is missing.
+
+    Accepts original CIRA names (t, r, q) or mapped EWB names.
+    """
+    if "specific_humidity" in ds.variables or "q" in ds.variables:
+        return ds
+    air_temperature = (
+        ds["air_temperature"] if "air_temperature" in ds else ds["t"]
+    )
+    relative_humidity = (
+        ds["relative_humidity"] if "relative_humidity" in ds else ds["r"]
+    )
+    ds["specific_humidity"] = calc.specific_humidity_from_relative_humidity(
+        air_temperature=air_temperature,
+        relative_humidity=relative_humidity / 100,
+        levels=ds["level"],
+    )
+    return ds
+
+
 def preprocess_cira_icechunk_ar_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """Preprocess CIRA icechunk data for atmospheric rivers.
 
@@ -97,14 +118,7 @@ def preprocess_cira_icechunk_ar_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The renamed forecast dataset.
     """
-    if "q" not in ds.variables:
-        # Calculate specific humidity from relative humidity and air temperature
-        ds["specific_humidity"] = calc.specific_humidity_from_relative_humidity(
-            air_temperature=ds["t"],
-            relative_humidity=ds["r"] / 100,  # Convert relative humidity to percentage
-            levels=ds["level"],
-        )
-    return ds
+    return _maybe_add_specific_humidity(ds)
 
 
 def preprocess_cira_icechunk_severe_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
@@ -116,13 +130,15 @@ def preprocess_cira_icechunk_severe_forecast_dataset(ds: xr.Dataset) -> xr.Datas
     Returns:
         The forecast dataset with specific humidity if not already calculated.
     """
-    if "q" not in ds.variables:
-        # Calculate specific humidity from relative humidity and air temperature
-        ds["specific_humidity"] = calc.specific_humidity_from_relative_humidity(
-            air_temperature=ds["t"],
-            relative_humidity=ds["r"] / 100,  # Convert relative humidity to percentage
-            levels=ds["level"],
-        )
+    return _maybe_add_specific_humidity(ds)
+
+
+def _set_cira_kerchunk_lead_time(ds: xr.Dataset) -> xr.Dataset:
+    """Rename time to lead_time and set the CIRA 0-240h / 6h grid."""
+    ds = ds.rename({"time": "lead_time"})
+    ds["lead_time"] = np.array(
+        [i for i in range(0, 241, 6)], dtype="timedelta64[h]"
+    ).astype("timedelta64[ns]")
     return ds
 
 
@@ -137,13 +153,7 @@ def preprocess_cira_kerchunk_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The preprocessed forecast dataset.
     """
-
-    ds = ds.rename({"time": "lead_time"})
-    # The evaluation configuration is used to set the lead time range and resolution.
-    ds["lead_time"] = np.array(
-        [i for i in range(0, 241, 6)], dtype="timedelta64[h]"
-    ).astype("timedelta64[ns]")
-    return ds
+    return _set_cira_kerchunk_lead_time(ds)
 
 
 def preprocess_cira_kerchunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
@@ -160,20 +170,13 @@ def preprocess_cira_kerchunk_tc_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The renamed forecast dataset.
     """
-    ds = ds.rename({"time": "lead_time"})
-    # The evaluation configuration is used to set the lead time range and resolution.
-    ds["lead_time"] = np.array(
-        [i for i in range(0, 241, 6)], dtype="timedelta64[h]"
-    ).astype("timedelta64[ns]")
-
-    # Calculate the geopotential thickness required for tropical cyclone tracks
+    ds = _set_cira_kerchunk_lead_time(ds)
     ds["geopotential_thickness"] = (
         calc.geopotential_thickness(ds["z"], top_level=300, bottom_level=500) / 9.81
     )
     return ds
 
 
-# Preprocess function for CIRA data using Brightband kerchunk parquets
 def preprocess_cira_kerchunk_ar_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """Preprocess CIRA kerchunk data for atmospheric rivers.
 
@@ -183,22 +186,9 @@ def preprocess_cira_kerchunk_ar_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     Returns:
         The renamed forecast dataset with specific humidity if not already calculated.
     """
-    ds = ds.rename({"time": "lead_time"})
-    # The evaluation configuration is used to set the lead time range and resolution.
-    ds["lead_time"] = np.array(
-        [i for i in range(0, 241, 6)], dtype="timedelta64[h]"
-    ).astype("timedelta64[ns]")
-    if "q" not in ds.variables:
-        # Calculate specific humidity from relative humidity and air temperature
-        ds["specific_humidity"] = calc.specific_humidity_from_relative_humidity(
-            air_temperature=ds["t"],
-            relative_humidity=ds["r"] / 100,  # Convert relative humidity to percentage
-            levels=ds["level"],
-        )
-    return ds
+    return _maybe_add_specific_humidity(_set_cira_kerchunk_lead_time(ds))
 
 
-# Preprocess function for CIRA data using Brightband kerchunk parquets
 def preprocess_cira_kerchunk_severe_forecast_dataset(ds: xr.Dataset) -> xr.Dataset:
     """Preprocess CIRA kerchunk data for severe convection.
 
@@ -208,19 +198,7 @@ def preprocess_cira_kerchunk_severe_forecast_dataset(ds: xr.Dataset) -> xr.Datas
     Returns:
         The renamed forecast dataset with specific humidity if not already calculated.
     """
-    ds = ds.rename({"time": "lead_time"})
-    # The evaluation configuration is used to set the lead time range and resolution.
-    ds["lead_time"] = np.array(
-        [i for i in range(0, 241, 6)], dtype="timedelta64[h]"
-    ).astype("timedelta64[ns]")
-    if "q" not in ds.variables:
-        # Calculate specific humidity from relative humidity and air temperature
-        ds["specific_humidity"] = calc.specific_humidity_from_relative_humidity(
-            air_temperature=ds["t"],
-            relative_humidity=ds["r"] / 100,  # Convert relative humidity to percentage
-            levels=ds["level"],
-        )
-    return ds
+    return _maybe_add_specific_humidity(_set_cira_kerchunk_lead_time(ds))
 
 
 # Preprocessing function for HRES data that includes geopotential thickness calculation

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -451,34 +451,8 @@ class AtmosphericRiverVariables(DerivedVariable):
     def derive_variable(self, data: xr.Dataset, *args, **kwargs) -> xr.Dataset:
         """Derive the atmospheric river mask and land intersection."""
 
-        # Subset the data to the top pressure level
         data = data.sel(level=data.level[data.level >= self.top_pressure_level])
-
-        # Generate IVT
-        ivt_data = ar.integrated_vapor_transport(
-            specific_humidity=data["specific_humidity"],
-            eastward_wind=data["eastward_wind"],
-            northward_wind=data["northward_wind"],
-        )
-
-        # Compute IVT Laplacian
-        ivt_laplacian = ar.integrated_vapor_transport_laplacian(ivt=ivt_data, sigma=3)
-
-        # Compute AR mask with default parameters
-        ar_mask_result = ar.atmospheric_river_mask(
-            ivt=ivt_data, ivt_laplacian=ivt_laplacian
-        )
-
-        # Compute land intersection
-        land_intersection = calc.find_land_intersection(ar_mask_result)
-
-        return xr.Dataset(
-            {
-                "atmospheric_river_mask": ar_mask_result,
-                "atmospheric_river_land_intersection": land_intersection,
-                "integrated_vapor_transport": ivt_data,
-            }
-        )
+        return ar.build_atmospheric_river_mask_and_land_intersection(data)
 
 
 def maybe_derive_variables(

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 OUTPUT_COLUMNS = outputs.OUTPUT_COLUMNS
 
 # Process-local reuse of forecast/target datasets within one evaluation.
-_pipeline_cache_var: contextvars.ContextVar[Optional[dict[tuple, xr.Dataset]]] = (
+_pipeline_cache_var: contextvars.ContextVar[dict[tuple, xr.Dataset] | None] = (
     contextvars.ContextVar("_pipeline_cache", default=None)
 )
 
@@ -109,7 +109,7 @@ class ExtremeWeatherBench:
         output_format: str = "pandas",
         sparse: bool = False,
         **kwargs,
-    ) -> Union[pd.DataFrame, xr.Dataset]:
+    ) -> pd.DataFrame | xr.Dataset:
         """Deprecated alias for :meth:`run_evaluation`."""
         logger.warning("The run method is deprecated. Use run_evaluation instead.")
         return self.run_evaluation(
@@ -129,7 +129,7 @@ class ExtremeWeatherBench:
         output_format: str = "pandas",
         sparse: bool = False,
         **kwargs,
-    ) -> Union[pd.DataFrame, xr.Dataset]:
+    ) -> pd.DataFrame | xr.Dataset:
         """Runs the ExtremeWeatherBench evaluation workflow.
 
         This method will run the evaluation workflow in the order of the case operators,
@@ -179,8 +179,7 @@ def _validate_output_format(output_format: str) -> None:
     """Raise ValueError unless output_format is pandas or xarray."""
     if output_format not in ("pandas", "xarray"):
         raise ValueError(
-            f"Unknown output_format '{output_format}'. Expected 'pandas' or "
-            "'xarray'."
+            f"Unknown output_format '{output_format}'. Expected 'pandas' or 'xarray'."
         )
 
 
@@ -188,7 +187,7 @@ def _convert_results(
     results: list[xr.DataArray],
     output_format: str,
     sparse: bool = False,
-) -> Union[pd.DataFrame, xr.Dataset]:
+) -> pd.DataFrame | xr.Dataset:
     """Convert a flat list of annotated metric results to output_format.
 
     Args:
@@ -415,9 +414,7 @@ def _run_parallel_evaluation(
                 )
                 for group in groups
             )
-        return _scatter_group_results(
-            groups, nested_results, len(case_operators)
-        )
+        return _scatter_group_results(groups, nested_results, len(case_operators))
     finally:
         _close_worker_progress()
         if manager is not None:
@@ -450,9 +447,7 @@ def _group_operators_sharing_forecast(
             op.forecast.name,
             op.forecast.source,
         )
-        groups.setdefault(key, []).append(
-            IndexedOperator(index=i, operator=op)
-        )
+        groups.setdefault(key, []).append(IndexedOperator(index=i, operator=op))
     return list(groups.values())
 
 
@@ -498,7 +493,7 @@ def _pipeline_cache_key(
 def _run_pipeline_maybe_cached(
     case_metadata: "cases.IndividualCase",
     input_data: "inputs.InputBase",
-    pipeline_cache: Optional[dict[tuple, xr.Dataset]],
+    pipeline_cache: dict[tuple, xr.Dataset] | None,
     extra_key: tuple = (),
     **kwargs,
 ) -> xr.Dataset:
@@ -521,7 +516,7 @@ def _run_pipeline_maybe_cached(
 
 def _compute_operator_group_with_progress(
     indexed_ops: list[IndexedOperator],
-    cache_dir: Optional[pathlib.Path] = None,
+    cache_dir: pathlib.Path | None = None,
     event_queue=None,
     log_queue=None,
     **kwargs,
@@ -660,7 +655,7 @@ def compute_case_operator(
     cache_dir: pathlib.Path | None = None,
     output_format: str = "pandas",
     **kwargs,
-) -> Union[pd.DataFrame, xr.Dataset]:
+) -> pd.DataFrame | xr.Dataset:
     """Compute the resulting evaluation of a case operator.
 
     This method will compute the results of a case operator. It validates
@@ -690,7 +685,7 @@ def compute_case_operator(
 
 def _compute_case_operator_results(
     case_operator: "cases.CaseOperator",
-    cache_dir: Optional[pathlib.Path] = None,
+    cache_dir: pathlib.Path | None = None,
     **kwargs,
 ) -> list[xr.DataArray]:
     """Compute the annotated metric results for a case operator.

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1204,7 +1204,10 @@ def run_pipeline(
     # Gridded: map names, subset case, preprocess, then subset variables so
     # preprocess can add fields such as geopotential thickness. Tabular
     # sources such as IBTrACS need original column names inside preprocess.
-    data = input_data._open_data_from_source()
+    if isinstance(input_data, inputs.LSR):
+        data = input_data._open_data_from_source(case_metadata=case_metadata)
+    else:
+        data = input_data._open_data_from_source()
     is_gridded = isinstance(data, (xr.Dataset, xr.DataArray))
     if not is_gridded:
         data = input_data.preprocess(data)

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1,11 +1,13 @@
 """Evaluation routines for use during ExtremeWeatherBench case studies / analyses."""
 
 import contextlib
+import contextvars
 import copy
 import dataclasses
 import logging
 import multiprocessing
 import pathlib
+from collections import OrderedDict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -34,6 +36,11 @@ logger = logging.getLogger(__name__)
 
 # Re-exported for backwards compatibility.
 OUTPUT_COLUMNS = outputs.OUTPUT_COLUMNS
+
+# Process-local reuse of forecast/target datasets within one evaluation.
+_pipeline_cache_var: contextvars.ContextVar[Optional[dict[tuple, xr.Dataset]]] = (
+    contextvars.ContextVar("_pipeline_cache", default=None)
+)
 
 
 class ExtremeWeatherBench:
@@ -103,55 +110,16 @@ class ExtremeWeatherBench:
         sparse: bool = False,
         **kwargs,
     ) -> Union[pd.DataFrame, xr.Dataset]:
-        """Runs the ExtremeWeatherBench evaluation workflow.
-
-        This method will run the evaluation workflow in the order of the case operators,
-        optionally caching the mid-flight outputs of the workflow if cache_dir was
-        provided for serial runs.
-
-        Args:
-            n_jobs: The number of jobs to run in parallel. If None, defaults to the
-                joblib backend default value. If 1, the workflow will run serially.
-                Ignored if parallel_config is provided.
-            parallel_config: Optional dictionary of joblib parallel configuration.
-                If provided, this takes precedence over n_jobs. If not provided and
-                n_jobs is specified, a default config with the loky backend is used.
-            progress: Whether to display progress bars. Defaults to True.
-            output_format: "pandas" for the long-form DataFrame, or "xarray"
-                for the flat Dataset from outputs.results_to_dataset.
-            sparse: Forwarded to outputs.results_to_dataset when
-                output_format is "xarray".
-            **kwargs: Additional arguments to pass to compute_case_operator.
-        Returns:
-            The evaluation results in the requested output_format.
-
-        Raises:
-            ValueError: If output_format is not "pandas" or "xarray".
-        """
+        """Deprecated alias for :meth:`run_evaluation`."""
         logger.warning("The run method is deprecated. Use run_evaluation instead.")
-        logger.info("Running ExtremeWeatherBench evaluations...")
-
-        if output_format not in ("pandas", "xarray"):
-            raise ValueError(
-                f"Unknown output_format '{output_format}'. Expected 'pandas' or "
-                "'xarray'."
-            )
-
-        # Check for serial or parallel configuration
-        parallel_config = _parallel_serial_config_check(n_jobs, parallel_config)
-
-        run_results = _run_evaluation(
-            self.case_operators,
-            cache_dir=self.cache_dir,
+        return self.run_evaluation(
+            n_jobs=n_jobs,
             parallel_config=parallel_config,
             progress=progress,
+            output_format=output_format,
+            sparse=sparse,
             **kwargs,
         )
-
-        flattened_results = [
-            result for case_results in run_results for result in case_results
-        ]
-        return _convert_results(flattened_results, output_format, sparse=sparse)
 
     def run_evaluation(
         self,
@@ -187,13 +155,8 @@ class ExtremeWeatherBench:
         Raises:
             ValueError: If output_format is not "pandas" or "xarray".
         """
+        _validate_output_format(output_format)
         logger.info("Running ExtremeWeatherBench evaluations...")
-
-        if output_format not in ("pandas", "xarray"):
-            raise ValueError(
-                f"Unknown output_format '{output_format}'. Expected 'pandas' or "
-                "'xarray'."
-            )
 
         # Check for serial or parallel configuration
         parallel_config = _parallel_serial_config_check(n_jobs, parallel_config)
@@ -210,6 +173,15 @@ class ExtremeWeatherBench:
             result for case_results in run_results for result in case_results
         ]
         return _convert_results(flattened_results, output_format, sparse=sparse)
+
+
+def _validate_output_format(output_format: str) -> None:
+    """Raise ValueError unless output_format is pandas or xarray."""
+    if output_format not in ("pandas", "xarray"):
+        raise ValueError(
+            f"Unknown output_format '{output_format}'. Expected 'pandas' or "
+            "'xarray'."
+        )
 
 
 def _convert_results(
@@ -232,13 +204,10 @@ def _convert_results(
     Raises:
         ValueError: If output_format is not "pandas" or "xarray".
     """
+    _validate_output_format(output_format)
     if output_format == "pandas":
         return outputs.results_to_dataframe(results)
-    if output_format == "xarray":
-        return outputs.results_to_dataset(results, sparse=sparse)
-    raise ValueError(
-        f"Unknown output_format '{output_format}'. Expected 'pandas' or 'xarray'."
-    )
+    return outputs.results_to_dataset(results, sparse=sparse)
 
 
 def _parallel_serial_config_check(
@@ -314,33 +283,37 @@ def _run_evaluation(
         else:
             logger.info("Running case operators in serial...")
             run_results = []
+            cache_token = _pipeline_cache_var.set({})
             case_bar = progress_module.make_case_bar(
                 len(case_operators), disable=not progress
             )
             task_bar = progress_module.make_dask_task_bar(disable=not progress)
-            with (
-                progress_module.registered_bar(case_bar, allow_phase_updates=True),
-                progress_module.DaskTaskBar(task_bar),
-            ):
-                for case_operator in case_operators:
-                    step_bar = progress_module.make_case_step_bar(
-                        case_operator.case_metadata.case_id_number,
-                        _count_case_steps(case_operator, cache_dir),
-                        disable=not progress,
-                    )
-                    progress_module.register_step_bar(step_bar)
-                    try:
-                        run_results.append(
-                            _compute_case_operator_results(
-                                case_operator, cache_dir, **kwargs
-                            )
+            try:
+                with (
+                    progress_module.registered_bar(case_bar, allow_phase_updates=True),
+                    progress_module.DaskTaskBar(task_bar),
+                ):
+                    for case_operator in case_operators:
+                        step_bar = progress_module.make_case_step_bar(
+                            case_operator.case_metadata.case_id_number,
+                            _count_case_steps(case_operator, cache_dir),
+                            disable=not progress,
                         )
-                    finally:
-                        progress_module.register_step_bar(None)
-                        step_bar.close()
-                    case_bar.update(1)
-            task_bar.close()
-            case_bar.close()
+                        progress_module.register_step_bar(step_bar)
+                        try:
+                            run_results.append(
+                                _compute_case_operator_results(
+                                    case_operator, cache_dir, **kwargs
+                                )
+                            )
+                        finally:
+                            progress_module.register_step_bar(None)
+                            step_bar.close()
+                        case_bar.update(1)
+            finally:
+                task_bar.close()
+                case_bar.close()
+                _pipeline_cache_var.reset(cache_token)
 
     return run_results
 
@@ -425,22 +398,26 @@ def _run_parallel_evaluation(
 
     try:
         # TODO(198): return a generator and compute at a higher level
+        # Group operators that share a case and forecast so one worker can
+        # reuse the forecast dataset (PPH + LSR on the same HRES object).
+        groups = _group_operators_sharing_forecast(case_operators)
+        parallel_tqdm_kwargs["total_tasks"] = len(groups)
         with joblib.parallel_config(**parallel_config):
-            run_results = utils.ParallelTqdm(
+            nested_results = utils.ParallelTqdm(
                 pre_close=_close_worker_progress, **parallel_tqdm_kwargs
             )(
-                # None is the cache_dir, we can't cache in parallel mode
-                joblib.delayed(_compute_case_operator_with_progress)(
-                    case_operator,
+                joblib.delayed(_compute_operator_group_with_progress)(
+                    group,
                     cache_dir=cache_dir,
                     event_queue=event_queue,
                     log_queue=log_queue,
-                    dispatch_id=dispatch_id,
                     **kwargs,
                 )
-                for dispatch_id, case_operator in enumerate(case_operators)
+                for group in groups
             )
-        return run_results
+        return _scatter_group_results(
+            groups, nested_results, len(case_operators)
+        )
     finally:
         _close_worker_progress()
         if manager is not None:
@@ -449,6 +426,128 @@ def _run_parallel_evaluation(
         if dask_client is not None:
             logger.info("Closing dask client")
             dask_client.close()
+
+
+@dataclasses.dataclass(frozen=True)
+class IndexedOperator:
+    """An operator tagged with its original input index."""
+
+    index: int
+    operator: "cases.CaseOperator"
+
+
+def _group_operators_sharing_forecast(
+    case_operators: list["cases.CaseOperator"],
+) -> list[list[IndexedOperator]]:
+    """Group operators that share a case and forecast source.
+
+    PPH and LSR for the same case can reuse one forecast pipeline this way.
+    """
+    groups: OrderedDict[tuple, list[IndexedOperator]] = OrderedDict()
+    for i, op in enumerate(case_operators):
+        key = (
+            op.case_metadata.case_id_number,
+            op.forecast.name,
+            op.forecast.source,
+        )
+        groups.setdefault(key, []).append(
+            IndexedOperator(index=i, operator=op)
+        )
+    return list(groups.values())
+
+
+def _scatter_group_results(
+    groups: list[list[IndexedOperator]],
+    nested_results: list[list[list[xr.DataArray]]],
+    n_operators: int,
+) -> list[list[xr.DataArray]]:
+    """Restore original operator order from grouped parallel results.
+
+    Each job returns per-operator results in group order. Indices stay
+    on the parent in ``groups``.
+    """
+    run_results: list[list[xr.DataArray]] = [[] for _ in range(n_operators)]
+    for group, group_results in zip(groups, nested_results, strict=True):
+        for indexed, res in zip(group, group_results, strict=True):
+            run_results[indexed.index] = res
+    return run_results
+
+
+def _variable_cache_token(var: Any) -> str:
+    """Stable cache token for a pipeline variable."""
+    if isinstance(var, str):
+        return var
+    return f"{type(var).__name__}:{getattr(var, 'name', '')}"
+
+
+def _pipeline_cache_key(
+    case_metadata: "cases.IndividualCase",
+    input_data: "inputs.InputBase",
+) -> tuple:
+    """Key for reusing a pipeline dataset within one evaluation run."""
+    var_key = tuple(sorted(_variable_cache_token(v) for v in input_data.variables))
+    return (
+        case_metadata.case_id_number,
+        type(input_data).__name__,
+        input_data.name,
+        input_data.source,
+        var_key,
+    )
+
+
+def _run_pipeline_maybe_cached(
+    case_metadata: "cases.IndividualCase",
+    input_data: "inputs.InputBase",
+    pipeline_cache: Optional[dict[tuple, xr.Dataset]],
+    extra_key: tuple = (),
+    **kwargs,
+) -> xr.Dataset:
+    """Run an input pipeline, reusing a dataset when the cache hits."""
+    if pipeline_cache is None:
+        return run_pipeline(case_metadata, input_data, **kwargs)
+    key = _pipeline_cache_key(case_metadata, input_data) + extra_key
+    cached = pipeline_cache.get(key)
+    if cached is not None:
+        logger.debug(
+            "Reusing cached %s dataset for case %s",
+            input_data.name,
+            case_metadata.case_id_number,
+        )
+        return cached
+    ds = run_pipeline(case_metadata, input_data, **kwargs)
+    pipeline_cache[key] = ds
+    return ds
+
+
+def _compute_operator_group_with_progress(
+    indexed_ops: list[IndexedOperator],
+    cache_dir: Optional[pathlib.Path] = None,
+    event_queue=None,
+    log_queue=None,
+    **kwargs,
+) -> list[list[xr.DataArray]]:
+    """Run operators that share a forecast in one worker.
+
+    A process-local pipeline cache lets the second operator skip a second
+    forecast derive (for example CBSS for PPH then LSR). Results stay in
+    group order; the parent scatters them with ``groups``.
+    """
+    kwargs = dict(kwargs)
+    token = _pipeline_cache_var.set({})
+    try:
+        return [
+            _compute_case_operator_with_progress(
+                indexed.operator,
+                cache_dir=cache_dir,
+                event_queue=event_queue,
+                log_queue=log_queue,
+                dispatch_id=indexed.index,
+                **kwargs,
+            )
+            for indexed in indexed_ops
+        ]
+    finally:
+        _pipeline_cache_var.reset(token)
 
 
 def _plan_metric_evaluations(
@@ -584,6 +683,7 @@ def compute_case_operator(
             instance or child class of BaseMetric).
         ValueError: If output_format is not "pandas" or "xarray".
     """
+    _validate_output_format(output_format)
     results = _compute_case_operator_results(case_operator, cache_dir, **kwargs)
     return _convert_results(results, output_format)
 
@@ -652,6 +752,10 @@ def _compute_case_operator_results(
         cache_dir=cache_dir,
         name=f"{case_operator.case_metadata.case_id_number}_{case_operator.target.name}",
     )
+    # Compute once so each metric does not rebuild the same dask graph.
+    if cache_dir is None:
+        aligned_forecast_ds = aligned_forecast_ds.compute()
+        aligned_target_ds = aligned_target_ds.compute()
     logger.info(
         "Datasets built for case %s.", case_operator.case_metadata.case_id_number
     )
@@ -686,17 +790,13 @@ def _compute_case_operator_results(
                     )
                 )
 
-        # Cache the results of each metric if caching
-        if cache_dir:
-            cache_path = (
-                pathlib.Path(cache_dir) if isinstance(cache_dir, str) else cache_dir
+    if cache_dir:
+        concatenated = outputs.results_to_dataframe(results)
+        if not concatenated.empty:
+            concatenated.to_pickle(
+                cache_dir
+                / f"case_{case_operator.case_metadata.case_id_number}_results.pkl"
             )
-            concatenated = outputs.results_to_dataframe(results)
-            if not concatenated.empty:
-                concatenated.to_pickle(
-                    cache_path
-                    / f"case_{case_operator.case_metadata.case_id_number}_results.pkl"
-                )
 
     return results
 
@@ -1024,7 +1124,13 @@ def _build_datasets(
     progress_module.set_phase(
         f"case {case_operator.case_metadata.case_id_number} | target pipeline"
     )
-    target_ds = run_pipeline(case_operator.case_metadata, augmented_target, **kwargs)
+    pipeline_cache = _pipeline_cache_var.get()
+    target_ds = _run_pipeline_maybe_cached(
+        case_operator.case_metadata,
+        augmented_target,
+        pipeline_cache,
+        **kwargs,
+    )
 
     # Pass target dataset to forecast pipeline only if needed
     # Check if any forecast variable requires target dataset
@@ -1046,8 +1152,13 @@ def _build_datasets(
     progress_module.set_phase(
         f"case {case_operator.case_metadata.case_id_number} | forecast pipeline"
     )
-    forecast_ds = run_pipeline(
-        case_operator.case_metadata, augmented_forecast, **kwargs
+    forecast_extra = (augmented_target.name,) if needs_target else ()
+    forecast_ds = _run_pipeline_maybe_cached(
+        case_operator.case_metadata,
+        augmented_forecast,
+        pipeline_cache,
+        extra_key=forecast_extra,
+        **kwargs,
     )
 
     # Check if any dimension has zero length
@@ -1090,10 +1201,14 @@ def run_pipeline(
     Returns:
         The processed input data as an xarray dataset.
     """
-    # Open data and process through pipeline steps
-    data = input_data.open_and_maybe_preprocess_data_from_source().pipe(
-        lambda ds: input_data.maybe_map_variable_names(ds)
-    )
+    # Gridded: map names, subset case, preprocess, then subset variables so
+    # preprocess can add fields such as geopotential thickness. Tabular
+    # sources such as IBTrACS need original column names inside preprocess.
+    data = input_data._open_data_from_source()
+    is_gridded = isinstance(data, (xr.Dataset, xr.DataArray))
+    if not is_gridded:
+        data = input_data.preprocess(data)
+    data = input_data.maybe_map_variable_names(data)
 
     # Get the appropriate source module for the data type
     source_module = sources.get_backend_module(type(data))
@@ -1105,25 +1220,34 @@ def run_pipeline(
         case_metadata,
         source_module=source_module,
     ):
-        valid_data = (
-            inputs.maybe_subset_variables(
+        # Gridded: time/space subset and preprocess before variable subset
+        # so preprocess can create fields such as geopotential thickness.
+        to_subset = data
+        if not is_gridded:
+            to_subset = inputs.maybe_subset_variables(
                 data,
                 variables=input_data.variables,
                 source_module=source_module,
             )
-            .pipe(
+        valid_data = (
+            to_subset.pipe(
                 lambda ds: input_data.subset_data_to_case(ds, case_metadata, **kwargs)
             )
             .pipe(input_data.maybe_convert_to_dataset)
             .pipe(input_data.add_source_to_dataset_attrs)
-            .pipe(
-                lambda ds: derived.maybe_derive_variables(
-                    ds,
-                    variables=input_data.variables,
-                    case_metadata=case_metadata,
-                    **kwargs,
-                )
+        )
+        if is_gridded:
+            valid_data = input_data.preprocess(valid_data)
+            valid_data = inputs.maybe_subset_variables(
+                valid_data,
+                variables=input_data.variables,
+                source_module=source_module,
             )
+        valid_data = derived.maybe_derive_variables(
+            valid_data,
+            variables=input_data.variables,
+            case_metadata=case_metadata,
+            **kwargs,
         )
         return valid_data
     else:

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -17,25 +17,23 @@ import xarray as xr
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 import extremeweatherbench.progress as progress_module
-from extremeweatherbench import cases, derived, inputs, metrics, sources, utils
+from extremeweatherbench import (
+    cases,
+    derived,
+    inputs,
+    metrics,
+    outputs,
+    sources,
+    utils,
+)
 
 if TYPE_CHECKING:
     from extremeweatherbench import regions
 
 logger = logging.getLogger(__name__)
 
-# Columns for the evaluation output dataframe
-OUTPUT_COLUMNS = [
-    "value",
-    "lead_time",
-    "init_time",
-    "target_variable",
-    "metric",
-    "forecast_source",
-    "target_source",
-    "case_id_number",
-    "event_type",
-]
+# Re-exported for backwards compatibility.
+OUTPUT_COLUMNS = outputs.OUTPUT_COLUMNS
 
 
 class ExtremeWeatherBench:
@@ -101,8 +99,10 @@ class ExtremeWeatherBench:
         n_jobs: int | None = None,
         parallel_config: dict | None = None,
         progress: bool = True,
+        output_format: str = "pandas",
+        sparse: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> Union[pd.DataFrame, xr.Dataset]:
         """Runs the ExtremeWeatherBench evaluation workflow.
 
         This method will run the evaluation workflow in the order of the case operators,
@@ -117,12 +117,25 @@ class ExtremeWeatherBench:
                 If provided, this takes precedence over n_jobs. If not provided and
                 n_jobs is specified, a default config with the loky backend is used.
             progress: Whether to display progress bars. Defaults to True.
+            output_format: "pandas" for the long-form DataFrame, or "xarray"
+                for the flat Dataset from outputs.results_to_dataset.
+            sparse: Forwarded to outputs.results_to_dataset when
+                output_format is "xarray".
             **kwargs: Additional arguments to pass to compute_case_operator.
         Returns:
-            A concatenated dataframe of the evaluation results.
+            The evaluation results in the requested output_format.
+
+        Raises:
+            ValueError: If output_format is not "pandas" or "xarray".
         """
         logger.warning("The run method is deprecated. Use run_evaluation instead.")
         logger.info("Running ExtremeWeatherBench evaluations...")
+
+        if output_format not in ("pandas", "xarray"):
+            raise ValueError(
+                f"Unknown output_format '{output_format}'. Expected 'pandas' or "
+                "'xarray'."
+            )
 
         # Check for serial or parallel configuration
         parallel_config = _parallel_serial_config_check(n_jobs, parallel_config)
@@ -135,20 +148,20 @@ class ExtremeWeatherBench:
             **kwargs,
         )
 
-        # If there are results, concatenate them and return, else return an empty
-        # DataFrame with the expected columns
-        if run_results:
-            return _safe_concat(run_results, ignore_index=True)
-        else:
-            return pd.DataFrame(columns=OUTPUT_COLUMNS)
+        flattened_results = [
+            result for case_results in run_results for result in case_results
+        ]
+        return _convert_results(flattened_results, output_format, sparse=sparse)
 
     def run_evaluation(
         self,
         n_jobs: int | None = None,
         parallel_config: dict | None = None,
         progress: bool = True,
+        output_format: str = "pandas",
+        sparse: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> Union[pd.DataFrame, xr.Dataset]:
         """Runs the ExtremeWeatherBench evaluation workflow.
 
         This method will run the evaluation workflow in the order of the case operators,
@@ -163,11 +176,24 @@ class ExtremeWeatherBench:
                 If provided, this takes precedence over n_jobs. If not provided and
                 n_jobs is specified, a default config with the loky backend is used.
             progress: Whether to display progress bars. Defaults to True.
+            output_format: "pandas" for the long-form DataFrame, or "xarray"
+                for the flat Dataset from outputs.results_to_dataset.
+            sparse: Forwarded to outputs.results_to_dataset when
+                output_format is "xarray".
             **kwargs: Additional arguments to pass to compute_case_operator.
         Returns:
-            A concatenated dataframe of the evaluation results.
+            The evaluation results in the requested output_format.
+
+        Raises:
+            ValueError: If output_format is not "pandas" or "xarray".
         """
         logger.info("Running ExtremeWeatherBench evaluations...")
+
+        if output_format not in ("pandas", "xarray"):
+            raise ValueError(
+                f"Unknown output_format '{output_format}'. Expected 'pandas' or "
+                "'xarray'."
+            )
 
         # Check for serial or parallel configuration
         parallel_config = _parallel_serial_config_check(n_jobs, parallel_config)
@@ -180,12 +206,39 @@ class ExtremeWeatherBench:
             **kwargs,
         )
 
-        # If there are results, concatenate them and return, else return an empty
-        # DataFrame with the expected columns
-        if run_results:
-            return _safe_concat(run_results, ignore_index=True)
-        else:
-            return pd.DataFrame(columns=OUTPUT_COLUMNS)
+        flattened_results = [
+            result for case_results in run_results for result in case_results
+        ]
+        return _convert_results(flattened_results, output_format, sparse=sparse)
+
+
+def _convert_results(
+    results: list[xr.DataArray],
+    output_format: str,
+    sparse: bool = False,
+) -> Union[pd.DataFrame, xr.Dataset]:
+    """Convert a flat list of annotated metric results to output_format.
+
+    Args:
+        results: A flat list of annotated metric results.
+        output_format: "pandas" for the long-form DataFrame, or "xarray"
+            for the flat Dataset from outputs.results_to_dataset.
+        sparse: Forwarded to outputs.results_to_dataset when output_format
+            is "xarray".
+
+    Returns:
+        The results converted to the requested output_format.
+
+    Raises:
+        ValueError: If output_format is not "pandas" or "xarray".
+    """
+    if output_format == "pandas":
+        return outputs.results_to_dataframe(results)
+    if output_format == "xarray":
+        return outputs.results_to_dataset(results, sparse=sparse)
+    raise ValueError(
+        f"Unknown output_format '{output_format}'. Expected 'pandas' or 'xarray'."
+    )
 
 
 def _parallel_serial_config_check(
@@ -235,7 +288,7 @@ def _run_evaluation(
     parallel_config: dict | None = None,
     progress: bool = True,
     **kwargs,
-) -> list[pd.DataFrame]:
+) -> list[list[xr.DataArray]]:
     """Run the case operators in parallel or serial.
 
     Args:
@@ -246,7 +299,7 @@ def _run_evaluation(
         **kwargs: Additional keyword arguments passed to case operators.
 
     Returns:
-        List of result DataFrames.
+        List of per-case-operator lists of annotated metric results.
     """
     with progress_module.captured_warnings(), logging_redirect_tqdm():
         if parallel_config is not None:
@@ -278,7 +331,9 @@ def _run_evaluation(
                     progress_module.register_step_bar(step_bar)
                     try:
                         run_results.append(
-                            compute_case_operator(case_operator, cache_dir, **kwargs)
+                            _compute_case_operator_results(
+                                case_operator, cache_dir, **kwargs
+                            )
                         )
                     finally:
                         progress_module.register_step_bar(None)
@@ -296,7 +351,7 @@ def _run_parallel_evaluation(
     cache_dir: pathlib.Path | None = None,
     progress: bool = True,
     **kwargs,
-) -> list[pd.DataFrame]:
+) -> list[list[xr.DataArray]]:
     """Run the case operators in parallel.
 
     Args:
@@ -307,7 +362,7 @@ def _run_parallel_evaluation(
         **kwargs: Additional arguments, must include 'parallel_config' dict.
 
     Returns:
-        List of result DataFrames.
+        List of per-case-operator lists of annotated metric results.
     """
     if parallel_config.get("n_jobs") is None:
         logger.warning("No number of jobs provided, using joblib backend default.")
@@ -504,8 +559,9 @@ def _count_case_steps(
 def compute_case_operator(
     case_operator: "cases.CaseOperator",
     cache_dir: pathlib.Path | None = None,
+    output_format: str = "pandas",
     **kwargs,
-) -> pd.DataFrame:
+) -> Union[pd.DataFrame, xr.Dataset]:
     """Compute the resulting evaluation of a case operator.
 
     This method will compute the results of a case operator. It validates
@@ -517,9 +573,40 @@ def compute_case_operator(
     Args:
         case_operator: The case operator to compute the results of.
         cache_dir: The directory to cache mid-flight outputs (serial mode).
+        output_format: "pandas" for the long-form DataFrame, or "xarray"
+            for the flat Dataset from outputs.results_to_dataset.
 
     Returns:
-        A pd.DataFrame of results from the case operator.
+        The case operator's results in the requested output_format.
+
+    Raises:
+        TypeError: If any metric is not properly instantiated (i.e. isn't an
+            instance or child class of BaseMetric).
+        ValueError: If output_format is not "pandas" or "xarray".
+    """
+    results = _compute_case_operator_results(case_operator, cache_dir, **kwargs)
+    return _convert_results(results, output_format)
+
+
+def _compute_case_operator_results(
+    case_operator: "cases.CaseOperator",
+    cache_dir: Optional[pathlib.Path] = None,
+    **kwargs,
+) -> list[xr.DataArray]:
+    """Compute the annotated metric results for a case operator.
+
+    This method validates that all metrics are properly instantiated, builds
+    the target and forecast datasets, aligns them, and computes each metric
+    with appropriate variable pairs. Metrics with their own forecast_variable
+    and target_variable use only those variables; metrics without will use
+    all InputBase variable pairs.
+
+    Args:
+        case_operator: The case operator to compute the results of.
+        cache_dir: The directory to cache mid-flight outputs (serial mode).
+
+    Returns:
+        A list of annotated metric result DataArrays.
 
     Raises:
         TypeError: If any metric is not properly instantiated (i.e. isn't an
@@ -547,7 +634,7 @@ def compute_case_operator(
         or len(forecast_ds.sizes) == 0
         or len(target_ds.sizes) == 0
     ):
-        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+        return []
 
     # spatiotemporally align the target and forecast datasets dependent on the target
     aligned_forecast_ds, aligned_target_ds = (
@@ -568,7 +655,7 @@ def compute_case_operator(
     logger.info(
         "Datasets built for case %s.", case_operator.case_metadata.case_id_number
     )
-    results = []
+    results: list[xr.DataArray] = []
 
     for metric, metrics_to_evaluate, variable_pairs in _plan_metric_evaluations(
         case_operator
@@ -588,7 +675,7 @@ def compute_case_operator(
             # Evaluate each expanded metric
             for single_metric in metrics_to_evaluate:
                 results.append(
-                    _evaluate_metric_and_return_df(
+                    _evaluate_metric(
                         forecast_ds=aligned_forecast_ds,
                         target_ds=aligned_target_ds,
                         forecast_variable=forecast_var,
@@ -604,14 +691,14 @@ def compute_case_operator(
             cache_path = (
                 pathlib.Path(cache_dir) if isinstance(cache_dir, str) else cache_dir
             )
-            concatenated = _safe_concat(results, ignore_index=True)
+            concatenated = outputs.results_to_dataframe(results)
             if not concatenated.empty:
                 concatenated.to_pickle(
                     cache_path
                     / f"case_{case_operator.case_metadata.case_id_number}_results.pkl"
                 )
 
-    return _safe_concat(results, ignore_index=True)
+    return results
 
 
 def _compute_case_operator_with_progress(
@@ -621,7 +708,7 @@ def _compute_case_operator_with_progress(
     log_queue=None,
     dispatch_id=None,
     **kwargs,
-) -> pd.DataFrame:
+) -> list[xr.DataArray]:
     """Compute a case operator, publishing progress to event_queue.
 
     Runs inside a worker process. Falls back to plain computation when no
@@ -641,10 +728,10 @@ def _compute_case_operator_with_progress(
         **kwargs: Additional arguments for compute_case_operator.
 
     Returns:
-        A pd.DataFrame of results from the case operator.
+        A list of annotated metric result DataArrays.
     """
     if event_queue is None:
-        return compute_case_operator(case_operator, cache_dir, **kwargs)
+        return _compute_case_operator_results(case_operator, cache_dir, **kwargs)
 
     case_id = case_operator.case_metadata.case_id_number
     slot_key = dispatch_id if dispatch_id is not None else case_id
@@ -669,7 +756,7 @@ def _compute_case_operator_with_progress(
     )
     try:
         with log_context, progress_module.DaskTaskSink(sink, case_id):
-            return compute_case_operator(case_operator, cache_dir, **kwargs)
+            return _compute_case_operator_results(case_operator, cache_dir, **kwargs)
     finally:
         sink(
             progress_module.ProgressEvent(
@@ -680,26 +767,29 @@ def _compute_case_operator_with_progress(
 
 
 def _extract_standard_metadata(
+    forecast_variable: Union[str, "derived.DerivedVariable"],
     target_variable: Union[str, "derived.DerivedVariable"],
     metric: "metrics.BaseMetric",
     case_operator: "cases.CaseOperator",
 ) -> dict:
-    """Extract standard metadata for output dataframe.
+    """Extract standard metadata for an annotated metric result.
 
     This function centralizes the logic for extracting metadata from the
     evaluation context. Makes it easy to modify how metadata is extracted
     without changing the schema enforcement logic.
 
     Args:
+        forecast_variable: The forecast variable
         target_variable: The target variable
         metric: The metric instance
         case_operator: The CaseOperator holding associated case metadata
 
     Returns:
-        Dictionary of metadata for the output dataframe
+        Dictionary of metadata for the metric result
     """
     return {
         "target_variable": target_variable,
+        "forecast_variable": forecast_variable,
         "metric": metric.name,
         "target_source": case_operator.target.name,
         "forecast_source": case_operator.forecast.name,
@@ -708,62 +798,7 @@ def _extract_standard_metadata(
     }
 
 
-def _ensure_output_schema(df: pd.DataFrame, **metadata) -> pd.DataFrame:
-    """Ensure dataframe conforms to OUTPUT_COLUMNS schema.
-
-    This function adds any provided metadata columns to the dataframe and validates
-    that all OUTPUT_COLUMNS are present. Any missing columns will be filled with NaN
-    and a warning will be logged.
-
-    Args:
-        df: Base dataframe (typically with 'value' column from metric result)
-        **metadata: Key-value pairs for metadata columns (e.g., target_variable='temp')
-
-    Returns:
-        DataFrame with columns matching OUTPUT_COLUMNS specification
-
-    Example:
-        df = _ensure_output_schema(
-            metric_df,
-            target_variable=target_var,
-            metric=metric.name,
-            case_id_number=case_id,
-            event_type=event_type
-        )
-    """
-    # Add metadata columns
-    for col, value in metadata.items():
-        df[col] = value
-
-    # Check for missing columns and warn
-    missing_cols = set(OUTPUT_COLUMNS) - set(df.columns)
-
-    # An output requires one of init_time or lead_time. init_time will be present for a
-    # metric that assesses something in an entire model run, such as the onset error of
-    # an event. Lead_time will be present for a metric that assesses something at a
-    # specific forecast hour, such as RMSE. If neither are present, the output is
-    # invalid, so a metric supplying only one of them is intended behavior. Peak metrics
-    # supply both, because they reduce over a run and then report against the lead time
-    # at which that run verified against the target's extreme.
-    init_time_missing = "init_time" in missing_cols
-    lead_time_missing = "lead_time" in missing_cols
-
-    # Check if exactly one of init_time or lead_time is missing
-    if init_time_missing != lead_time_missing:
-        missing_cols.discard("init_time")
-        missing_cols.discard("lead_time")
-
-    if missing_cols:
-        logger.warning("Missing expected columns: %s.", missing_cols)
-
-    # Ensure all OUTPUT_COLUMNS are present (missing ones will be NaN),
-    # reorder to match OUTPUT_COLUMNS specification, and preserve any
-    # extra columns (e.g. landfall metadata) appended at the end.
-    extra_cols = [c for c in df.columns if c not in OUTPUT_COLUMNS]
-    return df.reindex(columns=OUTPUT_COLUMNS + extra_cols)
-
-
-def _evaluate_metric_and_return_df(
+def _evaluate_metric(
     forecast_ds: xr.Dataset,
     target_ds: xr.Dataset,
     forecast_variable: Union[str, "derived.DerivedVariable"],
@@ -771,8 +806,8 @@ def _evaluate_metric_and_return_df(
     metric: "metrics.BaseMetric",
     case_operator: "cases.CaseOperator",
     **kwargs,
-) -> pd.DataFrame:
-    """Evaluate a metric and return a dataframe of the results.
+) -> xr.DataArray:
+    """Evaluate a metric and return the annotated result.
 
     Args:
         forecast_ds: The forecast dataset.
@@ -785,8 +820,7 @@ def _evaluate_metric_and_return_df(
             computation.
 
     Returns:
-        A dataframe of the results with standard output schema
-        columns.
+        The metric result with standard metadata attached as coords.
     """
 
     # Normalize variables to their string names if needed
@@ -835,12 +869,16 @@ def _evaluate_metric_and_return_df(
         metric_result.data = metric_result.data.map_blocks(
             lambda x: x.maybe_densify(), dtype=metric_result.data.dtype
         )
-    # Convert to DataFrame and add metadata, ensuring OUTPUT_COLUMNS compliance
 
-    df = metric_result.to_dataframe(name="value").reset_index()
     # TODO: add functionality for custom metadata columns
-    metadata = _extract_standard_metadata(target_variable, metric, case_operator)
-    return _ensure_output_schema(df, **metadata)
+    metadata = _extract_standard_metadata(
+        forecast_variable, target_variable, metric, case_operator
+    )
+    annotated_result = outputs.annotate_metric_result(metric_result, **metadata)
+    # Avoid pickling dask graphs back from worker processes.
+    if isinstance(annotated_result.data, da.Array):
+        annotated_result = annotated_result.compute()
+    return annotated_result
 
 
 def _maybe_expand_derived_variable_to_output_variables(
@@ -1097,68 +1135,3 @@ def run_pipeline(
             case_metadata.end_date.strftime("%Y-%m-%d %H:%M:%S"),
         )
         return xr.Dataset()
-
-
-def _safe_concat(
-    dataframes: list[pd.DataFrame], ignore_index: bool = True
-) -> pd.DataFrame:
-    """Safely concatenate DataFrames, filtering out empty ones.
-
-    This function prevents FutureWarnings from pd.concat when dealing with
-    empty or all-NA DataFrames by filtering them out before concatenation.
-    It also handles dtype mismatches by converting to object dtype only when
-    necessary to prevent concatenation warnings.
-
-    Args:
-        dataframes: List of DataFrames to concatenate
-        ignore_index: Whether to ignore index during concatenation
-
-    Returns:
-        Concatenated DataFrame, or empty DataFrame with OUTPUT_COLUMNS if all
-        input DataFrames are empty. Preserves original dtypes when consistent
-        across DataFrames, converts to object dtype only when there are
-        dtype mismatches.
-    """
-    # Filter out problematic DataFrames that would trigger FutureWarning
-    valid_dfs = []
-    for i, df in enumerate(dataframes):
-        # Skip empty DataFrames
-        if df.empty:
-            logger.debug("Skipping empty DataFrame %s", i)
-            continue
-        # Skip DataFrames where all values are NA
-        if df.isna().all().all():
-            logger.debug("Skipping all-NA DataFrame %s", i)
-            continue
-        # Skip DataFrames where all columns are empty/NA
-        if len(df.columns) > 0 and all(df[col].isna().all() for col in df.columns):
-            logger.debug("Skipping DataFrame %s with all-NA columns", i)
-            continue
-
-        valid_dfs.append(df)
-
-    if valid_dfs:
-        # Check for dtype inconsistencies that cause FutureWarning
-        if len(valid_dfs) > 1:
-            # Check if there are dtype mismatches between DataFrames
-            reference_df = valid_dfs[0]
-            has_dtype_mismatch = False
-
-            for df in valid_dfs[1:]:
-                # Check if columns have different dtypes across DataFrames
-                for col in reference_df.columns:
-                    if col in df.columns and reference_df[col].dtype != df[col].dtype:
-                        has_dtype_mismatch = True
-                        break
-                if has_dtype_mismatch:
-                    break
-
-            if has_dtype_mismatch:
-                # Only convert to object dtype if there are mismatches
-                consistent_dfs = [df.astype(object) for df in valid_dfs]
-                return pd.concat(consistent_dfs, ignore_index=ignore_index)
-
-        # No dtype mismatches, concatenate normally
-        return pd.concat(valid_dfs, ignore_index=ignore_index)
-    else:
-        return pd.DataFrame(columns=OUTPUT_COLUMNS)

--- a/src/extremeweatherbench/evaluate_cli.py
+++ b/src/extremeweatherbench/evaluate_cli.py
@@ -6,7 +6,13 @@ import pickle
 import click
 import pandas as pd
 
-from extremeweatherbench import cases, defaults, evaluate
+from extremeweatherbench import cases, defaults, evaluate, outputs
+
+_OUTPUT_FILENAMES = {
+    "csv": "evaluation_results.csv",
+    "netcdf": "evaluation_results.nc",
+    "zarr": "evaluation_results.zarr",
+}
 
 
 @click.command()
@@ -56,6 +62,17 @@ from extremeweatherbench import cases, defaults, evaluate
     is_flag=True,
     help="Disable all progress bars",
 )
+@click.option(
+    "--output-format",
+    type=click.Choice(["csv", "netcdf", "zarr"]),
+    default="csv",
+    help="Format for saving evaluation results (default: csv)",
+)
+@click.option(
+    "--sparse",
+    is_flag=True,
+    help="Store xarray results as sparse arrays (netcdf/zarr formats only)",
+)
 @click.pass_context
 def cli_runner(
     ctx: click.Context,
@@ -67,6 +84,8 @@ def cli_runner(
     parallel_config: dict | None,
     save_case_operators: str | None,
     no_progress: bool,
+    output_format: str,
+    sparse: bool,
 ):
     """ExtremeWeatherBench command line interface.
 
@@ -96,6 +115,10 @@ def cli_runner(
         save_case_operators: Save CaseOperator objects to a pickle file at this
             path.
         no_progress: Disable all progress bars.
+        output_format: Format for saving results: "csv", "netcdf", or "zarr"
+            (default: "csv").
+        sparse: Store xarray results as sparse arrays. Only valid with
+            --output-format netcdf or zarr.
     Examples:
         # Use default evaluation objects
         $ ewb --default
@@ -111,6 +134,12 @@ def cli_runner(
 
         # Use custom parallel configuration
         $ ewb --default --parallel-config '{"backend": "dask", "n_jobs": 4}'
+
+        # Save results as a NetCDF Dataset instead of a CSV
+        $ ewb --default --output-format netcdf
+
+        # Save results as a sparse zarr Dataset
+        $ ewb --default --output-format zarr --sparse
     """
     # Show help if no arguments provided
     if not default and not config_file:
@@ -126,6 +155,11 @@ def cli_runner(
 
     if default and config_file:
         raise click.UsageError("Cannot specify both --default and --config-file")
+
+    if sparse and output_format == "csv":
+        raise click.UsageError(
+            "--sparse is only valid with --output-format netcdf or zarr"
+        )
 
     # Load evaluation objects
     if default:
@@ -158,20 +192,31 @@ def cli_runner(
 
     # Run evaluation
     click.echo("Running evaluation...")
+    eval_output_format = "pandas" if output_format == "csv" else "xarray"
     results = ewb.run_evaluation(
         n_jobs=n_jobs,
         parallel_config=parallel_config,
         progress=not no_progress,
+        output_format=eval_output_format,
+        sparse=sparse,
     )
 
     # Save results
-    output_file = output_path / "evaluation_results.csv"
-    if isinstance(results, pd.DataFrame) and not results.empty:
-        results.to_csv(output_file, index=False)
-        click.echo(f"Results saved to {output_file}")
-        click.echo(f"Evaluated {len(results)} cases")
+    output_file = output_path / _OUTPUT_FILENAMES[output_format]
+    if isinstance(results, pd.DataFrame):
+        is_empty = results.empty
     else:
+        is_empty = not results.data_vars
+
+    if is_empty:
         click.echo("No results to save")
+    else:
+        outputs.write_results(results, output_file, output_format, sparse=sparse)
+        click.echo(f"Results saved to {output_file}")
+        if isinstance(results, pd.DataFrame):
+            click.echo(f"Evaluated {len(results)} cases")
+        else:
+            click.echo(f"Evaluated {results.sizes.get('case_id_number', 0)} cases")
 
 
 def _load_default_cases():

--- a/src/extremeweatherbench/events/atmospheric_river.py
+++ b/src/extremeweatherbench/events/atmospheric_river.py
@@ -1,8 +1,90 @@
+from collections.abc import Sequence
+
 import numpy as np
+import numpy.typing as npt
 import xarray as xr
 from scipy import ndimage
 
 from extremeweatherbench import calc
+
+
+def _label_time_linked_tyx(mask_tyx: npt.NDArray[np.bool_]) -> npt.NDArray[np.int32]:
+    """Label a (time, lat, lon) mask with 6-connectivity.
+
+    2D connected components plus union-find across consecutive times.
+    Matches ndimage.label with generate_binary_structure(3, 1).
+    """
+    n_t = mask_tyx.shape[0]
+    labeled = np.empty(mask_tyx.shape, dtype=np.int32)
+    n_feat = np.empty(n_t, dtype=np.int32)
+    for t in range(n_t):
+        labeled[t], n_feat[t] = ndimage.label(mask_tyx[t])
+    total = int(n_feat.sum())
+    if total == 0:
+        return labeled
+
+    glob = np.where(
+        labeled > 0, labeled + (np.cumsum(n_feat) - n_feat)[:, None, None], 0
+    ).astype(np.int32)
+    parent = np.arange(total + 1, dtype=np.int32)
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = int(parent[x])
+        return x
+
+    for t in range(n_t - 1):
+        both = (glob[t] > 0) & (glob[t + 1] > 0)
+        if not both.any():
+            continue
+        pairs = np.unique(np.stack((glob[t][both], glob[t + 1][both]), axis=1), axis=0)
+        for a, b in pairs:
+            ra, rb = find(int(a)), find(int(b))
+            if ra != rb:
+                parent[rb] = ra
+
+    remap = np.zeros(total + 1, dtype=np.int32)
+    n = 0
+    for i in range(1, total + 1):
+        root = find(i)
+        if remap[root] == 0:
+            n += 1
+            remap[root] = n
+        remap[i] = remap[root]
+    return remap[glob]
+
+
+def _label_objects_time_linked(
+    mask: npt.NDArray[np.bool_],
+    dims: Sequence[str],
+    time_dimension: str,
+) -> npt.NDArray[np.int32]:
+    """Label True pixels, linking through time but not across other dims."""
+    keep = {time_dimension, "latitude", "longitude"}
+    if not keep <= set(dims):
+        labeled, _ = ndimage.label(mask)
+        return np.asarray(labeled, dtype=np.int32)
+
+    order = (
+        [dims.index(time_dimension)]
+        + [i for i, name in enumerate(dims) if name not in keep]
+        + [dims.index("latitude"), dims.index("longitude")]
+    )
+    moved = np.transpose(mask, order)
+    n_t, *extra, n_y, n_x = moved.shape
+    n_extra = int(np.prod(extra, initial=1))
+    moved = moved.reshape(n_t, n_extra, n_y, n_x)
+    out = np.empty_like(moved, dtype=np.int32)
+    next_id = 1
+    for i in range(n_extra):
+        lab = _label_time_linked_tyx(moved[:, i])
+        n_lab = int(lab.max())
+        if n_lab:
+            lab = np.where(lab, lab + (next_id - 1), 0)
+            next_id += n_lab
+        out[:, i] = lab
+    return np.transpose(out.reshape(n_t, *extra, n_y, n_x), np.argsort(order))
 
 
 def atmospheric_river_mask(
@@ -66,8 +148,12 @@ def atmospheric_river_mask(
     # Combine conditions without tropical restriction initially
     initial_intersection = xr.where(dilated_laplacian & has_high_ivt, 1, 0)
 
-    # Label connected components and get their sizes
-    labeled_array, _ = ndimage.label(initial_intersection)
+    # Label 2D slices and merge across consecutive valid_time only.
+    labeled_array = _label_objects_time_linked(
+        np.asarray(initial_intersection, dtype=bool),
+        list(initial_intersection.dims),
+        time_dimension,
+    )
     unique_labels, label_counts = np.unique(labeled_array, return_counts=True)
 
     # Filter by size first (excluding background label 0)
@@ -82,11 +168,11 @@ def atmospheric_river_mask(
     lat_shape = [1] * labeled_array.ndim
     lat_shape[lat_axis] = len(latitudes)
     lat_grid = np.broadcast_to(latitudes.reshape(lat_shape), labeled_array.shape)
-    valid_labels = [
-        label
-        for label in size_valid_labels
-        if abs(lat_grid[labeled_array == label].mean()) > 15
-    ]
+    if size_valid_labels.size == 0:
+        valid_labels = size_valid_labels
+    else:
+        mean_lat = ndimage.mean(lat_grid, labels=labeled_array, index=size_valid_labels)
+        valid_labels = size_valid_labels[np.abs(mean_lat) > 15]
 
     # Create final mask using valid features
     feature_mask = np.isin(labeled_array, valid_labels)

--- a/src/extremeweatherbench/events/tropical_cyclone.py
+++ b/src/extremeweatherbench/events/tropical_cyclone.py
@@ -926,28 +926,25 @@ def _create_spatial_mask(
         Spatial mask as a boolean array
     """
 
-    # Create meshgrid of all lat/lon coordinates
     lat_grid, lon_grid = np.meshgrid(lat_coords, lon_coords, indexing="ij")
+    if nearby_tc_track_data.empty:
+        return np.zeros_like(lat_grid, dtype=bool)
 
-    # Initialize mask
+    tc_lats = nearby_tc_track_data["latitude"].to_numpy(dtype=float)
+    tc_lons = nearby_tc_track_data["longitude"].to_numpy(dtype=float)
     spatial_mask = np.zeros_like(lat_grid, dtype=bool)
-
-    # For each tropical cyclone track data point, compute distances to all grid points
-    # vectorized
-    for _, tc_track_data_row in nearby_tc_track_data.iterrows():
-        tc_track_data_lat = tc_track_data_row["latitude"]
-        tc_track_data_lon = tc_track_data_row["longitude"]
-
-        # Vectorized distance calculation
+    # Chunk track points so (n_tracks, nlat, nlon) stays bounded.
+    for start in range(0, len(tc_lats), 32):
+        stop = start + 32
         distances = calc.haversine_distance(
-            [lat_grid, lon_grid],
-            [tc_track_data_lat, tc_track_data_lon],
+            [lat_grid[np.newaxis], lon_grid[np.newaxis]],
+            [
+                tc_lats[start:stop, np.newaxis, np.newaxis],
+                tc_lons[start:stop, np.newaxis, np.newaxis],
+            ],
             units="degrees",
         )
-
-        # Update mask where distance is within threshold
-        spatial_mask |= distances <= max_distance_degrees
-
+        spatial_mask |= np.any(distances <= max_distance_degrees, axis=0)
     return spatial_mask
 
 

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -714,11 +714,23 @@ class LSR(TargetBase):
         default_factory=lambda: ["report_type"]
     )
 
-    def _open_data_from_source(self) -> IncomingDataInput:
+    def _open_data_from_source(
+        self, case_metadata: Optional["cases.IndividualCase"] = None
+    ) -> IncomingDataInput:
         # force LSR to use anon token to prevent google reauth issues for users
-        target_data = pd.read_parquet(self.source, storage_options=self.storage_options)
-
-        return target_data
+        kwargs: dict[str, Any] = {"storage_options": self.storage_options}
+        if case_metadata is not None:
+            kwargs["filters"] = [
+                ("valid_time", ">=", pd.Timestamp(case_metadata.start_date)),
+                ("valid_time", "<=", pd.Timestamp(case_metadata.end_date)),
+            ]
+        try:
+            return pd.read_parquet(self.source, **kwargs)
+        except Exception as exc:
+            if "filters" not in kwargs:
+                raise
+            logger.debug("LSR parquet filters failed (%s); reading full file", exc)
+            return pd.read_parquet(self.source, storage_options=self.storage_options)
 
     def subset_data_to_case(
         self,

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -392,13 +392,8 @@ class ForecastBase(InputBase):
             (len(subset_time_data.init_time), len(subset_time_data.lead_time)),
             dtype=bool,
         )
-
-        # Map the valid indices back to the subset data coordinates
-        for i, j in zip(subset_time_indices[0], subset_time_indices[1]):
-            # Find the position of this init_time in the subset data
-            init_pos = np.where(unique_init_indices == i)[0]
-            if len(init_pos) > 0:
-                valid_combinations_mask[init_pos[0], j] = True
+        init_pos = np.searchsorted(unique_init_indices, subset_time_indices[0])
+        valid_combinations_mask[init_pos, subset_time_indices[1]] = True
 
         # Add the mask as a coordinate so downstream code can use it
         subset_time_data = subset_time_data.assign_coords(
@@ -1224,17 +1219,24 @@ def align_forecast_to_target(
     # Regrid forecast to target grid using nearest neighbor interpolation
     # extrapolate in the case of targets slightly outside the forecast domain
     if spatial_dims:
-        interp_method: Literal["nearest", "linear"] = (
-            "nearest" if method == "nearest" else "linear"
+        same_grid = all(
+            time_aligned_forecast[dim].equals(time_aligned_target[dim])
+            for dim in spatial_dims
         )
+        if same_grid:
+            time_space_aligned_forecast = time_aligned_forecast
+        else:
+            interp_method: Literal["nearest", "linear"] = (
+                "nearest" if method == "nearest" else "linear"
+            )
 
-        interp_kwargs = cast(
-            dict[str, Any],
-            {"method": interp_method, "kwargs": {"fill_value": "extrapolate"}},
-        )
-        interp_kwargs.update(spatial_dims)
+            interp_kwargs = cast(
+                dict[str, Any],
+                {"method": interp_method, "kwargs": {"fill_value": "extrapolate"}},
+            )
+            interp_kwargs.update(spatial_dims)
 
-        time_space_aligned_forecast = time_aligned_forecast.interp(**interp_kwargs)
+            time_space_aligned_forecast = time_aligned_forecast.interp(**interp_kwargs)
     else:
         time_space_aligned_forecast = time_aligned_forecast
 

--- a/src/extremeweatherbench/metrics.py
+++ b/src/extremeweatherbench/metrics.py
@@ -1564,6 +1564,11 @@ class DurationMeanError(MeanError):
         if isinstance(threshold_criteria, xr.DataArray):
             # Climatology case, convert from dayofyear/hour to valid_time.
             # Note that unintended behavior may occur if the case spans multiple years.
+            days = np.intersect1d(
+                forecast.valid_time.dt.dayofyear, threshold_criteria.dayofyear
+            )
+            if days.size:
+                threshold_criteria = threshold_criteria.sel(dayofyear=days)
             threshold_criteria = utils.convert_day_yearofday_to_time(
                 threshold_criteria, forecast.valid_time.dt.year.values[0]
             )

--- a/src/extremeweatherbench/outputs.py
+++ b/src/extremeweatherbench/outputs.py
@@ -1,0 +1,571 @@
+"""The output contract for evaluation results: xarray in, pandas/xarray out."""
+
+import logging
+import pathlib
+from typing import Union
+
+import dask.array as da
+import numpy as np
+import pandas as pd
+import sparse
+import xarray as xr
+
+import extremeweatherbench.utils as utils
+
+logger = logging.getLogger(__name__)
+
+# Columns for the evaluation output dataframe
+OUTPUT_COLUMNS = [
+    "value",
+    "lead_time",
+    "init_time",
+    "target_variable",
+    "metric",
+    "forecast_source",
+    "target_source",
+    "case_id_number",
+    "event_type",
+]
+
+# forecast_variable is dropped when converting to a dataframe.
+METADATA_COORDS = (
+    "metric",
+    "target_variable",
+    "forecast_variable",
+    "forecast_source",
+    "target_source",
+    "case_id_number",
+    "event_type",
+)
+
+# These become dimensions of the merged Dataset; event_type rides along
+# case_id_number instead, and target/forecast_variable become the data
+# variable name rather than dimensions.
+_METADATA_DIMS = ("case_id_number", "metric", "forecast_source", "target_source")
+
+# A dense case_id_number x metric x ... x latitude x longitude hypercube
+# grows fast for unaggregated spatial results; past this many elements,
+# nudge the caller towards sparse=True instead of exhausting memory.
+_DENSE_SIZE_WARNING_THRESHOLD = 1_000_000
+
+
+def annotate_metric_result(result: xr.DataArray, **metadata) -> xr.DataArray:
+    """Attach evaluation metadata to a metric result as scalar coords.
+
+    Args:
+        result: The metric result to annotate.
+        **metadata: Scalar metadata to attach, typically the fields in
+            METADATA_COORDS.
+
+    Returns:
+        The result with metadata assigned as non-dim coords.
+    """
+    return result.assign_coords(metadata)
+
+
+def _ensure_output_schema(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure dataframe conforms to OUTPUT_COLUMNS schema.
+
+    Args:
+        df: Dataframe produced from an annotated metric result, with
+            metadata already present as columns.
+
+    Returns:
+        DataFrame with columns matching OUTPUT_COLUMNS specification,
+        followed by any extra columns (e.g. landfall metadata).
+    """
+    missing_cols = set(OUTPUT_COLUMNS) - set(df.columns)
+
+    # An output requires one of init_time or lead_time. init_time will be present for a
+    # metric that assesses something in an entire model run, such as the onset error of
+    # an event. Lead_time will be present for a metric that assesses something at a
+    # specific forecast hour, such as RMSE. If neither are present, the output is
+    # invalid. Both should not be present for one metric. Thus, one should always be
+    # missing, which is intended behavior.
+    init_time_missing = "init_time" in missing_cols
+    lead_time_missing = "lead_time" in missing_cols
+
+    # Check if exactly one of init_time or lead_time is missing
+    if init_time_missing != lead_time_missing:
+        missing_cols.discard("init_time")
+        missing_cols.discard("lead_time")
+
+    if missing_cols:
+        logger.warning("Missing expected columns: %s.", missing_cols)
+
+    extra_cols = [c for c in df.columns if c not in OUTPUT_COLUMNS]
+    return df.reindex(columns=OUTPUT_COLUMNS + extra_cols)
+
+
+def results_to_dataframe(results: list[xr.DataArray]) -> pd.DataFrame:
+    """Convert annotated metric results into the long-form output dataframe.
+
+    Args:
+        results: Annotated metric results, e.g. from annotate_metric_result.
+
+    Returns:
+        Concatenated long-form DataFrame matching the OUTPUT_COLUMNS schema.
+    """
+    if not results:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+    dataframes = []
+    for result in results:
+        df = result.to_dataframe(name="value").reset_index()
+        df = df.drop(columns="forecast_variable", errors="ignore")
+        dataframes.append(_ensure_output_schema(df))
+    return _safe_concat(dataframes, ignore_index=True)
+
+
+def _safe_concat(
+    dataframes: list[pd.DataFrame], ignore_index: bool = True
+) -> pd.DataFrame:
+    """Safely concatenate DataFrames, filtering out empty ones.
+
+    This function prevents FutureWarnings from pd.concat when dealing with
+    empty or all-NA DataFrames by filtering them out before concatenation.
+    It also handles dtype mismatches by converting to object dtype only when
+    necessary to prevent concatenation warnings.
+
+    Args:
+        dataframes: List of DataFrames to concatenate
+        ignore_index: Whether to ignore index during concatenation
+
+    Returns:
+        Concatenated DataFrame, or empty DataFrame with OUTPUT_COLUMNS if all
+        input DataFrames are empty. Preserves original dtypes when consistent
+        across DataFrames, converts to object dtype only when there are
+        dtype mismatches.
+    """
+    # Filter out problematic DataFrames that would trigger FutureWarning
+    valid_dfs = []
+    for i, df in enumerate(dataframes):
+        # Skip empty DataFrames
+        if df.empty:
+            logger.debug("Skipping empty DataFrame %s", i)
+            continue
+        # Skip DataFrames where all values are NA
+        if df.isna().all().all():
+            logger.debug("Skipping all-NA DataFrame %s", i)
+            continue
+        # Skip DataFrames where all columns are empty/NA
+        if len(df.columns) > 0 and all(df[col].isna().all() for col in df.columns):
+            logger.debug("Skipping DataFrame %s with all-NA columns", i)
+            continue
+
+        valid_dfs.append(df)
+
+    if valid_dfs:
+        # Check for dtype inconsistencies that cause FutureWarning
+        if len(valid_dfs) > 1:
+            # Check if there are dtype mismatches between DataFrames
+            reference_df = valid_dfs[0]
+            has_dtype_mismatch = False
+
+            for df in valid_dfs[1:]:
+                # Check if columns have different dtypes across DataFrames
+                for col in reference_df.columns:
+                    if col in df.columns:
+                        if reference_df[col].dtype != df[col].dtype:
+                            has_dtype_mismatch = True
+                            break
+                if has_dtype_mismatch:
+                    break
+
+            if has_dtype_mismatch:
+                # Only convert to object dtype if there are mismatches
+                consistent_dfs = [df.astype(object) for df in valid_dfs]
+                return pd.concat(consistent_dfs, ignore_index=ignore_index)
+
+        # No dtype mismatches, concatenate normally
+        return pd.concat(valid_dfs, ignore_index=ignore_index)
+    else:
+        return pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+
+def _variable_name(forecast_variable: str, target_variable: str) -> str:
+    """Name a merged data variable from its forecast/target variable pair."""
+    if forecast_variable == target_variable:
+        return target_variable
+    return f"{forecast_variable}_vs_{target_variable}"
+
+
+def _sentinel_for_dtype(dtype: np.dtype) -> object:
+    """Pick an out-of-band coordinate value to pad a dim a result lacks.
+
+    Args:
+        dtype: The dtype of the dimension coordinate elsewhere in the run.
+
+    Returns:
+        NaT for datetime/timedelta dtypes, otherwise NaN.
+    """
+    if np.issubdtype(dtype, np.datetime64):
+        return np.datetime64("NaT", "ns")
+    if np.issubdtype(dtype, np.timedelta64):
+        return np.timedelta64("NaT", "ns")
+    return np.nan
+
+
+_PEAK_TIME_COORDS = ("init_time", "lead_time")
+
+
+def _scatter_peak_time_coord(result: xr.DataArray) -> xr.DataArray:
+    """Turn a peak metric's verifying lead/init time into a real dim.
+
+    Peak metrics reduce over a run but report against the lead_time (or
+    init_time) at which that run verified: one of the pair is the
+    result's own dim, the other rides along it as a non-dim coord. A
+    MultiIndex over both, then unstacked, scatters each value to its
+    true position instead of leaving the pair to collide downstream.
+
+    Args:
+        result: A single annotated metric result.
+
+    Returns:
+        result unchanged, unless it carries exactly one of init_time/
+        lead_time as its own dim and the other as a non-dim coord along
+        it, in which case both become dims of the returned result.
+    """
+    own_dim = next((d for d in _PEAK_TIME_COORDS if d in result.dims), None)
+    other = next((c for c in _PEAK_TIME_COORDS if c != own_dim), None)
+    if own_dim is None or other not in result.coords or other in result.dims:
+        return result
+    return result.set_index(__scatter_idx=(own_dim, other)).unstack("__scatter_idx")
+
+
+def _collect_own_dim_dtypes(results: list[xr.DataArray]) -> dict[str, np.dtype]:
+    """Find every non-metadata dim used anywhere in the run, with its dtype."""
+    dim_dtypes: dict[str, np.dtype] = {}
+    for result in results:
+        for dim in result.dims:
+            if dim in _METADATA_DIMS or dim in dim_dtypes:
+                continue
+            dim_dtypes[dim] = (
+                result.coords[dim].dtype
+                if dim in result.coords
+                else np.dtype("float64")
+            )
+    return dim_dtypes
+
+
+def _result_to_padded_dataset(
+    result: xr.DataArray, own_dim_dtypes: dict[str, np.dtype]
+) -> xr.Dataset:
+    """Convert one annotated result into a slab ready to merge into a run.
+
+    Promotes non-dim coords other than metadata into data variables (they
+    otherwise conflict across results that share a dim label but not the
+    coord's value, e.g. landfall coords riding along init_time), pads in
+    any dim used elsewhere in the run but absent from this result (so
+    xarray can't silently broadcast this result's values across it), then
+    expand_dims the scalar metadata coords into length-1 dims.
+
+    Args:
+        result: A single annotated metric result.
+        own_dim_dtypes: Dtypes of every non-metadata dim seen in the run,
+            from _collect_own_dim_dtypes.
+
+    Returns:
+        A Dataset with one data variable per (variable pair, extra coord),
+        padded to case_id_number/metric/forecast_source/target_source.
+    """
+    event_type = result.coords["event_type"].item()
+    var_name = _variable_name(
+        result.coords["forecast_variable"].item(),
+        result.coords["target_variable"].item(),
+    )
+
+    extra_coords = [
+        c for c in result.coords if c not in METADATA_COORDS and c not in result.dims
+    ]
+    ds = result.to_dataset(name=var_name)
+    if extra_coords:
+        ds = ds.reset_coords(extra_coords)
+    ds = ds.drop_vars(["target_variable", "forecast_variable"])
+
+    for dim in own_dim_dtypes:
+        if dim not in ds.dims:
+            ds = ds.expand_dims({dim: [_sentinel_for_dtype(own_dim_dtypes[dim])]})
+
+    ds = ds.expand_dims(list(_METADATA_DIMS))
+    return ds.assign_coords(event_type=("case_id_number", [event_type]))
+
+
+def _estimate_dense_size(datasets: list[xr.Dataset]) -> int:
+    """Estimate the element count of the dense hypercube these would pad to."""
+    dim_labels: dict[str, set] = {}
+    for ds in datasets:
+        for dim, index in ds.indexes.items():
+            dim_labels.setdefault(dim, set()).update(index.values.tolist())
+    size = 1
+    for labels in dim_labels.values():
+        size *= max(len(labels), 1)
+    return size
+
+
+def _maybe_chunk(ds: xr.Dataset) -> xr.Dataset:
+    """Chunk a Dataset with dask unless it is already dask-backed."""
+    if any(isinstance(v.data, da.Array) for v in ds.data_vars.values()):
+        return ds
+    return ds.chunk()
+
+
+def _sparsifiable(dtype: np.dtype) -> bool:
+    """Whether sparse.COO can hold dtype with a well-defined fill value."""
+    return (
+        np.issubdtype(dtype, np.floating)
+        or np.issubdtype(dtype, np.datetime64)
+        or np.issubdtype(dtype, np.timedelta64)
+    )
+
+
+def _collect_data_var_info(
+    datasets: list[xr.Dataset],
+) -> dict[str, tuple[tuple[str, ...], np.dtype]]:
+    """First-seen dims and dtype for every data variable across all slabs."""
+    info: dict[str, tuple[tuple[str, ...], np.dtype]] = {}
+    for ds in datasets:
+        for name, variable in ds.data_vars.items():
+            if name not in info:
+                info[name] = (variable.dims, variable.dtype)
+    return info
+
+
+def _positions_in_union(index: pd.Index, values: np.ndarray) -> np.ndarray:
+    """Map values onto integer positions in index, resolving null padding.
+
+    get_indexer can't match a null placeholder (NaT/NaN) by value, so an
+    unmatched query is pointed at index's own (unique) null entry.
+    """
+    positions = index.get_indexer(values)
+    unmatched = positions == -1
+    if unmatched.any():
+        positions[unmatched] = np.flatnonzero(index.isna())[0]
+    return positions
+
+
+def _scatter_variable(
+    dims: tuple[str, ...],
+    dtype: np.dtype,
+    name: str,
+    datasets: list[xr.Dataset],
+    dim_index: dict[str, pd.Index],
+) -> Union[sparse.COO, np.ndarray]:
+    """Scatter one data variable's values from every slab that has it.
+
+    Positions are resolved per slab, per dim, straight into the run-wide
+    union index, so this never needs xr.merge's fillna-based combine.
+    """
+    shape = tuple(len(dim_index[d]) for d in dims)
+    fill_value = _sentinel_for_dtype(dtype)
+
+    coord_rows: list[list[np.ndarray]] = [[] for _ in dims]
+    value_chunks: list[np.ndarray] = []
+    for ds in datasets:
+        if name not in ds.data_vars:
+            continue
+        variable = ds.data_vars[name]
+        positions = {
+            d: _positions_in_union(dim_index[d], ds.indexes[d].values)
+            for d in variable.dims
+        }
+        grids = np.meshgrid(*(positions[d] for d in variable.dims), indexing="ij")
+        for row, d in zip(coord_rows, dims):
+            row.append(grids[variable.dims.index(d)].ravel())
+        value_chunks.append(np.asarray(variable.data).ravel())
+
+    coords = np.array([np.concatenate(row) for row in coord_rows], dtype=np.intp)
+    values = np.concatenate(value_chunks)
+
+    if _sparsifiable(dtype):
+        return sparse.COO(
+            coords=coords, data=values, shape=shape, fill_value=fill_value
+        )
+    dense = np.full(shape, fill_value, dtype=object)
+    dense[tuple(coords)] = values
+    return dense
+
+
+def _scatter_to_sparse_dataset(datasets: list[xr.Dataset]) -> xr.Dataset:
+    """Combine padded slabs into one Dataset without going through xr.merge.
+
+    xr.merge's compat="no_conflicts" combines same-named variables via
+    fillna, which broadcasts through duck_array_ops.transpose whenever two
+    slabs disagree on that variable's dim order -- exactly the case where a
+    variable shows up from metrics that preserve different dims. sparse
+    0.19.1 has no module-level transpose, so that combine crashes for any
+    sparse-backed variable. Scattering each variable's values directly into
+    its own array, in the run's outer-joined dim order, avoids it.
+
+    Non-sparsifiable data variables (anything but floating/datetime64/
+    timedelta64) are merged the ordinary way instead, since they're never
+    sparse-backed and so can't trip the same bug.
+    """
+    var_info = _collect_data_var_info(datasets)
+    sparsifiable = {n for n, (_, dt) in var_info.items() if _sparsifiable(dt)}
+
+    dense_slabs = [ds.drop_vars(sparsifiable, errors="ignore") for ds in datasets]
+    dense_ds = xr.merge(dense_slabs, join="outer", compat="no_conflicts")
+
+    dim_index = {dim: dense_ds.indexes[dim] for dim in dense_ds.dims}
+    scattered = {
+        name: (dims, _scatter_variable(dims, dtype, name, datasets, dim_index))
+        for name, (dims, dtype) in var_info.items()
+        if name in sparsifiable
+    }
+    return xr.Dataset(
+        data_vars={**dense_ds.data_vars, **scattered}, coords=dense_ds.coords
+    )
+
+
+def results_to_dataset(results: list[xr.DataArray], sparse: bool = False) -> xr.Dataset:
+    """Build one flat Dataset from a whole run's annotated metric results.
+
+    Each result becomes a length-1 slab along case_id_number, metric,
+    forecast_source, and target_source (via expand_dims on the scalar
+    metadata coords annotate_metric_result attached), keeping whatever
+    dims the metric itself preserved (lead_time, init_time, latitude,
+    longitude, level, ...). A peak metric result that carries both
+    init_time and lead_time (see _scatter_peak_time_coord) occupies
+    both dims. Slabs are combined with an outer join so each result
+    occupies its own disjoint hyper-slab; everything else is NaN (or
+    absent, if sparse=True).
+
+    Args:
+        results: A flat list of annotated metric results for a run.
+        sparse: If True, back data variables with sparse.COO (fill_value
+            NaN) instead of densifying the padded hypercube.
+
+    Returns:
+        The merged Dataset, or an empty Dataset if results is empty.
+    """
+    if not results:
+        return xr.Dataset()
+
+    results = [_scatter_peak_time_coord(r) for r in results]
+    own_dim_dtypes = _collect_own_dim_dtypes(results)
+    datasets = [_result_to_padded_dataset(r, own_dim_dtypes) for r in results]
+
+    if sparse:
+        return _scatter_to_sparse_dataset(datasets)
+
+    dense_size = _estimate_dense_size(datasets)
+    if dense_size > _DENSE_SIZE_WARNING_THRESHOLD:
+        logger.warning(
+            "Densifying this run's results would require an estimated "
+            "%d elements per data variable. Pass sparse=True to avoid "
+            "materializing the padded hypercube.",
+            dense_size,
+        )
+    datasets = [_maybe_chunk(ds) for ds in datasets]
+    return xr.merge(datasets, join="outer", compat="no_conflicts")
+
+
+def _label_has_data(obj: Union[xr.Dataset, xr.DataArray], dim: str) -> xr.DataArray:
+    """Find which labels along dim have at least one non-NaN value."""
+    other_dims = [d for d in obj.dims if d != dim]
+    reduced = obj.notnull().any(other_dims) if other_dims else obj.notnull()
+    if isinstance(reduced, xr.Dataset):
+        reduced = reduced.to_array().any("variable")
+    return reduced
+
+
+def drop_empty_slices(
+    obj: Union[xr.Dataset, xr.DataArray],
+) -> Union[xr.Dataset, xr.DataArray]:
+    """Collapse the placeholder padding results_to_dataset introduces.
+
+    Meant to be called after selecting down to a single metric (and,
+    typically, a single case), not on the full run's cube: there, every
+    dim mixes real and placeholder labels, so nothing is all-NaN and
+    this is close to a no-op.
+
+    For each dim, drops labels that are entirely NaN, then drops any
+    dim left with only a single null (placeholder) label. Applied to
+    an RMSE selection, this removes the untouched init_time labels and
+    then the now-single-label placeholder init_time dim, leaving a
+    clean series over lead_time; a DurationMeanError selection
+    collapses symmetrically to a clean series over init_time.
+
+    Does not work on sparse.COO-backed input (from results_to_dataset's
+    sparse=True): indexing with a boolean mask ends up calling .values,
+    which sparse.COO refuses to densify implicitly. Densify first with
+    utils.maybe_densify_dataarray if obj may be sparse-backed.
+
+    Args:
+        obj: A Dataset or DataArray, typically a selection out of
+            results_to_dataset's output.
+
+    Returns:
+        The same type as obj, with empty slices and placeholder-only
+        dims dropped.
+    """
+    result = obj
+    for dim in list(result.dims):
+        has_data = _label_has_data(result, dim)
+        result = result.isel({dim: has_data.compute().values})
+
+    placeholder_dims = [
+        dim
+        for dim in result.dims
+        if result.sizes[dim] == 1 and pd.isnull(result[dim].values[0])
+    ]
+    return result.squeeze(placeholder_dims, drop=True)
+
+
+def write_results(
+    results: Union[list[xr.DataArray], pd.DataFrame, xr.Dataset],
+    path: Union[str, pathlib.Path],
+    output_format: str = "csv",
+    sparse: bool = False,
+) -> None:
+    """Write evaluation results to disk in the given format.
+
+    Args:
+        results: A flat list of annotated metric results, or the
+            already-converted output: a DataFrame for output_format
+            "csv", or a Dataset for output_format "netcdf"/"zarr".
+        path: Destination path.
+        output_format: One of "csv", "netcdf", or "zarr".
+        sparse: Forwarded to results_to_dataset when results is a list
+            and output_format is "netcdf" or "zarr".
+
+    Raises:
+        ValueError: If output_format is not "csv", "netcdf", or "zarr".
+    """
+    if output_format == "csv":
+        df = (
+            results
+            if isinstance(results, pd.DataFrame)
+            else results_to_dataframe(results)
+        )
+        df.to_csv(path, index=False)
+        return
+
+    if output_format in ("netcdf", "zarr"):
+        ds = (
+            results
+            if isinstance(results, xr.Dataset)
+            else results_to_dataset(results, sparse=sparse)
+        )
+        # netCDF/zarr can't store sparse.COO directly; dask stays lazy.
+        ds = ds.map(utils.maybe_densify_dataarray)
+        # Coords are cheap to materialize and avoid a dtype-inference
+        # warning from writing them as dask arrays.
+        dask_coords = {
+            c: ds.coords[c].compute()
+            for c in ds.coords
+            if isinstance(ds.coords[c].data, da.Array)
+        }
+        if dask_coords:
+            ds = ds.assign_coords(dask_coords)
+        if output_format == "netcdf":
+            ds.to_netcdf(path)
+        else:
+            ds.to_zarr(path, mode="w")
+        return
+
+    raise ValueError(
+        f"Unknown output_format '{output_format}'. Expected one of: "
+        "'csv', 'netcdf', 'zarr'."
+    )

--- a/src/extremeweatherbench/outputs.py
+++ b/src/extremeweatherbench/outputs.py
@@ -2,7 +2,7 @@
 
 import logging
 import pathlib
-from typing import Union
+from typing import cast
 
 import dask.array as da
 import numpy as np
@@ -10,7 +10,7 @@ import pandas as pd
 import sparse
 import xarray as xr
 
-import extremeweatherbench.utils as utils
+from extremeweatherbench import utils
 
 logger = logging.getLogger(__name__)
 
@@ -154,10 +154,9 @@ def _safe_concat(
             for df in valid_dfs[1:]:
                 # Check if columns have different dtypes across DataFrames
                 for col in reference_df.columns:
-                    if col in df.columns:
-                        if reference_df[col].dtype != df[col].dtype:
-                            has_dtype_mismatch = True
-                            break
+                    if col in df.columns and reference_df[col].dtype != df[col].dtype:
+                        has_dtype_mismatch = True
+                        break
                 if has_dtype_mismatch:
                     break
 
@@ -177,6 +176,11 @@ def _variable_name(forecast_variable: str, target_variable: str) -> str:
     if forecast_variable == target_variable:
         return target_variable
     return f"{forecast_variable}_vs_{target_variable}"
+
+
+def _is_temporal_dtype(dtype: np.dtype) -> bool:
+    """Whether dtype is datetime64 or timedelta64."""
+    return np.issubdtype(dtype, np.datetime64) or np.issubdtype(dtype, np.timedelta64)
 
 
 def _sentinel_for_dtype(dtype: np.dtype) -> object:
@@ -223,17 +227,28 @@ def _scatter_peak_time_coord(result: xr.DataArray) -> xr.DataArray:
 
 
 def _collect_own_dim_dtypes(results: list[xr.DataArray]) -> dict[str, np.dtype]:
-    """Find every non-metadata dim used anywhere in the run, with its dtype."""
+    """Find every non-metadata dim used anywhere in the run, with its dtype.
+
+    Prefers a datetime or timedelta dtype when the same dim also appears
+    with an untyped coordinate, such as the int64 RangeIndex from an
+    empty fallback.
+    """
     dim_dtypes: dict[str, np.dtype] = {}
     for result in results:
         for dim in result.dims:
-            if dim in _METADATA_DIMS or dim in dim_dtypes:
+            if dim in _METADATA_DIMS:
                 continue
-            dim_dtypes[dim] = (
-                result.coords[dim].dtype
-                if dim in result.coords
+            dim_name = cast(str, dim)
+            dtype = (
+                result.coords[dim_name].dtype
+                if dim_name in result.coords
                 else np.dtype("float64")
             )
+            existing = dim_dtypes.get(dim_name)
+            if existing is None or (
+                _is_temporal_dtype(dtype) and not _is_temporal_dtype(existing)
+            ):
+                dim_dtypes[dim_name] = dtype
     return dim_dtypes
 
 
@@ -246,7 +261,9 @@ def _result_to_padded_dataset(
     otherwise conflict across results that share a dim label but not the
     coord's value, e.g. landfall coords riding along init_time), pads in
     any dim used elsewhere in the run but absent from this result (so
-    xarray can't silently broadcast this result's values across it), then
+    xarray can't silently broadcast this result's values across it),
+    rewrites a size-1 untyped dim to a temporal sentinel when the run
+    already has a datetime or timedelta dtype for that dim, then
     expand_dims the scalar metadata coords into length-1 dims.
 
     Args:
@@ -272,9 +289,17 @@ def _result_to_padded_dataset(
         ds = ds.reset_coords(extra_coords)
     ds = ds.drop_vars(["target_variable", "forecast_variable"])
 
-    for dim in own_dim_dtypes:
+    for dim, dtype in own_dim_dtypes.items():
         if dim not in ds.dims:
-            ds = ds.expand_dims({dim: [_sentinel_for_dtype(own_dim_dtypes[dim])]})
+            ds = ds.expand_dims({dim: [_sentinel_for_dtype(dtype)]})
+            continue
+        current = ds.coords[dim].dtype if dim in ds.coords else np.dtype("float64")
+        if (
+            ds.sizes[dim] == 1
+            and _is_temporal_dtype(dtype)
+            and not _is_temporal_dtype(current)
+        ):
+            ds = ds.assign_coords({dim: [_sentinel_for_dtype(dtype)]})
 
     ds = ds.expand_dims(list(_METADATA_DIMS))
     return ds.assign_coords(event_type=("case_id_number", [event_type]))
@@ -316,7 +341,10 @@ def _collect_data_var_info(
     for ds in datasets:
         for name, variable in ds.data_vars.items():
             if name not in info:
-                info[name] = (variable.dims, variable.dtype)
+                info[cast(str, name)] = (
+                    cast(tuple[str, ...], variable.dims),
+                    variable.dtype,
+                )
     return info
 
 
@@ -326,7 +354,7 @@ def _positions_in_union(index: pd.Index, values: np.ndarray) -> np.ndarray:
     get_indexer can't match a null placeholder (NaT/NaN) by value, so an
     unmatched query is pointed at index's own (unique) null entry.
     """
-    positions = index.get_indexer(values)
+    positions = index.get_indexer(values)  # type: ignore[arg-type]
     unmatched = positions == -1
     if unmatched.any():
         positions[unmatched] = np.flatnonzero(index.isna())[0]
@@ -339,7 +367,7 @@ def _scatter_variable(
     name: str,
     datasets: list[xr.Dataset],
     dim_index: dict[str, pd.Index],
-) -> Union[sparse.COO, np.ndarray]:
+) -> sparse.COO | np.ndarray:
     """Scatter one data variable's values from every slab that has it.
 
     Positions are resolved per slab, per dim, straight into the run-wide
@@ -355,7 +383,7 @@ def _scatter_variable(
             continue
         variable = ds.data_vars[name]
         positions = {
-            d: _positions_in_union(dim_index[d], ds.indexes[d].values)
+            d: _positions_in_union(dim_index[cast(str, d)], ds.indexes[d].values)
             for d in variable.dims
         }
         grids = np.meshgrid(*(positions[d] for d in variable.dims), indexing="ij")
@@ -396,7 +424,7 @@ def _scatter_to_sparse_dataset(datasets: list[xr.Dataset]) -> xr.Dataset:
     dense_slabs = [ds.drop_vars(sparsifiable, errors="ignore") for ds in datasets]
     dense_ds = xr.merge(dense_slabs, join="outer", compat="no_conflicts")
 
-    dim_index = {dim: dense_ds.indexes[dim] for dim in dense_ds.dims}
+    dim_index = {cast(str, dim): dense_ds.indexes[dim] for dim in dense_ds.dims}
     scattered = {
         name: (dims, _scatter_variable(dims, dtype, name, datasets, dim_index))
         for name, (dims, dtype) in var_info.items()
@@ -450,7 +478,7 @@ def results_to_dataset(results: list[xr.DataArray], sparse: bool = False) -> xr.
     return xr.merge(datasets, join="outer", compat="no_conflicts")
 
 
-def _label_has_data(obj: Union[xr.Dataset, xr.DataArray], dim: str) -> xr.DataArray:
+def _label_has_data(obj: xr.Dataset | xr.DataArray, dim: str) -> xr.DataArray:
     """Find which labels along dim have at least one non-NaN value."""
     other_dims = [d for d in obj.dims if d != dim]
     reduced = obj.notnull().any(other_dims) if other_dims else obj.notnull()
@@ -460,8 +488,8 @@ def _label_has_data(obj: Union[xr.Dataset, xr.DataArray], dim: str) -> xr.DataAr
 
 
 def drop_empty_slices(
-    obj: Union[xr.Dataset, xr.DataArray],
-) -> Union[xr.Dataset, xr.DataArray]:
+    obj: xr.Dataset | xr.DataArray,
+) -> xr.Dataset | xr.DataArray:
     """Collapse the placeholder padding results_to_dataset introduces.
 
     Meant to be called after selecting down to a single metric (and,
@@ -491,7 +519,7 @@ def drop_empty_slices(
     """
     result = obj
     for dim in list(result.dims):
-        has_data = _label_has_data(result, dim)
+        has_data = _label_has_data(result, cast(str, dim))
         result = result.isel({dim: has_data.compute().values})
 
     placeholder_dims = [
@@ -503,8 +531,8 @@ def drop_empty_slices(
 
 
 def write_results(
-    results: Union[list[xr.DataArray], pd.DataFrame, xr.Dataset],
-    path: Union[str, pathlib.Path],
+    results: list[xr.DataArray] | pd.DataFrame | xr.Dataset,
+    path: str | pathlib.Path,
     output_format: str = "csv",
     sparse: bool = False,
 ) -> None:
@@ -523,20 +551,18 @@ def write_results(
         ValueError: If output_format is not "csv", "netcdf", or "zarr".
     """
     if output_format == "csv":
-        df = (
-            results
-            if isinstance(results, pd.DataFrame)
-            else results_to_dataframe(results)
-        )
+        if isinstance(results, pd.DataFrame):
+            df = results
+        else:
+            df = results_to_dataframe(cast(list[xr.DataArray], results))
         df.to_csv(path, index=False)
         return
 
     if output_format in ("netcdf", "zarr"):
-        ds = (
-            results
-            if isinstance(results, xr.Dataset)
-            else results_to_dataset(results, sparse=sparse)
-        )
+        if isinstance(results, xr.Dataset):
+            ds = results
+        else:
+            ds = results_to_dataset(cast(list[xr.DataArray], results), sparse=sparse)
         # netCDF/zarr can't store sparse.COO directly; dask stays lazy.
         ds = ds.map(utils.maybe_densify_dataarray)
         # Coords are cheap to materialize and avoid a dtype-inference

--- a/src/extremeweatherbench/outputs.py
+++ b/src/extremeweatherbench/outputs.py
@@ -137,22 +137,11 @@ def _safe_concat(
         across DataFrames, converts to object dtype only when there are
         dtype mismatches.
     """
-    # Filter out problematic DataFrames that would trigger FutureWarning
     valid_dfs = []
     for i, df in enumerate(dataframes):
-        # Skip empty DataFrames
-        if df.empty:
-            logger.debug("Skipping empty DataFrame %s", i)
+        if df.empty or df.isna().all().all():
+            logger.debug("Skipping empty or all-NA DataFrame %s", i)
             continue
-        # Skip DataFrames where all values are NA
-        if df.isna().all().all():
-            logger.debug("Skipping all-NA DataFrame %s", i)
-            continue
-        # Skip DataFrames where all columns are empty/NA
-        if len(df.columns) > 0 and all(df[col].isna().all() for col in df.columns):
-            logger.debug("Skipping DataFrame %s with all-NA columns", i)
-            continue
-
         valid_dfs.append(df)
 
     if valid_dfs:

--- a/src/extremeweatherbench/regions.py
+++ b/src/extremeweatherbench/regions.py
@@ -613,9 +613,9 @@ def subset_cases_to_region(
 
 def subset_results_to_region(
     region: RegionSubsetter,
-    results: Union[pd.DataFrame, xr.Dataset],
+    results: pd.DataFrame | xr.Dataset,
     case_list: "list[cases.IndividualCase]",
-) -> Union[pd.DataFrame, xr.Dataset]:
+) -> pd.DataFrame | xr.Dataset:
     """Subset results by region using case_id_number.
 
     This is a convenience function that creates a RegionSubsetter and applies it to

--- a/src/extremeweatherbench/regions.py
+++ b/src/extremeweatherbench/regions.py
@@ -613,31 +613,41 @@ def subset_cases_to_region(
 
 def subset_results_to_region(
     region: RegionSubsetter,
-    results_df: pd.DataFrame,
+    results: Union[pd.DataFrame, xr.Dataset],
     case_list: "list[cases.IndividualCase]",
-) -> pd.DataFrame:
-    """Subset results DataFrame by region using case_id_number.
+) -> Union[pd.DataFrame, xr.Dataset]:
+    """Subset results by region using case_id_number.
 
     This is a convenience function that creates a RegionSubsetter and applies it to
-    the results DataFrame that is output from ExtremeWeatherBench.run().
+    the results output from ExtremeWeatherBench.run(), whether that is the
+    long-form DataFrame or the flat Dataset.
 
     Args:
         region: The region to subset to. Can be a Region object or a
             dictionary of bounds with keys "latitude_min", "latitude_max",
             "longitude_min", and "longitude_max".
-        results_df: DataFrame with results from ExtremeWeatherBench.run()
+        results: DataFrame or Dataset with results from
+            ExtremeWeatherBench.run()
         case_list: The original case list to determine which
             case_id_numbers correspond to cases in the region
 
     Returns:
-        Subset DataFrame containing only results for cases in the region
+        Subset results containing only data for cases in the region
     """
     # Get the case IDs that should be included
     subset_cases = region.subset_case_list(case_list)
     included_case_ids = {case.case_id_number for case in subset_cases}
 
+    if isinstance(results, xr.Dataset):
+        present_ids = [
+            case_id
+            for case_id in results["case_id_number"].values
+            if case_id in included_case_ids
+        ]
+        return results.sel(case_id_number=present_ids)
+
     # Filter the results DataFrame
-    return results_df[results_df["case_id_number"].isin(included_case_ids)]
+    return results[results["case_id_number"].isin(included_case_ids)]
 
 
 def _adjust_bounds_to_dataset_convention(

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -785,19 +785,13 @@ def convert_day_yearofday_to_time(
     Returns:
         The dataset or dataarray with a new time coordinate.
     """
-    # Create a new time coordinate by combining dayofyear and hour
-    time_dim = pd.date_range(
-        start=f"{year}-01-01",
-        periods=len(dataset["dayofyear"]) * len(dataset["hour"]),
-        freq="6h",
+    stacked = dataset.stack(valid_time=("dayofyear", "hour"))
+    times = pd.to_datetime(
+        year * 1000 + stacked.dayofyear.values.astype(int), format="%Y%j"
+    ) + pd.to_timedelta(stacked.hour.values.astype(int), unit="h")
+    return stacked.reset_index("valid_time", drop=True).assign_coords(
+        valid_time=("valid_time", times)
     )
-    dataset = dataset.stack(valid_time=("dayofyear", "hour")).drop_vars(
-        ["dayofyear", "hour"]
-    )
-    # Assign the new time coordinate to the dataset
-    dataset = dataset.assign_coords(valid_time=time_dim)
-
-    return dataset
 
 
 def interp_climatology_to_target(

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -157,6 +157,25 @@ def convert_longitude_to_180(
         return np.mod(longitude - 180, 360) - 180
 
 
+# Cached Natural Earth land masks keyed by lat/lon byte values.
+_REGIONMASK_LAND_CACHE: dict[tuple[bytes, bytes], xr.DataArray] = {}
+
+
+def regionmask_land_110(
+    latitude: xr.DataArray | npt.NDArray, longitude: xr.DataArray | npt.NDArray
+) -> xr.DataArray:
+    """Land mask from Natural Earth 110m. 0 is land. Cached per grid."""
+    lat_vals = np.asarray(latitude)
+    lon_vals = np.asarray(longitude)
+    key = (lat_vals.tobytes(), lon_vals.tobytes())
+    mask = _REGIONMASK_LAND_CACHE.get(key)
+    if mask is None:
+        land = regionmask.defined_regions.natural_earth_v5_0_0.land_110
+        mask = land.mask(longitude, latitude)
+        _REGIONMASK_LAND_CACHE[key] = mask
+    return mask
+
+
 def remove_ocean_gridpoints(dataset: xr.Dataset) -> xr.Dataset:
     """Subset a dataset to only include land gridpoints based on a land-sea mask.
 
@@ -166,8 +185,7 @@ def remove_ocean_gridpoints(dataset: xr.Dataset) -> xr.Dataset:
     Returns:
         The dataset masked to only land gridpoints.
     """
-    land = regionmask.defined_regions.natural_earth_v5_0_0.land_110
-    land_sea_mask = land.mask(dataset.longitude, dataset.latitude)
+    land_sea_mask = regionmask_land_110(dataset.latitude, dataset.longitude)
     land_mask = land_sea_mask == 0
     # Subset the dataset to only include land gridpoints
     return dataset.where(land_mask)
@@ -439,6 +457,9 @@ def _lead_time_as_timedelta(lead_time: xr.DataArray) -> xr.DataArray:
 def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
     """Convert the init_time coordinate to a valid_time coordinate.
 
+    Each lead is reindexed onto the union of valid times, then concatenated.
+    That matches concat(..., join="outer") without growing aligns.
+
     Args:
         ds: The dataset to convert with lead_time and init_time coordinates.
 
@@ -446,20 +467,22 @@ def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
         The dataset with a valid_time coordinate.
     """
     lead_time = _lead_time_as_timedelta(ds.lead_time)
-    valid_time = xr.DataArray(
-        ds.init_time, coords={"init_time": ds.init_time}
-    ) + xr.DataArray(lead_time, coords={"lead_time": ds.lead_time})
-    ds = ds.assign_coords(valid_time=valid_time)
-    return xr.concat(
-        [
-            ds.sel(lead_time=lead).swap_dims({"init_time": "valid_time"})
-            for lead in ds.lead_time
-        ],
-        "lead_time",
+    ds = ds.assign_coords(valid_time=ds.init_time + lead_time)
+    vt_union = np.unique(ds.valid_time.values.reshape(-1))
+    pieces = [
+        ds.isel(lead_time=i)
+        .swap_dims({"init_time": "valid_time"})
+        .reindex(valid_time=vt_union)
+        for i in range(ds.sizes["lead_time"])
+    ]
+    out = xr.concat(
+        pieces,
+        dim="lead_time",
         coords="different",
         compat="equals",
         join="outer",
     )
+    return out.assign_coords(lead_time=("lead_time", ds.lead_time.values))
 
 
 def convert_valid_time_to_init_time(da: xr.DataArray) -> xr.DataArray:

--- a/tests/test_atmospheric_river.py
+++ b/tests/test_atmospheric_river.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from scipy import ndimage
 
 from extremeweatherbench import calc
 from extremeweatherbench.events import atmospheric_river
@@ -1009,3 +1010,52 @@ class TestBuildMaskAndLandIntersection:
 
         # Values should be 0 or 1 (boolean mask)
         assert set(ar_mask.values.flatten()).issubset({0, 1})
+
+
+def _assert_same_cc_partition(a: np.ndarray, b: np.ndarray) -> None:
+    """True pixels must form the same connected components in a and b."""
+    a, b = np.asarray(a), np.asarray(b)
+    np.testing.assert_array_equal(a > 0, b > 0)
+    for lab in np.unique(a[a > 0]):
+        assert len(np.unique(b[a == lab])) == 1
+    for lab in np.unique(b[b > 0]):
+        assert len(np.unique(a[b == lab])) == 1
+
+
+class TestTimeLinkedLabeling:
+    """Tests for 2D labels plus union-find across valid_time."""
+
+    def test_3d_matches_ndimage_label_partition(self):
+        """3D (valid_time, lat, lon) matches scipy 6-connectivity labeling."""
+        rng_local = np.random.default_rng(0)
+        mask = rng_local.random((8, 12, 10)) > 0.65
+        mask[2:6, 4, 5] = True
+        expected, _ = ndimage.label(mask)
+        got = atmospheric_river._label_objects_time_linked(
+            mask, ["valid_time", "latitude", "longitude"], "valid_time"
+        )
+        _assert_same_cc_partition(expected, got)
+
+    def test_init_time_does_not_merge_across_inits(self):
+        """Objects at the same lat/lon in adjacent inits stay separate."""
+        mask = np.zeros((2, 3, 5, 5), dtype=bool)
+        mask[:, 0, 2, 2] = True
+        mask[:, 0, 2, 3] = True
+        labeled = atmospheric_river._label_objects_time_linked(
+            mask,
+            ["init_time", "valid_time", "latitude", "longitude"],
+            "valid_time",
+        )
+        labs0 = set(np.unique(labeled[0][labeled[0] > 0]))
+        labs1 = set(np.unique(labeled[1][labeled[1] > 0]))
+        assert labs0 and labs1
+        assert labs0.isdisjoint(labs1)
+
+    def test_time_adjacent_pixels_are_linked(self):
+        """The same grid cell at consecutive times is one object."""
+        mask = np.zeros((4, 3, 3), dtype=bool)
+        mask[:, 1, 1] = True
+        labeled = atmospheric_river._label_objects_time_linked(
+            mask, ["valid_time", "latitude", "longitude"], "valid_time"
+        )
+        assert len(np.unique(labeled[labeled > 0])) == 1

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1000,6 +1000,8 @@ class TestFindLandIntersection:
         # Should return intersection
         assert isinstance(result, xr.DataArray)
         assert result.shape == mask.shape
+        expected = xr.where(mask.astype(bool) & land_mask.astype(bool), 1, 0)
+        xr.testing.assert_equal(result, expected)
 
 
 class TestNantrapezoidPressureLevels:

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -260,6 +260,4 @@ class TestMaybeAddSpecificHumidity:
         ds = self._column_ds("air_temperature", "relative_humidity")
         ds["specific_humidity"] = (["level"], np.array([0.01, 0.02]))
         result = defaults._maybe_add_specific_humidity(ds)
-        np.testing.assert_array_equal(
-            result["specific_humidity"].values, [0.01, 0.02]
-        )
+        np.testing.assert_array_equal(result["specific_humidity"].values, [0.01, 0.02])

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -232,3 +232,34 @@ class TestCiraFcnv2PreprocessFunctions:
         heatwave_preprocess = defaults.cira_fcnv2_heatwave_forecast.preprocess
         freeze_preprocess = defaults.cira_fcnv2_freeze_forecast.preprocess
         assert heatwave_preprocess == freeze_preprocess
+
+
+class TestMaybeAddSpecificHumidity:
+    """Tests for humidity preprocess after variable mapping."""
+
+    def _column_ds(self, temp_name, rh_name):
+        return xr.Dataset(
+            {
+                temp_name: (["level"], np.array([280.0, 270.0])),
+                rh_name: (["level"], np.array([50.0, 40.0])),
+            },
+            coords={"level": [1000.0, 850.0]},
+        )
+
+    def test_mapped_names(self):
+        ds = self._column_ds("air_temperature", "relative_humidity")
+        result = defaults._maybe_add_specific_humidity(ds)
+        assert "specific_humidity" in result.data_vars
+
+    def test_original_cira_names(self):
+        ds = self._column_ds("t", "r")
+        result = defaults._maybe_add_specific_humidity(ds)
+        assert "specific_humidity" in result.data_vars
+
+    def test_skips_when_specific_humidity_present(self):
+        ds = self._column_ds("air_temperature", "relative_humidity")
+        ds["specific_humidity"] = (["level"], np.array([0.01, 0.02]))
+        result = defaults._maybe_add_specific_humidity(ds)
+        np.testing.assert_array_equal(
+            result["specific_humidity"].values, [0.01, 0.02]
+        )

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 """Tests for evaluate module."""
 
 import contextlib
+import dataclasses
 import datetime
 import logging
 import pathlib
@@ -77,6 +78,7 @@ def mock_target_base():
     """Create a mock TargetBase object."""
     mock_target = mock.Mock(spec=inputs.TargetBase)
     mock_target.name = "MockTarget"
+    mock_target.source = "mock://target"
     mock_target.variables = ["2m_temperature"]
 
     # Create a dataset with time coordinate for valid_times check
@@ -85,11 +87,12 @@ def mock_target_base():
         coords={"time": time_coords}, attrs={"source": "mock_target"}
     )
 
-    mock_target.open_and_maybe_preprocess_data_from_source.return_value = mock_dataset
+    mock_target._open_data_from_source.return_value = mock_dataset
     mock_target.maybe_map_variable_names.return_value = mock_dataset
     mock_target.subset_data_to_case.return_value = mock_dataset
     mock_target.maybe_convert_to_dataset.return_value = mock_dataset
     mock_target.add_source_to_dataset_attrs.return_value = mock_dataset
+    mock_target.preprocess.return_value = mock_dataset
     mock_target.maybe_align_forecast_to_target.return_value = (
         mock_dataset,
         mock_dataset,
@@ -102,6 +105,7 @@ def mock_forecast_base():
     """Create a mock ForecastBase object."""
     mock_forecast = mock.Mock(spec=inputs.ForecastBase)
     mock_forecast.name = "MockForecast"
+    mock_forecast.source = "mock://forecast"
     mock_forecast.variables = ["surface_air_temperature"]
 
     # Create a dataset with init_time coordinate for valid_times check
@@ -112,11 +116,12 @@ def mock_forecast_base():
         attrs={"source": "mock_forecast"},
     )
 
-    mock_forecast.open_and_maybe_preprocess_data_from_source.return_value = mock_dataset
+    mock_forecast._open_data_from_source.return_value = mock_dataset
     mock_forecast.maybe_map_variable_names.return_value = mock_dataset
     mock_forecast.subset_data_to_case.return_value = mock_dataset
     mock_forecast.maybe_convert_to_dataset.return_value = mock_dataset
     mock_forecast.add_source_to_dataset_attrs.return_value = mock_dataset
+    mock_forecast.preprocess.return_value = mock_dataset
     return mock_forecast
 
 
@@ -644,7 +649,7 @@ class TestOutputFormatWiring:
                 ewb.run_evaluation(output_format="geojson")
 
     @mock.patch("extremeweatherbench.evaluate._run_evaluation")
-    def test_run_deprecated_output_format_xarray_returns_dataset(
+    def test_run_deprecated_delegates_to_run_evaluation(
         self,
         mock_run_evaluation,
         sample_cases_list,
@@ -663,28 +668,6 @@ class TestOutputFormatWiring:
             result = ewb.run(n_jobs=1, output_format="xarray")
 
             assert isinstance(result, xr.Dataset)
-
-    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
-    def test_run_deprecated_unknown_output_format_raises_value_error(
-        self,
-        mock_run_evaluation,
-        sample_cases_list,
-        sample_evaluation_object,
-        sample_case_operator,
-    ):
-        with mock.patch.object(
-            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
-        ):
-            mock_run_evaluation.return_value = [
-                [_annotated_result(value=1.0, case_id_number=1)]
-            ]
-            ewb = evaluate.ExtremeWeatherBench(
-                case_metadata=sample_cases_list,
-                evaluation_objects=[sample_evaluation_object],
-            )
-
-            with pytest.raises(ValueError, match="pandas"):
-                ewb.run(output_format="geojson")
 
 
 class TestRunCaseOperators:
@@ -899,6 +882,89 @@ class TestRunSerial:
         assert result == []
 
 
+class TestGroupOperatorsSharingForecast:
+    """Test forecast-reuse grouping and named index types."""
+
+    def test_shared_forecast_is_one_group(self, sample_case_operator):
+        """PPH- and LSR-like operators that share a forecast form one group."""
+        op2 = dataclasses.replace(
+            sample_case_operator,
+            target=mock.Mock(spec=inputs.TargetBase),
+        )
+        sample_case_operator.forecast.name = "HRES"
+        sample_case_operator.forecast.source = "hres://x"
+        op2.forecast.name = "HRES"
+        op2.forecast.source = "hres://x"
+        groups = evaluate._group_operators_sharing_forecast(
+            [sample_case_operator, op2]
+        )
+        assert len(groups) == 1
+        assert [item.index for item in groups[0]] == [0, 1]
+        assert all(
+            isinstance(item, evaluate.IndexedOperator) for item in groups[0]
+        )
+        assert groups[0][0].operator is sample_case_operator
+        assert groups[0][1].operator is op2
+
+    def test_different_forecasts_are_separate_groups(self, sample_case_operator):
+        """Operators with different forecast identities stay in two groups."""
+        other_forecast = mock.Mock(spec=inputs.ForecastBase)
+        other_forecast.name = "other"
+        other_forecast.source = "other://x"
+        sample_case_operator.forecast.name = "HRES"
+        sample_case_operator.forecast.source = "hres://x"
+        op2 = dataclasses.replace(sample_case_operator, forecast=other_forecast)
+        groups = evaluate._group_operators_sharing_forecast(
+            [sample_case_operator, op2]
+        )
+        assert len(groups) == 2
+        assert [item.index for item in groups[0]] == [0]
+        assert [item.index for item in groups[1]] == [1]
+
+    def test_interleaved_operators_keep_original_indices(
+        self, sample_case_operator
+    ):
+        """Non-adjacent shared-forecast operators keep their input indices."""
+        shared = sample_case_operator.forecast
+        shared.name = "HRES"
+        shared.source = "hres://x"
+        other = mock.Mock(spec=inputs.ForecastBase)
+        other.name = "other"
+        other.source = "other://x"
+        op_b = dataclasses.replace(sample_case_operator, forecast=other)
+        op_c = dataclasses.replace(sample_case_operator)
+        groups = evaluate._group_operators_sharing_forecast(
+            [sample_case_operator, op_b, op_c]
+        )
+        assert [item.index for item in groups[0]] == [0, 2]
+        assert [item.index for item in groups[1]] == [1]
+        assert groups[0][0].operator is sample_case_operator
+        assert groups[0][1].operator is op_c
+
+    def test_scatter_restores_input_order(self, sample_case_operator):
+        """Parent-side indices scatter group-order results back to slots."""
+        da0 = xr.DataArray([0.0])
+        da1 = xr.DataArray([1.0])
+        da2 = xr.DataArray([2.0])
+        other = mock.Mock(spec=inputs.ForecastBase)
+        other.name = "other"
+        other.source = "other://x"
+        op_b = dataclasses.replace(sample_case_operator, forecast=other)
+        op_c = dataclasses.replace(sample_case_operator)
+        groups = [
+            [
+                evaluate.IndexedOperator(index=0, operator=sample_case_operator),
+                evaluate.IndexedOperator(index=2, operator=op_c),
+            ],
+            [evaluate.IndexedOperator(index=1, operator=op_b)],
+        ]
+        nested = [[[da0], [da2]], [[da1]]]
+        restored = evaluate._scatter_group_results(groups, nested, 3)
+        assert restored[0][0] is da0
+        assert restored[1][0] is da1
+        assert restored[2][0] is da2
+
+
 class TestRunParallel:
     """Test the _run_parallel_evaluation function."""
 
@@ -917,7 +983,7 @@ class TestRunParallel:
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
         mock_result = [pd.DataFrame({"value": [1.0], "case_id_number": [1]})]
-        mock_parallel_instance.return_value = mock_result
+        mock_parallel_instance.return_value = [mock_result]
 
         result = evaluate._run_parallel_evaluation(
             [sample_case_operator],
@@ -946,7 +1012,7 @@ class TestRunParallel:
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
         mock_result = [pd.DataFrame({"value": [1.0]})]
-        mock_parallel_instance.return_value = mock_result
+        mock_parallel_instance.return_value = [mock_result]
 
         with mock.patch("extremeweatherbench.evaluate.logger.warning") as mock_warning:
             result = evaluate._run_parallel_evaluation(
@@ -975,7 +1041,7 @@ class TestRunParallel:
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
         mock_result = [pd.DataFrame({"value": [1.0]})]
-        mock_parallel_instance.return_value = mock_result
+        mock_parallel_instance.return_value = [mock_result]
 
         # Create a context manager mock
         mock_context = mock.MagicMock()
@@ -1020,7 +1086,7 @@ class TestRunParallel:
             pd.DataFrame({"value": [1.0], "case_id_number": [1]}),
             pd.DataFrame({"value": [2.0], "case_id_number": [2]}),
         ]
-        mock_parallel_instance.return_value = mock_result
+        mock_parallel_instance.return_value = [[row] for row in mock_result]
 
         result = evaluate._run_parallel_evaluation(
             case_operators, parallel_config={"backend": "threading", "n_jobs": 4}
@@ -1044,7 +1110,7 @@ class TestRunParallel:
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
         mock_result = [pd.DataFrame({"value": [1.0]})]
-        mock_parallel_instance.return_value = mock_result
+        mock_parallel_instance.return_value = [mock_result]
 
         result = evaluate._run_parallel_evaluation(
             [sample_case_operator],
@@ -1100,7 +1166,7 @@ class TestRunParallel:
         mock_delayed.return_value = mock.Mock()
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+        mock_parallel_instance.return_value = [[pd.DataFrame({"value": [1.0]})]]
 
         evaluate._run_parallel_evaluation(
             [sample_case_operator],
@@ -1132,7 +1198,7 @@ class TestRunParallel:
         mock_delayed.return_value = mock.Mock()
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+        mock_parallel_instance.return_value = [[pd.DataFrame({"value": [1.0]})]]
         mock_manager.return_value.Queue.return_value = mock.Mock()
 
         evaluate._run_parallel_evaluation(
@@ -1170,7 +1236,7 @@ class TestRunParallel:
         mock_delayed.return_value = mock.Mock()
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+        mock_parallel_instance.return_value = [[pd.DataFrame({"value": [1.0]})]]
 
         evaluate._run_parallel_evaluation(
             [sample_case_operator],
@@ -1205,7 +1271,7 @@ class TestRunParallel:
         mock_delayed.return_value = mock.Mock()
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+        mock_parallel_instance.return_value = [[pd.DataFrame({"value": [1.0]})]]
         event_queue = mock.Mock(name="event_queue")
         log_queue = mock.Mock(name="log_queue")
         mock_manager.return_value.Queue.side_effect = [event_queue, log_queue]
@@ -1234,13 +1300,22 @@ class TestRunParallel:
         CaseOperators that share a case_id (one case, several
         EvaluationObjects), so the slot key can't be case_id itself.
         """
-        case_operators = [sample_case_operator, sample_case_operator]
+        forecast2 = mock.Mock()
+        forecast2.name = "other_forecast"
+        forecast2.source = "other_source"
+        op2 = cases.CaseOperator(
+            case_metadata=sample_case_operator.case_metadata,
+            metric_list=sample_case_operator.metric_list,
+            target=sample_case_operator.target,
+            forecast=forecast2,
+        )
+        case_operators = [sample_case_operator, op2]
         mock_tqdm.return_value = case_operators
         mock_delayed_func = mock.Mock()
         mock_delayed.return_value = mock_delayed_func
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame(), pd.DataFrame()]
+        mock_parallel_instance.return_value = [[[]], [[]]]
 
         evaluate._run_parallel_evaluation(
             case_operators, parallel_config={"backend": "threading", "n_jobs": 2}
@@ -1248,10 +1323,12 @@ class TestRunParallel:
 
         generator_arg = mock_parallel_instance.call_args[0][0]
         list(generator_arg)
-        dispatch_ids = [
-            call.kwargs["dispatch_id"] for call in mock_delayed_func.call_args_list
+        indices = [
+            item.index
+            for call in mock_delayed_func.call_args_list
+            for item in call.args[0]
         ]
-        assert dispatch_ids == [0, 1]
+        assert indices == [0, 1]
 
     @mock.patch("extremeweatherbench.evaluate.multiprocessing.Manager")
     @mock.patch("extremeweatherbench.evaluate.progress_module.LogQueueListener")
@@ -1282,7 +1359,7 @@ class TestRunParallel:
         mock_delayed.return_value = mock.Mock()
         mock_parallel_instance = mock.Mock()
         mock_parallel_class.return_value = mock_parallel_instance
-        mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+        mock_parallel_instance.return_value = [[pd.DataFrame({"value": [1.0]})]]
 
         order = []
         mock_renderer_class.return_value.close.side_effect = lambda: order.append(
@@ -1330,7 +1407,7 @@ class TestRunParallel:
         with mock.patch("extremeweatherbench.utils.ParallelTqdm") as mock_parallel:
             mock_parallel_instance = mock.Mock()
             mock_parallel.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = [pd.DataFrame({"test": [1]})]
+            mock_parallel_instance.return_value = [[pd.DataFrame({"test": [1]})]]
 
             with mock.patch("joblib.parallel_config"):
                 result = evaluate._run_parallel_evaluation(
@@ -1359,7 +1436,7 @@ class TestRunParallel:
         with mock.patch("extremeweatherbench.utils.ParallelTqdm") as mock_parallel:
             mock_parallel_instance = mock.Mock()
             mock_parallel.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = [pd.DataFrame({"test": [1]})]
+            mock_parallel_instance.return_value = [[pd.DataFrame({"test": [1]})]]
 
             with mock.patch("joblib.parallel_config"):
                 result = evaluate._run_parallel_evaluation(
@@ -1640,6 +1717,8 @@ class TestComputeCaseOperator:
                 # Called twice: once for forecast, once for target
                 assert mock_compute_cache.call_count == 2
                 assert isinstance(result, pd.DataFrame)
+                case_id = sample_case_operator.case_metadata.case_id_number
+                assert (cache_dir / f"case_{case_id}_results.pkl").exists()
 
     @mock.patch("extremeweatherbench.evaluate._build_datasets")
     def test_compute_case_operator_multiple_metrics(
@@ -1879,12 +1958,48 @@ class TestPipelineFunctions:
             assert forecast_ds.attrs["name"] == "forecast_source"
             assert target_ds.attrs["name"] == "target_source"
 
+    def test_build_datasets_reuses_cached_forecast(self, sample_case_operator):
+        """A shared pipeline cache should skip a second forecast derive."""
+        with mock.patch(
+            "extremeweatherbench.evaluate.run_pipeline"
+        ) as mock_run_pipeline:
+            mock_forecast_ds = xr.Dataset(
+                coords={"valid_time": [1, 2, 3]}, attrs={"name": "forecast_source"}
+            )
+            mock_target_ds = xr.Dataset(
+                coords={"time": [1, 2, 3]}, attrs={"name": "target_source"}
+            )
+            other_target_ds = xr.Dataset(
+                coords={"time": [1, 2, 3]}, attrs={"name": "other_target"}
+            )
+            mock_run_pipeline.side_effect = [
+                mock_target_ds,
+                mock_forecast_ds,
+                other_target_ds,
+            ]
+            cache: dict = {}
+            token = evaluate._pipeline_cache_var.set(cache)
+            try:
+                evaluate._build_datasets(sample_case_operator)
+                original_name = sample_case_operator.target.name
+                sample_case_operator.target.name = "other_target"
+                try:
+                    evaluate._build_datasets(sample_case_operator)
+                finally:
+                    sample_case_operator.target.name = original_name
+            finally:
+                evaluate._pipeline_cache_var.reset(token)
+            # Two targets + one forecast; the second forecast is reused.
+            assert mock_run_pipeline.call_count == 3
+
     def test_build_datasets_zero_length_dimensions(self, sample_case_operator):
         """Test _build_datasets when forecast has zero-length dimensions."""
         # Set up the mock to return a dataset that will trigger the warning
         # by having no valid times in the date range
         empty_dataset = xr.Dataset()
-        sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source.return_value = empty_dataset
+        sample_case_operator.forecast._open_data_from_source.return_value = (
+            empty_dataset
+        )
         sample_case_operator.forecast.maybe_map_variable_names.return_value = (
             empty_dataset
         )
@@ -1913,7 +2028,9 @@ class TestPipelineFunctions:
         zero-length dimensions."""
         # Set up the mock to return a dataset that will trigger the warning
         empty_dataset = xr.Dataset()
-        sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source.return_value = empty_dataset
+        sample_case_operator.forecast._open_data_from_source.return_value = (
+            empty_dataset
+        )
         sample_case_operator.forecast.maybe_map_variable_names.return_value = (
             empty_dataset
         )
@@ -1939,7 +2056,9 @@ class TestPipelineFunctions:
         """Test _build_datasets when forecast has multiple zero-length dimensions."""
         # Set up the mock to return a dataset that will trigger the warning
         empty_dataset = xr.Dataset()
-        sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source.return_value = empty_dataset
+        sample_case_operator.forecast._open_data_from_source.return_value = (
+            empty_dataset
+        )
         sample_case_operator.forecast.maybe_map_variable_names.return_value = (
             empty_dataset
         )
@@ -2003,7 +2122,9 @@ class TestPipelineFunctions:
     ):
         """Test run_pipeline function for forecast data."""
         # Mock the pipeline methods
-        sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source.return_value = sample_forecast_dataset
+        sample_case_operator.forecast._open_data_from_source.return_value = (
+            sample_forecast_dataset
+        )
         sample_case_operator.forecast.maybe_map_variable_names.return_value = (
             sample_forecast_dataset
         )
@@ -2017,6 +2138,7 @@ class TestPipelineFunctions:
         sample_case_operator.forecast.add_source_to_dataset_attrs.return_value = (
             sample_forecast_dataset
         )
+        sample_case_operator.forecast.preprocess.return_value = sample_forecast_dataset
         mock_derived.return_value = sample_forecast_dataset
 
         result = evaluate.run_pipeline(
@@ -2024,7 +2146,7 @@ class TestPipelineFunctions:
         )
 
         assert isinstance(result, xr.Dataset)
-        sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source.assert_called_once()
+        sample_case_operator.forecast._open_data_from_source.assert_called_once()
         sample_case_operator.forecast.maybe_map_variable_names.assert_called_once()
         mock_maybe_subset_variables.assert_called_once()
         # The method is called with data as first arg, case_metadata as second arg
@@ -2033,6 +2155,13 @@ class TestPipelineFunctions:
         assert call_args[0][1] == sample_case_operator.case_metadata
         sample_case_operator.forecast.maybe_convert_to_dataset.assert_called_once()
         sample_case_operator.forecast.add_source_to_dataset_attrs.assert_called_once()
+        sample_case_operator.forecast.preprocess.assert_called_once()
+        method_names = [
+            name for name, *_ in sample_case_operator.forecast.method_calls
+        ]
+        assert method_names.index("subset_data_to_case") < method_names.index(
+            "preprocess"
+        )
 
     @mock.patch("extremeweatherbench.derived.maybe_derive_variables")
     @mock.patch("extremeweatherbench.evaluate.inputs.maybe_subset_variables")
@@ -2045,7 +2174,9 @@ class TestPipelineFunctions:
     ):
         """Test run_pipeline function for target data."""
         # Mock the pipeline methods
-        sample_case_operator.target.open_and_maybe_preprocess_data_from_source.return_value = sample_target_dataset
+        sample_case_operator.target._open_data_from_source.return_value = (
+            sample_target_dataset
+        )
         sample_case_operator.target.maybe_map_variable_names.return_value = (
             sample_target_dataset
         )
@@ -2059,6 +2190,7 @@ class TestPipelineFunctions:
         sample_case_operator.target.add_source_to_dataset_attrs.return_value = (
             sample_target_dataset
         )
+        sample_case_operator.target.preprocess.return_value = sample_target_dataset
         mock_derived.return_value = sample_target_dataset
 
         result = evaluate.run_pipeline(
@@ -2066,7 +2198,12 @@ class TestPipelineFunctions:
         )
 
         assert isinstance(result, xr.Dataset)
-        sample_case_operator.target.open_and_maybe_preprocess_data_from_source.assert_called_once()
+        sample_case_operator.target._open_data_from_source.assert_called_once()
+        sample_case_operator.target.preprocess.assert_called_once()
+        method_names = [name for name, *_ in sample_case_operator.target.method_calls]
+        assert method_names.index("subset_data_to_case") < method_names.index(
+            "preprocess"
+        )
 
     def test_run_pipeline_invalid_source(self, sample_case_operator):
         """Test run_pipeline function with invalid input source."""
@@ -2121,6 +2258,36 @@ class TestPipelineFunctions:
         # Should still be lazy
         first_var = next(iter(result.data_vars))
         assert hasattr(result.data_vars[first_var].data, "chunks")
+
+    @mock.patch("extremeweatherbench.evaluate._build_datasets")
+    @mock.patch("extremeweatherbench.evaluate._evaluate_metric")
+    def test_aligned_datasets_computed_without_cache(
+        self,
+        mock_evaluate_metric,
+        mock_build_datasets,
+        sample_case_operator,
+        sample_forecast_dataset,
+        sample_target_dataset,
+    ):
+        """Aligned data is computed once when cache_dir is None."""
+        lazy_forecast = sample_forecast_dataset.chunk()
+        lazy_target = sample_target_dataset.chunk()
+        mock_build_datasets.return_value = (lazy_forecast, lazy_target)
+        sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
+            lazy_forecast,
+            lazy_target,
+        )
+        mock_evaluate_metric.return_value = _annotated_result()
+
+        evaluate._compute_case_operator_results(sample_case_operator)
+
+        assert mock_evaluate_metric.called
+        forecast_ds = mock_evaluate_metric.call_args.kwargs["forecast_ds"]
+        target_ds = mock_evaluate_metric.call_args.kwargs["target_ds"]
+        first_fc = list(forecast_ds.data_vars)[0]
+        first_tg = list(target_ds.data_vars)[0]
+        assert not hasattr(forecast_ds[first_fc].data, "chunks")
+        assert not hasattr(target_ds[first_tg].data, "chunks")
 
 
 class TestMetricEvaluation:
@@ -2304,7 +2471,7 @@ class TestErrorHandling:
     def test_run_pipeline_missing_method(self, sample_case_operator):
         """Test run_pipeline when a required method is missing."""
         # Remove a required method
-        del sample_case_operator.forecast.open_and_maybe_preprocess_data_from_source
+        del sample_case_operator.forecast._open_data_from_source
 
         with pytest.raises(AttributeError):
             evaluate.run_pipeline(
@@ -2516,7 +2683,9 @@ class TestIntegration:
         )
 
         # Mock the pipeline methods to return our test datasets
-        sample_evaluation_object.forecast.open_and_maybe_preprocess_data_from_source.return_value = sample_forecast_dataset
+        sample_evaluation_object.forecast._open_data_from_source.return_value = (
+            sample_forecast_dataset
+        )
         sample_evaluation_object.forecast.maybe_map_variable_names.return_value = (
             sample_forecast_dataset
         )
@@ -2530,8 +2699,13 @@ class TestIntegration:
         sample_evaluation_object.forecast.add_source_to_dataset_attrs.return_value = (
             sample_forecast_dataset
         )
+        sample_evaluation_object.forecast.preprocess.return_value = (
+            sample_forecast_dataset
+        )
 
-        sample_evaluation_object.target.open_and_maybe_preprocess_data_from_source.return_value = sample_target_dataset
+        sample_evaluation_object.target._open_data_from_source.return_value = (
+            sample_target_dataset
+        )
         sample_evaluation_object.target.maybe_map_variable_names.return_value = (
             sample_target_dataset
         )
@@ -2544,6 +2718,7 @@ class TestIntegration:
         sample_evaluation_object.target.add_source_to_dataset_attrs.return_value = (
             sample_target_dataset
         )
+        sample_evaluation_object.target.preprocess.return_value = sample_target_dataset
 
         # Mock the metric evaluation to return a proper annotated result
         mock_result = _annotated_result(
@@ -2615,12 +2790,14 @@ class TestIntegration:
         # Mock target and forecast with variables that match our datasets
         eval_obj.target = mock.Mock(spec=inputs.TargetBase)
         eval_obj.target.name = "MultiTarget"
+        eval_obj.target.source = "mock://target"
         eval_obj.target.variables = [
             "2m_temperature"
         ]  # Only include variables that exist
 
         eval_obj.forecast = mock.Mock(spec=inputs.ForecastBase)
         eval_obj.forecast.name = "MultiForecast"
+        eval_obj.forecast.source = "mock://forecast"
         eval_obj.forecast.variables = [
             "surface_air_temperature"
         ]  # Only include variables that exist
@@ -2628,13 +2805,12 @@ class TestIntegration:
         # Setup pipeline mocks
         mock_maybe_subset_variables.return_value = sample_forecast_dataset
         for obj in [eval_obj.target, eval_obj.forecast]:
-            obj.open_and_maybe_preprocess_data_from_source.return_value = (
-                sample_forecast_dataset
-            )
+            obj._open_data_from_source.return_value = sample_forecast_dataset
             obj.maybe_map_variable_names.return_value = sample_forecast_dataset
             obj.subset_data_to_case.return_value = sample_forecast_dataset
             obj.maybe_convert_to_dataset.return_value = sample_forecast_dataset
             obj.add_source_to_dataset_attrs.return_value = sample_forecast_dataset
+            obj.preprocess.return_value = sample_forecast_dataset
 
         eval_obj.target.maybe_align_forecast_to_target.return_value = (
             sample_forecast_dataset,
@@ -2777,7 +2953,9 @@ class TestIntegration:
         ) as mock_parallel_class:
             mock_parallel_instance = mock.Mock()
             mock_parallel_class.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = mock_results
+            mock_parallel_instance.return_value = [
+                [row] for row in mock_results
+            ]
 
             start_time = time.time()
             parallel_result = evaluate._run_parallel_evaluation(
@@ -2840,7 +3018,9 @@ class TestIntegration:
                 ) as mock_parallel_class:
                     mock_parallel_instance = mock.Mock()
                     mock_parallel_class.return_value = mock_parallel_instance
-                    mock_parallel_instance.return_value = mock_results
+                    mock_parallel_instance.return_value = [
+                        [row] for row in mock_results
+                    ]
 
                     # Add parallel_config to kwargs
                     kwargs = config.get("kwargs", {})
@@ -2906,7 +3086,7 @@ class TestIntegration:
                 mock_parallel_instance = mock.Mock()
                 mock_parallel_class.return_value = mock_parallel_instance
                 mock_parallel_instance.return_value = [
-                    [_annotated_result(value=1.0)]
+                    [[_annotated_result(value=1.0)]]
                 ]
 
                 # Reset captured kwargs
@@ -2988,7 +3168,9 @@ class TestIntegration:
         ) as mock_parallel_class:
             mock_parallel_instance = mock.Mock()
             mock_parallel_class.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = mock_results
+            mock_parallel_instance.return_value = [
+                [row] for row in mock_results
+            ]
 
             parallel_results = evaluate._run_parallel_evaluation(
                 case_operators, parallel_config={"backend": "threading", "n_jobs": 4}

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -21,6 +21,7 @@ from extremeweatherbench import (
     evaluate,
     inputs,
     metrics,
+    outputs,
     regions,
     utils,
 )
@@ -217,6 +218,34 @@ def sample_target_dataset():
     )
 
 
+def _annotated_result(value=1.0, lead_time=0, **metadata):
+    """Build a minimal annotated metric result DataArray for mocking."""
+    result = xr.DataArray(
+        data=[value], dims=["lead_time"], coords={"lead_time": [lead_time]}
+    )
+    return result.assign_coords(metadata)
+
+
+def _fully_annotated_result(value=1.0, lead_time=0, **metadata):
+    """Build an annotated result with every outputs.METADATA_COORDS field.
+
+    Real pipeline results always carry all of these (see
+    evaluate._extract_standard_metadata), which results_to_dataset relies
+    on; _annotated_result alone is too sparse for xarray-output tests.
+    """
+    full_metadata = {
+        "metric": "MockMetric",
+        "target_variable": "2m_temperature",
+        "forecast_variable": "2m_temperature",
+        "forecast_source": "test_forecast",
+        "target_source": "test_target",
+        "case_id_number": 1,
+        "event_type": "heat_wave",
+        **metadata,
+    }
+    return _annotated_result(value=value, lead_time=lead_time, **full_metadata)
+
+
 class TestOutputColumns:
     """Test the OUTPUT_COLUMNS constant."""
 
@@ -350,15 +379,9 @@ class TestExtremeWeatherBench:
         with mock.patch.object(
             evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
         ):
-            # Mock _run_evaluation to return a list of DataFrames
+            # Mock _run_evaluation to return per-case-operator result lists
             mock_result = [
-                pd.DataFrame(
-                    {
-                        "value": [1.0],
-                        "metric": ["MockMetric"],
-                        "case_id_number": [1],
-                    }
-                )
+                [_annotated_result(value=1.0, metric="MockMetric", case_id_number=1)]
             ]
             mock_run_evaluation.return_value = mock_result
 
@@ -392,13 +415,7 @@ class TestExtremeWeatherBench:
             evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
         ):
             mock_result = [
-                pd.DataFrame(
-                    {
-                        "value": [1.0],
-                        "metric": ["MockMetric"],
-                        "case_id_number": [1],
-                    }
-                )
+                [_annotated_result(value=1.0, metric="MockMetric", case_id_number=1)]
             ]
             mock_run_evaluation.return_value = mock_result
 
@@ -430,7 +447,7 @@ class TestExtremeWeatherBench:
         with mock.patch.object(
             evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
         ):
-            mock_result = [pd.DataFrame({"value": [1.0]})]
+            mock_result = [[_annotated_result(value=1.0)]]
             mock_run_evaluation.return_value = mock_result
 
             ewb = evaluate.ExtremeWeatherBench(
@@ -467,10 +484,10 @@ class TestExtremeWeatherBench:
             assert len(result) == 0
             assert list(result.columns) == evaluate.OUTPUT_COLUMNS
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     def test_run_with_caching(
         self,
-        mock_compute_case_operator,
+        mock_compute_case_operator_results,
         sample_cases_list,
         sample_evaluation_object,
         sample_case_operator,
@@ -484,13 +501,9 @@ class TestExtremeWeatherBench:
                 "case_operators",
                 new=[sample_case_operator],
             ):
-                mock_result = pd.DataFrame(
-                    {
-                        "value": [1.0],
-                        "metric": ["MockMetric"],
-                        "case_id_number": [1],
-                    }
-                )
+                mock_result = [
+                    _annotated_result(value=1.0, metric="MockMetric", case_id_number=1)
+                ]
 
                 # Make the mock also perform caching like the real function would
                 def mock_compute_with_caching(case_operator, cache_dir_arg, **kwargs):
@@ -500,10 +513,14 @@ class TestExtremeWeatherBench:
                             if isinstance(cache_dir_arg, str)
                             else cache_dir_arg
                         )
-                        mock_result.to_pickle(cache_path / "case_results.pkl")
+                        outputs.results_to_dataframe(mock_result).to_pickle(
+                            cache_path / "case_results.pkl"
+                        )
                     return mock_result
 
-                mock_compute_case_operator.side_effect = mock_compute_with_caching
+                mock_compute_case_operator_results.side_effect = (
+                    mock_compute_with_caching
+                )
 
                 ewb = evaluate.ExtremeWeatherBench(
                     case_metadata=sample_cases_list,
@@ -520,9 +537,12 @@ class TestExtremeWeatherBench:
                 cache_file = cache_dir / "case_results.pkl"
                 assert cache_file.exists()
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     def test_run_multiple_cases(
-        self, mock_compute_case_operator, sample_cases_list, sample_evaluation_object
+        self,
+        mock_compute_case_operator_results,
+        sample_cases_list,
+        sample_evaluation_object,
     ):
         """Test the run method with multiple case operators."""
         # Create multiple case operators
@@ -536,10 +556,10 @@ class TestExtremeWeatherBench:
             "case_operators",
             new=[case_operator_1, case_operator_2],
         ):
-            # Mock compute_case_operator to return different DataFrames
-            mock_compute_case_operator.side_effect = [
-                pd.DataFrame({"value": [1.0], "case_id_number": [1]}),
-                pd.DataFrame({"value": [2.0], "case_id_number": [2]}),
+            # Mock to return different per-case-operator result lists
+            mock_compute_case_operator_results.side_effect = [
+                [_annotated_result(value=1.0, case_id_number=1)],
+                [_annotated_result(value=2.0, case_id_number=2)],
             ]
 
             ewb = evaluate.ExtremeWeatherBench(
@@ -549,30 +569,145 @@ class TestExtremeWeatherBench:
 
             result = ewb.run_evaluation()
 
-            assert mock_compute_case_operator.call_count == 2
+            assert mock_compute_case_operator_results.call_count == 2
             assert len(result) == 2
             assert result["case_id_number"].tolist() == [1, 2]
+
+
+class TestOutputFormatWiring:
+    """Test the output_format kwarg on run_evaluation and the deprecated run."""
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_evaluation_output_format_pandas_returns_dataframe(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_run_evaluation.return_value = [
+                [_annotated_result(value=1.0, metric="MockMetric", case_id_number=1)]
+            ]
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+            )
+
+            result = ewb.run_evaluation(n_jobs=1, output_format="pandas")
+
+            assert isinstance(result, pd.DataFrame)
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_evaluation_output_format_xarray_returns_dataset(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_run_evaluation.return_value = [[_fully_annotated_result()]]
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+            )
+
+            result = ewb.run_evaluation(n_jobs=1, output_format="xarray")
+
+            assert isinstance(result, xr.Dataset)
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_evaluation_unknown_output_format_raises_value_error(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_run_evaluation.return_value = [
+                [_annotated_result(value=1.0, case_id_number=1)]
+            ]
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+            )
+
+            with pytest.raises(ValueError, match="pandas"):
+                ewb.run_evaluation(output_format="geojson")
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_deprecated_output_format_xarray_returns_dataset(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_run_evaluation.return_value = [[_fully_annotated_result()]]
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+            )
+
+            result = ewb.run(n_jobs=1, output_format="xarray")
+
+            assert isinstance(result, xr.Dataset)
+
+    @mock.patch("extremeweatherbench.evaluate._run_evaluation")
+    def test_run_deprecated_unknown_output_format_raises_value_error(
+        self,
+        mock_run_evaluation,
+        sample_cases_list,
+        sample_evaluation_object,
+        sample_case_operator,
+    ):
+        with mock.patch.object(
+            evaluate.ExtremeWeatherBench, "case_operators", new=[sample_case_operator]
+        ):
+            mock_run_evaluation.return_value = [
+                [_annotated_result(value=1.0, case_id_number=1)]
+            ]
+            ewb = evaluate.ExtremeWeatherBench(
+                case_metadata=sample_cases_list,
+                evaluation_objects=[sample_evaluation_object],
+            )
+
+            with pytest.raises(ValueError, match="pandas"):
+                ewb.run(output_format="geojson")
 
 
 class TestRunCaseOperators:
     """Test the _run_evaluation function."""
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_evaluation_serial(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test _run_evaluation executes serially when parallel_config=None."""
         mock_tqdm.return_value = [sample_case_operator]
-        mock_results = pd.DataFrame({"value": [1.0]})
-        mock_compute_case_operator.return_value = mock_results
+        mock_results = [_annotated_result(value=1.0)]
+        mock_compute_case_operator_results.return_value = mock_results
 
         # Serial mode: don't pass parallel_config
         result = evaluate._run_evaluation([sample_case_operator], cache_dir=None)
 
-        mock_compute_case_operator.assert_called_once_with(sample_case_operator, None)
+        mock_compute_case_operator_results.assert_called_once_with(
+            sample_case_operator, None
+        )
         assert len(result) == 1
-        assert result[0].equals(mock_results)
+        assert result[0] is mock_results
 
     @mock.patch("extremeweatherbench.evaluate._run_parallel_evaluation")
     def test_run_evaluation_parallel(
@@ -596,15 +731,15 @@ class TestRunCaseOperators:
         )
         assert result == mock_results
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_evaluation_with_kwargs(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test _run_evaluation passes kwargs correctly in serial mode."""
         mock_tqdm.return_value = [sample_case_operator]
-        mock_results = pd.DataFrame({"value": [1.0]})
-        mock_compute_case_operator.return_value = mock_results
+        mock_results = [_annotated_result(value=1.0)]
+        mock_compute_case_operator_results.return_value = mock_results
 
         # Serial mode: don't pass parallel_config
         result = evaluate._run_evaluation(
@@ -613,7 +748,7 @@ class TestRunCaseOperators:
             threshold=0.5,
         )
 
-        call_args = mock_compute_case_operator.call_args
+        call_args = mock_compute_case_operator_results.call_args
         assert call_args[0][0] == sample_case_operator
         assert call_args[0][1] is None  # cache_dir
         assert call_args[1]["threshold"] == 0.5
@@ -653,9 +788,11 @@ class TestRunCaseOperators:
 
         def warn_and_compute(case_operator, cache_dir=None, **kwargs):
             warnings.warn("serial run warning", RuntimeWarning)
-            return pd.DataFrame({"value": [1.0]})
+            return [_annotated_result(value=1.0)]
 
-        monkeypatch.setattr(evaluate, "compute_case_operator", warn_and_compute)
+        monkeypatch.setattr(
+            evaluate, "_compute_case_operator_results", warn_and_compute
+        )
 
         with caplog.at_level(logging.WARNING, logger="py.warnings"):
             evaluate._run_evaluation([sample_case_operator], parallel_config=None)
@@ -689,27 +826,29 @@ class TestRunCaseOperators:
 class TestRunSerial:
     """Test the serial execution path of _run_evaluation."""
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_serial_evaluation_basic(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test basic serial execution functionality."""
         # Setup mocks
         mock_tqdm.return_value = [sample_case_operator]  # tqdm returns iterable
-        mock_result = pd.DataFrame({"value": [1.0], "case_id_number": [1]})
-        mock_compute_case_operator.return_value = mock_result
+        mock_result = [_annotated_result(value=1.0, case_id_number=1)]
+        mock_compute_case_operator_results.return_value = mock_result
 
         result = evaluate._run_evaluation([sample_case_operator], parallel_config=None)
 
-        mock_compute_case_operator.assert_called_once_with(sample_case_operator, None)
+        mock_compute_case_operator_results.assert_called_once_with(
+            sample_case_operator, None
+        )
         assert len(result) == 1
-        assert result[0].equals(mock_result)
+        assert result[0] is mock_result
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_serial_evaluation_multiple_cases(
-        self, mock_tqdm, mock_compute_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results
     ):
         """Test serial execution with multiple case operators."""
         case_op_1 = mock.Mock()
@@ -719,27 +858,27 @@ class TestRunSerial:
         case_operators = [case_op_1, case_op_2]
 
         mock_tqdm.return_value = case_operators
-        mock_compute_case_operator.side_effect = [
-            pd.DataFrame({"value": [1.0], "case_id_number": [1]}),
-            pd.DataFrame({"value": [2.0], "case_id_number": [2]}),
+        mock_compute_case_operator_results.side_effect = [
+            [_annotated_result(value=1.0, case_id_number=1)],
+            [_annotated_result(value=2.0, case_id_number=2)],
         ]
 
         result = evaluate._run_evaluation(case_operators, parallel_config=None)
 
-        assert mock_compute_case_operator.call_count == 2
+        assert mock_compute_case_operator_results.call_count == 2
         assert len(result) == 2
-        assert result[0]["case_id_number"].iloc[0] == 1
-        assert result[1]["case_id_number"].iloc[0] == 2
+        assert result[0][0].coords["case_id_number"].item() == 1
+        assert result[1][0].coords["case_id_number"].item() == 2
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_serial_evaluation_with_kwargs(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test serial execution passes kwargs to compute_case_operator."""
         mock_tqdm.return_value = [sample_case_operator]
-        mock_result = pd.DataFrame({"value": [1.0]})
-        mock_compute_case_operator.return_value = mock_result
+        mock_result = [_annotated_result(value=1.0)]
+        mock_compute_case_operator_results.return_value = mock_result
 
         result = evaluate._run_evaluation(
             [sample_case_operator],
@@ -748,7 +887,7 @@ class TestRunSerial:
             custom_param="test",
         )
 
-        call_args = mock_compute_case_operator.call_args
+        call_args = mock_compute_case_operator_results.call_args
         assert call_args[0][0] == sample_case_operator
         assert call_args[1]["threshold"] == 0.7
         assert call_args[1]["custom_param"] == "test"
@@ -1247,9 +1386,9 @@ class TestComputeCaseOperatorWithProgress:
         def fake_compute(case_operator, cache_dir=None, **kwargs):
             logging.getLogger("extremeweatherbench.derived").warning("worker warn")
             warnings.warn("worker user warning", RuntimeWarning)
-            return pd.DataFrame({"value": [1.0]})
+            return [_annotated_result(value=1.0)]
 
-        monkeypatch.setattr(evaluate, "compute_case_operator", fake_compute)
+        monkeypatch.setattr(evaluate, "_compute_case_operator_results", fake_compute)
 
         evaluate._compute_case_operator_with_progress(
             sample_case_operator,
@@ -1277,7 +1416,7 @@ class TestComputeCaseOperatorWithProgress:
         def failing_compute(case_operator, cache_dir=None, **kwargs):
             raise ValueError("boom")
 
-        monkeypatch.setattr(evaluate, "compute_case_operator", failing_compute)
+        monkeypatch.setattr(evaluate, "_compute_case_operator_results", failing_compute)
 
         with pytest.raises(ValueError):
             evaluate._compute_case_operator_with_progress(
@@ -1300,9 +1439,9 @@ class TestComputeCaseOperatorWithProgress:
 
         def fake_compute(case_operator, cache_dir=None, **kwargs):
             seen_handlers.append(root.handlers[:])
-            return pd.DataFrame({"value": [1.0]})
+            return [_annotated_result(value=1.0)]
 
-        monkeypatch.setattr(evaluate, "compute_case_operator", fake_compute)
+        monkeypatch.setattr(evaluate, "_compute_case_operator_results", fake_compute)
 
         evaluate._compute_case_operator_with_progress(
             sample_case_operator,
@@ -1387,9 +1526,9 @@ class TestComputeCaseOperatorWithProgress:
 
         def fake_compute(case_operator, cache_dir=None, **kwargs):
             evaluate.progress_module.set_phase("target pipeline")
-            return pd.DataFrame({"value": [1.0]})
+            return [_annotated_result(value=1.0)]
 
-        monkeypatch.setattr(evaluate, "compute_case_operator", fake_compute)
+        monkeypatch.setattr(evaluate, "_compute_case_operator_results", fake_compute)
 
         evaluate._compute_case_operator_with_progress(
             case_operator, cache_dir=None, event_queue=event_queue, dispatch_id=0
@@ -1410,7 +1549,7 @@ class TestComputeCaseOperator:
 
     @mock.patch("extremeweatherbench.evaluate._build_datasets")
     @mock.patch("extremeweatherbench.derived.maybe_derive_variables")
-    @mock.patch("extremeweatherbench.evaluate._evaluate_metric_and_return_df")
+    @mock.patch("extremeweatherbench.evaluate._evaluate_metric")
     def test_compute_case_operator_basic(
         self,
         mock_evaluate_metric,
@@ -1430,13 +1569,7 @@ class TestComputeCaseOperator:
             lambda ds, variables, **kwargs: ds  # Return unchanged
         )
 
-        mock_result = pd.DataFrame(
-            {
-                "value": [1.0],
-                "metric": ["MockMetric"],
-                "case_id_number": [1],
-            }
-        )
+        mock_result = _annotated_result(metric="MockMetric", case_id_number=1)
         mock_evaluate_metric.return_value = mock_result
 
         # Setup the case operator mocks
@@ -1449,6 +1582,9 @@ class TestComputeCaseOperator:
 
         mock_build_datasets.assert_called_once_with(sample_case_operator)
         assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == evaluate.OUTPUT_COLUMNS
+        assert result["metric"].iloc[0] == "MockMetric"
+        assert result["case_id_number"].iloc[0] == 1
 
     @mock.patch("extremeweatherbench.evaluate._build_datasets")
     @mock.patch("extremeweatherbench.derived.maybe_derive_variables")
@@ -1493,9 +1629,9 @@ class TestComputeCaseOperator:
             ]
 
             with mock.patch(
-                "extremeweatherbench.evaluate._evaluate_metric_and_return_df"
+                "extremeweatherbench.evaluate._evaluate_metric"
             ) as mock_evaluate:
-                mock_evaluate.return_value = pd.DataFrame({"value": [1.0]})
+                mock_evaluate.return_value = _annotated_result()
 
                 result = evaluate.compute_case_operator(
                     sample_case_operator, cache_dir=cache_dir
@@ -1543,9 +1679,9 @@ class TestComputeCaseOperator:
             mock_derive.side_effect = lambda ds, variables, **kwargs: ds
 
             with mock.patch(
-                "extremeweatherbench.evaluate._evaluate_metric_and_return_df"
+                "extremeweatherbench.evaluate._evaluate_metric"
             ) as mock_evaluate:
-                mock_evaluate.return_value = pd.DataFrame({"value": [1.0]})
+                mock_evaluate.return_value = _annotated_result()
 
                 result = evaluate.compute_case_operator(sample_case_operator)
 
@@ -1632,6 +1768,93 @@ class TestComputeCaseOperator:
         assert list(result.columns) == evaluate.OUTPUT_COLUMNS
 
         mock_build_datasets.assert_called_once_with(sample_case_operator)
+
+    @mock.patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_results_zero_length_dataset_returns_empty_list(
+        self, mock_build_datasets, sample_case_operator
+    ):
+        """_compute_case_operator_results returns [] for zero-length dims."""
+        empty_forecast_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
+        empty_target_ds = xr.Dataset(coords={"valid_time": pd.DatetimeIndex([])})
+        mock_build_datasets.return_value = (empty_forecast_ds, empty_target_ds)
+
+        result = evaluate._compute_case_operator_results(sample_case_operator)
+
+        assert result == []
+
+    @mock.patch("extremeweatherbench.evaluate._build_datasets")
+    def test_compute_case_operator_results_dimensionless_dataset_returns_empty_list(
+        self, mock_build_datasets, sample_case_operator
+    ):
+        """_compute_case_operator_results returns [] for dimensionless data."""
+        empty_forecast_ds = xr.Dataset()
+        empty_target_ds = xr.Dataset()
+        mock_build_datasets.return_value = (empty_forecast_ds, empty_target_ds)
+
+        result = evaluate._compute_case_operator_results(sample_case_operator)
+
+        assert result == []
+
+
+class TestComputeCaseOperatorOutputFormat:
+    """Test the output_format kwarg on compute_case_operator."""
+
+    @mock.patch("extremeweatherbench.evaluate._build_datasets")
+    @mock.patch("extremeweatherbench.derived.maybe_derive_variables")
+    @mock.patch("extremeweatherbench.evaluate._evaluate_metric")
+    def test_output_format_xarray_returns_dataset(
+        self,
+        mock_evaluate_metric,
+        mock_derive_variables,
+        mock_build_datasets,
+        sample_case_operator,
+        sample_forecast_dataset,
+        sample_target_dataset,
+    ):
+        mock_build_datasets.return_value = (
+            sample_forecast_dataset,
+            sample_target_dataset,
+        )
+        mock_derive_variables.side_effect = lambda ds, variables, **kwargs: ds
+        mock_evaluate_metric.return_value = _fully_annotated_result()
+        sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
+            sample_forecast_dataset,
+            sample_target_dataset,
+        )
+
+        result = evaluate.compute_case_operator(
+            sample_case_operator, output_format="xarray"
+        )
+
+        assert isinstance(result, xr.Dataset)
+
+    @mock.patch("extremeweatherbench.evaluate._build_datasets")
+    @mock.patch("extremeweatherbench.derived.maybe_derive_variables")
+    @mock.patch("extremeweatherbench.evaluate._evaluate_metric")
+    def test_unknown_output_format_raises_value_error(
+        self,
+        mock_evaluate_metric,
+        mock_derive_variables,
+        mock_build_datasets,
+        sample_case_operator,
+        sample_forecast_dataset,
+        sample_target_dataset,
+    ):
+        mock_build_datasets.return_value = (
+            sample_forecast_dataset,
+            sample_target_dataset,
+        )
+        mock_derive_variables.side_effect = lambda ds, variables, **kwargs: ds
+        mock_evaluate_metric.return_value = _annotated_result(
+            metric="MockMetric", case_id_number=1
+        )
+        sample_case_operator.target.maybe_align_forecast_to_target.return_value = (
+            sample_forecast_dataset,
+            sample_target_dataset,
+        )
+
+        with pytest.raises(ValueError, match="pandas"):
+            evaluate.compute_case_operator(sample_case_operator, output_format="csv")
 
 
 class TestPipelineFunctions:
@@ -1903,21 +2126,21 @@ class TestPipelineFunctions:
 class TestMetricEvaluation:
     """Test metric evaluation functionality."""
 
-    def test_evaluate_metric_and_return_df(
+    def test_evaluate_metric(
         self,
         sample_forecast_dataset,
         sample_target_dataset,
         sample_case_operator,
         mock_base_metric,
     ):
-        """Test _evaluate_metric_and_return_df function."""
+        """Test _evaluate_metric function."""
         # Setup the metric mock
         mock_result = xr.DataArray(
             data=[1.5], dims=["lead_time"], coords={"lead_time": [0]}
         )
         mock_base_metric.name = "TestMetric"
         mock_base_metric.compute_metric.return_value = mock_result
-        result = evaluate._evaluate_metric_and_return_df(
+        result = evaluate._evaluate_metric(
             forecast_ds=sample_forecast_dataset,
             target_ds=sample_target_dataset,
             forecast_variable="surface_air_temperature",
@@ -1926,30 +2149,29 @@ class TestMetricEvaluation:
             case_operator=sample_case_operator,
         )
 
-        assert isinstance(result, pd.DataFrame)
-        assert "value" in result.columns
-        assert "metric" in result.columns
-        assert "case_id_number" in result.columns
-        assert "event_type" in result.columns
-        assert result["metric"].iloc[0] == "TestMetric"
-        assert result["case_id_number"].iloc[0] == 1
-        assert result["event_type"].iloc[0] == "heat_wave"
+        assert isinstance(result, xr.DataArray)
+        assert "metric" in result.coords
+        assert "case_id_number" in result.coords
+        assert "event_type" in result.coords
+        assert result.coords["metric"].item() == "TestMetric"
+        assert result.coords["case_id_number"].item() == 1
+        assert result.coords["event_type"].item() == "heat_wave"
 
-    def test_evaluate_metric_and_return_df_with_kwargs(
+    def test_evaluate_metric_with_kwargs(
         self,
         sample_forecast_dataset,
         sample_target_dataset,
         sample_case_operator,
         mock_base_metric,
     ):
-        """Test _evaluate_metric_and_return_df with additional kwargs."""
+        """Test _evaluate_metric with additional kwargs."""
         mock_result = xr.DataArray(
             data=[2.0], dims=["lead_time"], coords={"lead_time": [6]}
         )
         mock_base_metric.name = "TestMetric"
         mock_base_metric.compute_metric.return_value = mock_result
 
-        evaluate._evaluate_metric_and_return_df(
+        evaluate._evaluate_metric(
             forecast_ds=sample_forecast_dataset,
             target_ds=sample_target_dataset,
             forecast_variable="surface_air_temperature",
@@ -1965,10 +2187,10 @@ class TestMetricEvaluation:
         assert "threshold" in call_kwargs
         assert call_kwargs["threshold"] == 0.5
 
-    def test_evaluate_metric_and_return_df_with_derived_variables(
+    def test_evaluate_metric_with_derived_variables(
         self, mock_base_metric, sample_case_operator
     ):
-        """Test _evaluate_metric_and_return_df with derived variables."""
+        """Test _evaluate_metric with derived variables."""
         # Create datasets with derived variables included
         forecast_ds = xr.Dataset(
             {
@@ -2016,7 +2238,7 @@ class TestMetricEvaluation:
         mock_base_metric.name = "TestDerivedMetric"
         mock_base_metric.compute_metric.return_value = mock_result
 
-        result = evaluate._evaluate_metric_and_return_df(
+        result = evaluate._evaluate_metric(
             forecast_ds=forecast_ds,
             target_ds=target_ds,
             forecast_variable="derived_forecast_var",
@@ -2026,18 +2248,17 @@ class TestMetricEvaluation:
         )
 
         # Verify the result structure
-        assert isinstance(result, pd.DataFrame)
-        assert "value" in result.columns
-        assert "metric" in result.columns
-        assert "target_variable" in result.columns
-        assert "case_id_number" in result.columns
-        assert "event_type" in result.columns
+        assert isinstance(result, xr.DataArray)
+        assert "metric" in result.coords
+        assert "target_variable" in result.coords
+        assert "case_id_number" in result.coords
+        assert "event_type" in result.coords
 
         # Check the values
-        assert result["metric"].iloc[0] == "TestDerivedMetric"
-        assert result["case_id_number"].iloc[0] == 1
-        assert result["event_type"].iloc[0] == "heat_wave"
-        assert result["value"].iloc[0] == 2.5
+        assert result.coords["metric"].item() == "TestDerivedMetric"
+        assert result.coords["case_id_number"].item() == 1
+        assert result.coords["event_type"].item() == "heat_wave"
+        assert result.item() == 2.5
 
         # Verify that compute_metric was called with the derived variables
         mock_base_metric.compute_metric.assert_called_once()
@@ -2104,7 +2325,7 @@ class TestErrorHandling:
         )
 
         with pytest.raises(Exception, match="Metric computation failed"):
-            evaluate._evaluate_metric_and_return_df(
+            evaluate._evaluate_metric(
                 forecast_ds=sample_forecast_dataset,
                 target_ds=sample_target_dataset,
                 forecast_variable="surface_air_temperature",
@@ -2113,14 +2334,16 @@ class TestErrorHandling:
                 case_operator=sample_case_operator,
             )
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_evaluation_serial_exception(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test _run_evaluation handles exceptions in serial execution."""
         mock_tqdm.return_value = [sample_case_operator]
-        mock_compute_case_operator.side_effect = Exception("Serial execution failed")
+        mock_compute_case_operator_results.side_effect = Exception(
+            "Serial execution failed"
+        )
 
         with pytest.raises(Exception, match="Serial execution failed"):
             # Serial mode: don't pass parallel_config
@@ -2141,14 +2364,16 @@ class TestErrorHandling:
                 parallel_config={"backend": "threading", "n_jobs": 2},
             )
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_serial_evaluation_case_operator_exception(
-        self, mock_tqdm, mock_compute_case_operator, sample_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results, sample_case_operator
     ):
         """Test serial execution handles exceptions from individual case operators."""
         mock_tqdm.return_value = [sample_case_operator]
-        mock_compute_case_operator.side_effect = Exception("Case operator failed")
+        mock_compute_case_operator_results.side_effect = Exception(
+            "Case operator failed"
+        )
 
         with pytest.raises(Exception, match="Case operator failed"):
             evaluate._run_evaluation([sample_case_operator], parallel_config=None)
@@ -2216,10 +2441,10 @@ class TestErrorHandling:
         with pytest.raises(Exception, match="Execution failed"):
             ewb.run_evaluation()
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_run_serial_evaluation_partial_failure(
-        self, mock_tqdm, mock_compute_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results
     ):
         """Test serial execution behavior when some case operators fail."""
         case_op_1 = mock.Mock()
@@ -2233,10 +2458,10 @@ class TestErrorHandling:
         mock_tqdm.return_value = case_operators
 
         # First succeeds, second fails, third never reached
-        mock_compute_case_operator.side_effect = [
-            pd.DataFrame({"value": [1.0], "case_id_number": [1]}),
+        mock_compute_case_operator_results.side_effect = [
+            [_annotated_result(value=1.0, case_id_number=1)],
             Exception("Case operator 2 failed"),
-            pd.DataFrame({"value": [3.0], "case_id_number": [3]}),
+            [_annotated_result(value=3.0, case_id_number=3)],
         ]
 
         # Should fail on the second case operator
@@ -2244,7 +2469,7 @@ class TestErrorHandling:
             evaluate._run_evaluation(case_operators, parallel_config=None)
 
         # Should have tried only the first two
-        assert mock_compute_case_operator.call_count == 2
+        assert mock_compute_case_operator_results.call_count == 2
 
     @mock.patch("extremeweatherbench.utils.ParallelTqdm")
     @mock.patch("joblib.delayed")
@@ -2320,23 +2545,19 @@ class TestIntegration:
             sample_target_dataset
         )
 
-        # Mock the metric evaluation to return a proper DataFrame
-        mock_result_df = pd.DataFrame(
-            {
-                "value": [1.0],
-                "target_variable": ["2m_temperature"],
-                "metric": ["MockMetric"],
-                "target_source": ["test_target"],
-                "forecast_source": ["test_forecast"],
-                "case_id_number": [1],
-                "event_type": ["heat_wave"],
-            }
+        # Mock the metric evaluation to return a proper annotated result
+        mock_result = _annotated_result(
+            value=1.0,
+            target_variable="2m_temperature",
+            metric="MockMetric",
+            target_source="test_target",
+            forecast_source="test_forecast",
+            case_id_number=1,
+            event_type="heat_wave",
         )
 
-        with mock.patch(
-            "extremeweatherbench.evaluate._evaluate_metric_and_return_df"
-        ) as mock_eval:
-            mock_eval.return_value = mock_result_df
+        with mock.patch("extremeweatherbench.evaluate._evaluate_metric") as mock_eval:
+            mock_eval.return_value = mock_result
 
             # Create and run the workflow
             ewb = evaluate.ExtremeWeatherBench(
@@ -2420,17 +2641,15 @@ class TestIntegration:
             sample_target_dataset,
         )
 
-        # Mock the metric evaluation to return proper DataFrames
-        mock_result_df = pd.DataFrame(
-            {
-                "value": [1.0],
-                "target_variable": ["2m_temperature"],
-                "metric": ["TestMetric"],
-                "target_source": ["test_target"],
-                "forecast_source": ["test_forecast"],
-                "case_id_number": [1],
-                "event_type": ["heat_wave"],
-            }
+        # Mock the metric evaluation to return proper annotated results
+        mock_result = _annotated_result(
+            value=1.0,
+            target_variable="2m_temperature",
+            metric="TestMetric",
+            target_source="test_target",
+            forecast_source="test_forecast",
+            case_id_number=1,
+            event_type="heat_wave",
         )
 
         with mock.patch(
@@ -2439,9 +2658,9 @@ class TestIntegration:
             mock_derive.side_effect = lambda ds, variables, **kwargs: ds
 
             with mock.patch(
-                "extremeweatherbench.evaluate._evaluate_metric_and_return_df"
+                "extremeweatherbench.evaluate._evaluate_metric"
             ) as mock_eval:
-                mock_eval.return_value = mock_result_df
+                mock_eval.return_value = mock_result
 
                 ewb = evaluate.ExtremeWeatherBench(
                     case_metadata=sample_cases_list,
@@ -2453,9 +2672,12 @@ class TestIntegration:
                 # Should have results for each metric combination
                 assert len(result) >= 2  # At least 2 metrics * 1 case
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     def test_serial_vs_parallel_results_consistency(
-        self, mock_compute_case_operator, sample_cases_list, sample_evaluation_object
+        self,
+        mock_compute_case_operator_results,
+        sample_cases_list,
+        sample_evaluation_object,
     ):
         """Test that serial and parallel execution produce identical results."""
         # Setup mock case operators
@@ -2466,22 +2688,22 @@ class TestIntegration:
         case_operators = [case_op_1, case_op_2]
 
         # Define consistent results
-        result_1 = pd.DataFrame(
-            {
-                "value": [1.5],
-                "metric": ["TestMetric"],
-                "case_id_number": [1],
-                "event_type": ["heat_wave"],
-            }
-        )
-        result_2 = pd.DataFrame(
-            {
-                "value": [2.3],
-                "metric": ["TestMetric"],
-                "case_id_number": [2],
-                "event_type": ["heat_wave"],
-            }
-        )
+        result_1 = [
+            _annotated_result(
+                value=1.5,
+                metric="TestMetric",
+                case_id_number=1,
+                event_type="heat_wave",
+            )
+        ]
+        result_2 = [
+            _annotated_result(
+                value=2.3,
+                metric="TestMetric",
+                case_id_number=2,
+                event_type="heat_wave",
+            )
+        ]
 
         ewb = evaluate.ExtremeWeatherBench(
             case_metadata=sample_cases_list,
@@ -2492,15 +2714,15 @@ class TestIntegration:
             mock_build.return_value = case_operators
 
             # Test serial execution
-            mock_compute_case_operator.side_effect = [result_1, result_2]
+            mock_compute_case_operator_results.side_effect = [result_1, result_2]
             serial_result = ewb.run_evaluation(n_jobs=1)
 
             # Reset mock and test parallel execution. Threading (rather than
             # the default loky) keeps this in-process, since the mocked
-            # compute_case_operator can't be pickled across process
-            # boundaries by the progress-reporting wrapper.
-            mock_compute_case_operator.reset_mock()
-            mock_compute_case_operator.side_effect = [result_1, result_2]
+            # compute results can't be pickled across process boundaries by
+            # the progress-reporting wrapper.
+            mock_compute_case_operator_results.reset_mock()
+            mock_compute_case_operator_results.side_effect = [result_1, result_2]
             parallel_result = ewb.run_evaluation(
                 parallel_config={"backend": "threading", "n_jobs": 2}
             )
@@ -2512,10 +2734,10 @@ class TestIntegration:
             assert len(parallel_result) == 2
             assert list(serial_result.columns) == list(parallel_result.columns)
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_execution_method_performance_comparison(
-        self, mock_tqdm, mock_compute_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results
     ):
         """Test that both execution methods handle the same workload."""
         import time
@@ -2528,27 +2750,27 @@ class TestIntegration:
 
         # Mock results
         mock_results = [
-            pd.DataFrame(
-                {
-                    "value": [i * 0.1],
-                    "metric": ["TestMetric"],
-                    "case_id_number": [i],
-                    "event_type": ["heat_wave"],
-                }
-            )
+            [
+                _annotated_result(
+                    value=i * 0.1,
+                    metric="TestMetric",
+                    case_id_number=i,
+                    event_type="heat_wave",
+                )
+            ]
             for i in range(10)
         ]
 
         # Test serial execution timing - call _run_evaluation in serial mode
-        mock_compute_case_operator.side_effect = mock_results
+        mock_compute_case_operator_results.side_effect = mock_results
         start_time = time.time()
         serial_result = evaluate._run_evaluation(case_operators, parallel_config=None)
         serial_time = time.time() - start_time
 
         # Test parallel execution timing - call _run_parallel_evaluation directly with mocked
         # Parallel
-        serial_call_count = mock_compute_case_operator.call_count
-        mock_compute_case_operator.side_effect = mock_results
+        serial_call_count = mock_compute_case_operator_results.call_count
+        mock_compute_case_operator_results.side_effect = mock_results
 
         with mock.patch(
             "extremeweatherbench.utils.ParallelTqdm"
@@ -2569,22 +2791,24 @@ class TestIntegration:
         # Serial execution should have called compute_case_operator
         assert serial_call_count == 10  # Serial execution
         # Parallel execution is mocked, so the call count doesn't increase
-        assert mock_compute_case_operator.call_count == 10  # Only serial calls
+        assert mock_compute_case_operator_results.call_count == 10  # Only serial calls
         # Verify timing variables are used (avoid unused variable warnings)
         assert serial_time >= 0
         assert parallel_time >= 0
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
-    def test_mixed_execution_parameters(self, mock_tqdm, mock_compute_case_operator):
+    def test_mixed_execution_parameters(
+        self, mock_tqdm, mock_compute_case_operator_results
+    ):
         """Test various parameter combinations for execution methods."""
         case_operators = [mock.Mock(), mock.Mock()]
         for case_operator in case_operators:
             case_operator.metric_list = []
         mock_tqdm.return_value = case_operators
         mock_results = [
-            pd.DataFrame({"value": [1.0], "case_id_number": [1]}),
-            pd.DataFrame({"value": [2.0], "case_id_number": [2]}),
+            [_annotated_result(value=1.0, case_id_number=1)],
+            [_annotated_result(value=2.0, case_id_number=2)],
         ]
 
         # Test different execution methods directly
@@ -2600,15 +2824,15 @@ class TestIntegration:
         ]
 
         for config in test_configs:
-            mock_compute_case_operator.reset_mock()
-            mock_compute_case_operator.side_effect = mock_results
+            mock_compute_case_operator_results.reset_mock()
+            mock_compute_case_operator_results.side_effect = mock_results
 
             if config["method"] == "serial":
                 result = evaluate._run_evaluation(*config["args"], parallel_config=None)
                 # All configurations should produce valid results
                 assert isinstance(result, list)
                 assert len(result) == 2
-                assert mock_compute_case_operator.call_count == 2
+                assert mock_compute_case_operator_results.call_count == 2
             else:
                 # Mock parallel execution to avoid serialization issues
                 with mock.patch(
@@ -2634,26 +2858,26 @@ class TestIntegration:
                     # All configurations should produce valid results
                     assert isinstance(result, list)
                     assert len(result) == 2
-                    # Parallel execution is mocked, so compute_case_operator is not
-                    # called
-                    assert mock_compute_case_operator.call_count == 0
+                    # Parallel execution is mocked, so compute results are not
+                    # gathered via the serial path
+                    assert mock_compute_case_operator_results.call_count == 0
 
     def test_execution_method_kwargs_propagation(self):
         """Test that kwargs are properly propagated through execution methods."""
         case_operator = mock.Mock()
         case_operator.metric_list = []
 
-        # Mock compute_case_operator to capture kwargs
+        # Mock _compute_case_operator_results to capture kwargs
         def mock_compute_with_kwargs(case_op, cache_dir, **kwargs):
             # Store kwargs for verification
             mock_compute_with_kwargs.captured_kwargs = kwargs
-            return pd.DataFrame({"value": [1.0]})
+            return [_annotated_result(value=1.0)]
 
         mock_compute_with_kwargs.captured_kwargs = {}
 
         with (
             mock.patch(
-                "extremeweatherbench.evaluate.compute_case_operator",
+                "extremeweatherbench.evaluate._compute_case_operator_results",
                 side_effect=mock_compute_with_kwargs,
             ),
             mock.patch("tqdm.auto.tqdm", return_value=[case_operator]),
@@ -2681,7 +2905,9 @@ class TestIntegration:
                 mock_delayed.return_value = mock_compute_with_kwargs
                 mock_parallel_instance = mock.Mock()
                 mock_parallel_class.return_value = mock_parallel_instance
-                mock_parallel_instance.return_value = [pd.DataFrame({"value": [1.0]})]
+                mock_parallel_instance.return_value = [
+                    [_annotated_result(value=1.0)]
+                ]
 
                 # Reset captured kwargs
                 mock_compute_with_kwargs.captured_kwargs = {}
@@ -2727,10 +2953,10 @@ class TestIntegration:
             )
             assert result == []
 
-    @mock.patch("extremeweatherbench.evaluate.compute_case_operator")
+    @mock.patch("extremeweatherbench.evaluate._compute_case_operator_results")
     @mock.patch("tqdm.auto.tqdm")
     def test_large_case_operator_list_handling(
-        self, mock_tqdm, mock_compute_case_operator
+        self, mock_tqdm, mock_compute_case_operator_results
     ):
         """Test handling of large numbers of case operators."""
         # Create a large list of case operators
@@ -2742,22 +2968,20 @@ class TestIntegration:
 
         # Create mock results
         mock_results = [
-            pd.DataFrame(
-                {"value": [i * 0.01], "case_id_number": [i], "metric": ["TestMetric"]}
-            )
+            [_annotated_result(value=i * 0.01, case_id_number=i, metric="TestMetric")]
             for i in range(num_cases)
         ]
 
         # Test serial execution
-        mock_compute_case_operator.side_effect = mock_results
+        mock_compute_case_operator_results.side_effect = mock_results
         serial_results = evaluate._run_evaluation(case_operators, parallel_config=None)
 
         assert len(serial_results) == num_cases
-        assert mock_compute_case_operator.call_count == num_cases
+        assert mock_compute_case_operator_results.call_count == num_cases
 
         # Test parallel execution
-        mock_compute_case_operator.reset_mock()
-        mock_compute_case_operator.side_effect = mock_results
+        mock_compute_case_operator_results.reset_mock()
+        mock_compute_case_operator_results.side_effect = mock_results
 
         with mock.patch(
             "extremeweatherbench.utils.ParallelTqdm"

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -895,14 +895,10 @@ class TestGroupOperatorsSharingForecast:
         sample_case_operator.forecast.source = "hres://x"
         op2.forecast.name = "HRES"
         op2.forecast.source = "hres://x"
-        groups = evaluate._group_operators_sharing_forecast(
-            [sample_case_operator, op2]
-        )
+        groups = evaluate._group_operators_sharing_forecast([sample_case_operator, op2])
         assert len(groups) == 1
         assert [item.index for item in groups[0]] == [0, 1]
-        assert all(
-            isinstance(item, evaluate.IndexedOperator) for item in groups[0]
-        )
+        assert all(isinstance(item, evaluate.IndexedOperator) for item in groups[0])
         assert groups[0][0].operator is sample_case_operator
         assert groups[0][1].operator is op2
 
@@ -914,16 +910,12 @@ class TestGroupOperatorsSharingForecast:
         sample_case_operator.forecast.name = "HRES"
         sample_case_operator.forecast.source = "hres://x"
         op2 = dataclasses.replace(sample_case_operator, forecast=other_forecast)
-        groups = evaluate._group_operators_sharing_forecast(
-            [sample_case_operator, op2]
-        )
+        groups = evaluate._group_operators_sharing_forecast([sample_case_operator, op2])
         assert len(groups) == 2
         assert [item.index for item in groups[0]] == [0]
         assert [item.index for item in groups[1]] == [1]
 
-    def test_interleaved_operators_keep_original_indices(
-        self, sample_case_operator
-    ):
+    def test_interleaved_operators_keep_original_indices(self, sample_case_operator):
         """Non-adjacent shared-forecast operators keep their input indices."""
         shared = sample_case_operator.forecast
         shared.name = "HRES"
@@ -2156,9 +2148,7 @@ class TestPipelineFunctions:
         sample_case_operator.forecast.maybe_convert_to_dataset.assert_called_once()
         sample_case_operator.forecast.add_source_to_dataset_attrs.assert_called_once()
         sample_case_operator.forecast.preprocess.assert_called_once()
-        method_names = [
-            name for name, *_ in sample_case_operator.forecast.method_calls
-        ]
+        method_names = [name for name, *_ in sample_case_operator.forecast.method_calls]
         assert method_names.index("subset_data_to_case") < method_names.index(
             "preprocess"
         )
@@ -2284,8 +2274,8 @@ class TestPipelineFunctions:
         assert mock_evaluate_metric.called
         forecast_ds = mock_evaluate_metric.call_args.kwargs["forecast_ds"]
         target_ds = mock_evaluate_metric.call_args.kwargs["target_ds"]
-        first_fc = list(forecast_ds.data_vars)[0]
-        first_tg = list(target_ds.data_vars)[0]
+        first_fc = next(iter(forecast_ds.data_vars))
+        first_tg = next(iter(target_ds.data_vars))
         assert not hasattr(forecast_ds[first_fc].data, "chunks")
         assert not hasattr(target_ds[first_tg].data, "chunks")
 
@@ -2953,9 +2943,7 @@ class TestIntegration:
         ) as mock_parallel_class:
             mock_parallel_instance = mock.Mock()
             mock_parallel_class.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = [
-                [row] for row in mock_results
-            ]
+            mock_parallel_instance.return_value = [[row] for row in mock_results]
 
             start_time = time.time()
             parallel_result = evaluate._run_parallel_evaluation(
@@ -3085,9 +3073,7 @@ class TestIntegration:
                 mock_delayed.return_value = mock_compute_with_kwargs
                 mock_parallel_instance = mock.Mock()
                 mock_parallel_class.return_value = mock_parallel_instance
-                mock_parallel_instance.return_value = [
-                    [[_annotated_result(value=1.0)]]
-                ]
+                mock_parallel_instance.return_value = [[[_annotated_result(value=1.0)]]]
 
                 # Reset captured kwargs
                 mock_compute_with_kwargs.captured_kwargs = {}
@@ -3168,9 +3154,7 @@ class TestIntegration:
         ) as mock_parallel_class:
             mock_parallel_instance = mock.Mock()
             mock_parallel_class.return_value = mock_parallel_instance
-            mock_parallel_instance.return_value = [
-                [row] for row in mock_results
-            ]
+            mock_parallel_instance.return_value = [[row] for row in mock_results]
 
             parallel_results = evaluate._run_parallel_evaluation(
                 case_operators, parallel_config={"backend": "threading", "n_jobs": 4}

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+import xarray as xr
 
 from extremeweatherbench import evaluate_cli
 
@@ -211,6 +212,8 @@ class TestParallelExecution:
             n_jobs=3,
             parallel_config=None,
             progress=True,
+            output_format="pandas",
+            sparse=False,
         )
 
     @mock.patch(
@@ -445,6 +448,306 @@ class TestResultsSaving:
 
         assert result.exit_code == 0
         # Output suppressed - only check exit code
+
+
+def _sample_results_dataset():
+    """Build a small flat results Dataset matching the run's output shape."""
+    return xr.Dataset(
+        {"surface_air_temperature": (("case_id_number", "metric"), [[1.5, 2.3]])},
+        coords={
+            "case_id_number": [1],
+            "metric": ["rmse", "mae"],
+            "event_type": ("case_id_number", ["heat_wave"]),
+        },
+    )
+
+
+class TestOutputFormats:
+    """Test --output-format and --sparse CLI options."""
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    @mock.patch("extremeweatherbench.evaluate_cli.outputs.write_results")
+    def test_default_output_format_writes_csv(
+        self,
+        mock_write_results,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test that omitting --output-format still writes a csv via csv path."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame({"value": [1.0]})
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner, ["--default", "--output-dir", str(temp_config_dir)]
+        )
+
+        assert result.exit_code == 0
+        mock_ewb.run_evaluation.assert_called_once_with(
+            n_jobs=1,
+            parallel_config=None,
+            progress=True,
+            output_format="pandas",
+            sparse=False,
+        )
+        mock_write_results.assert_called_once()
+        args, kwargs = mock_write_results.call_args
+        assert str(args[1]).endswith("evaluation_results.csv")
+        assert args[2] == "csv"
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    @mock.patch("extremeweatherbench.evaluate_cli.outputs.write_results")
+    def test_explicit_csv_output_format(
+        self,
+        mock_write_results,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test that --output-format csv writes the same csv filename."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame({"value": [1.0]})
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--output-dir",
+                str(temp_config_dir),
+                "--output-format",
+                "csv",
+            ],
+        )
+
+        assert result.exit_code == 0
+        args, kwargs = mock_write_results.call_args
+        assert str(args[1]).endswith("evaluation_results.csv")
+        assert args[2] == "csv"
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_netcdf_output_format_writes_real_file(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test --output-format netcdf writes a reopenable .nc file."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = _sample_results_dataset()
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--output-dir",
+                str(temp_config_dir),
+                "--output-format",
+                "netcdf",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_ewb.run_evaluation.assert_called_once_with(
+            n_jobs=1,
+            parallel_config=None,
+            progress=True,
+            output_format="xarray",
+            sparse=False,
+        )
+
+        output_file = temp_config_dir / "evaluation_results.nc"
+        assert output_file.exists()
+        with xr.open_dataset(output_file) as reopened:
+            assert list(reopened["case_id_number"].values) == [1]
+            assert reopened["surface_air_temperature"].values.tolist() == [[1.5, 2.3]]
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_zarr_output_format_writes_real_store(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test --output-format zarr writes a reopenable .zarr store."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = _sample_results_dataset()
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--output-dir",
+                str(temp_config_dir),
+                "--output-format",
+                "zarr",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output_store = temp_config_dir / "evaluation_results.zarr"
+        assert output_store.exists()
+        with xr.open_zarr(output_store) as reopened:
+            assert list(reopened["case_id_number"].values) == [1]
+
+    def test_sparse_with_csv_raises_usage_error(self, runner):
+        """Test --sparse with --output-format csv fails with a usage error."""
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            ["--default", "--output-format", "csv", "--sparse"],
+        )
+
+        assert result.exit_code != 0
+        assert "--sparse" in result.output
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    @mock.patch("extremeweatherbench.evaluate_cli.outputs.write_results")
+    def test_sparse_forwarded_for_netcdf(
+        self,
+        mock_write_results,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test --sparse is forwarded to run_evaluation for netcdf output."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = _sample_results_dataset()
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--output-dir",
+                str(temp_config_dir),
+                "--output-format",
+                "netcdf",
+                "--sparse",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_ewb.run_evaluation.assert_called_once_with(
+            n_jobs=1,
+            parallel_config=None,
+            progress=True,
+            output_format="xarray",
+            sparse=True,
+        )
+        args, kwargs = mock_write_results.call_args
+        assert kwargs.get("sparse") is True or args[-1] is True
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_empty_dataframe_results_not_written(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test the empty-results path is unchanged for output_format csv."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = pd.DataFrame()
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            ["--default", "--output-dir", str(temp_config_dir)],
+        )
+
+        assert result.exit_code == 0
+        assert not (temp_config_dir / "evaluation_results.csv").exists()
+
+    @mock.patch(
+        "extremeweatherbench.defaults.get_brightband_evaluation_objects",
+        return_value=[],
+    )
+    @mock.patch("extremeweatherbench.evaluate_cli._load_default_cases")
+    @mock.patch("extremeweatherbench.evaluate.ExtremeWeatherBench")
+    def test_empty_dataset_results_not_written(
+        self,
+        mock_ewb_class,
+        mock_load_cases,
+        mock_get_brightband,
+        runner,
+        temp_config_dir,
+    ):
+        """Test the empty-results path works for an empty xarray Dataset."""
+        mock_ewb = mock.Mock()
+        mock_ewb.case_operators = []
+        mock_ewb.run_evaluation.return_value = xr.Dataset()
+        mock_ewb_class.return_value = mock_ewb
+        mock_load_cases.return_value = []
+
+        result = runner.invoke(
+            evaluate_cli.cli_runner,
+            [
+                "--default",
+                "--output-dir",
+                str(temp_config_dir),
+                "--output-format",
+                "netcdf",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert not (temp_config_dir / "evaluation_results.nc").exists()
 
 
 class TestHelperFunctions:

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -501,7 +501,7 @@ class TestOutputFormats:
             sparse=False,
         )
         mock_write_results.assert_called_once()
-        args, kwargs = mock_write_results.call_args
+        args, _kwargs = mock_write_results.call_args
         assert str(args[1]).endswith("evaluation_results.csv")
         assert args[2] == "csv"
 
@@ -540,7 +540,7 @@ class TestOutputFormats:
         )
 
         assert result.exit_code == 0
-        args, kwargs = mock_write_results.call_args
+        args, _kwargs = mock_write_results.call_args
         assert str(args[1]).endswith("evaluation_results.csv")
         assert args[2] == "csv"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,6 +48,12 @@ class TestModuleImports:
 
         assert isinstance(cases, types.ModuleType)
 
+    def test_outputs_is_module(self):
+        """Test that outputs is an actual module, not a SimpleNamespace."""
+        from extremeweatherbench import outputs
+
+        assert isinstance(outputs, types.ModuleType)
+
 
 class TestModuleAccessPatterns:
     """Test both import patterns work identically."""
@@ -72,6 +78,13 @@ class TestModuleAccessPatterns:
         from extremeweatherbench import utils
 
         assert ewb.utils is utils
+
+    def test_ewb_dot_notation_equals_direct_import_outputs(self):
+        """Test ewb.outputs is the same object as direct import."""
+        import extremeweatherbench as ewb
+        from extremeweatherbench import outputs
+
+        assert ewb.outputs is outputs
 
 
 class TestModuleLevelConstants:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1553,6 +1553,28 @@ class TestLSR:
         mock_read_parquet.assert_called_once_with("test.parquet", storage_options={})
         assert result.equals(sample_lsr_dataframe)
 
+    @mock.patch("pandas.read_parquet")
+    def test_lsr_open_data_from_source_with_time_filters(
+        self, mock_read_parquet, sample_lsr_dataframe
+    ):
+        """Case metadata should be pushed into the parquet read as filters."""
+        mock_read_parquet.return_value = sample_lsr_dataframe
+        mock_case = mock.Mock()
+        mock_case.start_date = pd.Timestamp("2021-06-20")
+        mock_case.end_date = pd.Timestamp("2021-06-21")
+        lsr = inputs.LSR(
+            source="test.parquet",
+            variables=["report"],
+            variable_mapping={},
+            storage_options={},
+        )
+        lsr._open_data_from_source(case_metadata=mock_case)
+        kwargs = mock_read_parquet.call_args.kwargs
+        assert kwargs["storage_options"] == {}
+        assert kwargs["filters"] == [
+            ("valid_time", ">=", pd.Timestamp("2021-06-20")),
+            ("valid_time", "<=", pd.Timestamp("2021-06-21")),
+        ]
 
     def test_lsr_subset_data_to_case(self, sample_lsr_dataframe):
         """Test LSR subset_data_to_case."""

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1074,9 +1074,7 @@ class TestERA5:
         )
         forecast = target.copy(deep=True)
         with mock.patch.object(xr.Dataset, "interp") as mock_interp:
-            aligned_fc, aligned_tg = inputs.align_forecast_to_target(
-                forecast, target
-            )
+            aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
             mock_interp.assert_not_called()
         np.testing.assert_array_equal(
             aligned_fc.latitude.values, aligned_tg.latitude.values

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1057,6 +1057,68 @@ class TestERA5:
         assert len(aligned_target.time) > 0
         assert len(aligned_forecast.valid_time) > 0
 
+    def test_align_skips_interp_when_lat_lon_match(self):
+        """Skip spatial interp when forecast and target grids already match."""
+        times = pd.date_range("2021-06-20", periods=4, freq="6h")
+        lat = np.linspace(40, 50, 5)
+        lon = np.linspace(100, 110, 6)
+        data = np.ones((4, 5, 6))
+        target = xr.Dataset(
+            {
+                "surface_air_temperature": (
+                    ["valid_time", "latitude", "longitude"],
+                    data,
+                )
+            },
+            coords={"valid_time": times, "latitude": lat, "longitude": lon},
+        )
+        forecast = target.copy(deep=True)
+        with mock.patch.object(xr.Dataset, "interp") as mock_interp:
+            aligned_fc, aligned_tg = inputs.align_forecast_to_target(
+                forecast, target
+            )
+            mock_interp.assert_not_called()
+        np.testing.assert_array_equal(
+            aligned_fc.latitude.values, aligned_tg.latitude.values
+        )
+
+    def test_align_interps_when_lat_lon_differ(self):
+        """Mismatched lat/lon still interpolates forecast onto the target."""
+        times = pd.date_range("2021-06-20", periods=4, freq="6h")
+        target = xr.Dataset(
+            {
+                "surface_air_temperature": (
+                    ["valid_time", "latitude", "longitude"],
+                    np.ones((4, 5, 6)),
+                )
+            },
+            coords={
+                "valid_time": times,
+                "latitude": np.linspace(40, 50, 5),
+                "longitude": np.linspace(100, 110, 6),
+            },
+        )
+        forecast = xr.Dataset(
+            {
+                "surface_air_temperature": (
+                    ["valid_time", "latitude", "longitude"],
+                    np.ones((4, 4, 5)),
+                )
+            },
+            coords={
+                "valid_time": times,
+                "latitude": np.linspace(40, 50, 4),
+                "longitude": np.linspace(100, 110, 5),
+            },
+        )
+        aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        np.testing.assert_array_equal(
+            aligned_fc.latitude.values, aligned_tg.latitude.values
+        )
+        np.testing.assert_array_equal(
+            aligned_fc.longitude.values, aligned_tg.longitude.values
+        )
+
     def test_era5_maybe_align_forecast_to_target_different_grid(
         self, sample_era5_dataset
     ):
@@ -1490,6 +1552,7 @@ class TestLSR:
 
         mock_read_parquet.assert_called_once_with("test.parquet", storage_options={})
         assert result.equals(sample_lsr_dataframe)
+
 
     def test_lsr_subset_data_to_case(self, sample_lsr_dataframe):
         """Test LSR subset_data_to_case."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -131,12 +131,13 @@ def create_mock_input(variables: list[str], dataset: xr.Dataset, input_type: str
     mock_input.variables = variables
 
     # Mock all pipeline methods to return the dataset
-    mock_input.open_and_maybe_preprocess_data_from_source.return_value = dataset
+    mock_input._open_data_from_source.return_value = dataset
     mock_input.maybe_map_variable_names.return_value = dataset
     mock_input.maybe_subset_variables.return_value = dataset
     mock_input.subset_data_to_case.return_value = dataset
     mock_input.maybe_convert_to_dataset.return_value = dataset
     mock_input.add_source_to_dataset_attrs.return_value = dataset
+    mock_input.preprocess.return_value = dataset
 
     if input_type == "target":
         # This should return (aligned_forecast, aligned_target)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,1412 @@
+"""Tests for the outputs module."""
+
+import datetime
+import logging
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pandas as pd
+import pytest
+import sparse
+import xarray as xr
+
+from extremeweatherbench import (
+    cases,
+    evaluate,
+    inputs,
+    metrics,
+    outputs,
+    regions,
+    utils,
+)
+
+METADATA_KWARGS = {
+    "metric": "RMSE",
+    "target_variable": "2m_temperature",
+    "forecast_variable": "surface_air_temperature",
+    "forecast_source": "test_forecast",
+    "target_source": "test_target",
+    "case_id_number": 1,
+    "event_type": "heat_wave",
+}
+
+
+def _lead_time_result(values=(1.0, 2.0), lead_times=(0, 6)):
+    result = xr.DataArray(
+        data=list(values), dims=["lead_time"], coords={"lead_time": list(lead_times)}
+    )
+    return outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+
+def _init_time_result(values=(3.0, 4.0)):
+    init_times = pd.date_range("2021-06-20", periods=len(values), freq="D")
+    result = xr.DataArray(
+        data=list(values), dims=["init_time"], coords={"init_time": init_times}
+    )
+    return outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+
+class TestAnnotateMetricResult:
+    """Test annotate_metric_result attaches metadata without altering data."""
+
+    def test_attaches_scalar_coords_without_altering_dims_or_values(self):
+        result = xr.DataArray(
+            data=[1.0, 2.0, 3.0],
+            dims=["lead_time"],
+            coords={"lead_time": [0, 6, 12]},
+        )
+        annotated = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+        assert annotated.dims == result.dims
+        np.testing.assert_array_equal(annotated.values, result.values)
+        for coord in outputs.METADATA_COORDS:
+            assert coord in annotated.coords
+            assert annotated.coords[coord].ndim == 0
+            assert coord not in annotated.dims
+
+    def test_does_not_mutate_the_input_array(self):
+        result = xr.DataArray(data=[1.0], dims=["lead_time"], coords={"lead_time": [0]})
+        outputs.annotate_metric_result(result, metric="RMSE")
+        assert "metric" not in result.coords
+
+    def test_metadata_values_are_correct(self):
+        result = xr.DataArray(data=[1.0], dims=["lead_time"], coords={"lead_time": [0]})
+        annotated = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+        for key, value in METADATA_KWARGS.items():
+            assert annotated.coords[key].item() == value
+
+
+class TestResultsToDataFrame:
+    """Test conversion of annotated results into the long-form DataFrame."""
+
+    def test_lead_time_result_has_output_columns(self):
+        df = outputs.results_to_dataframe([_lead_time_result()])
+        assert list(df.columns) == outputs.OUTPUT_COLUMNS
+
+    def test_init_time_result_has_output_columns(self):
+        df = outputs.results_to_dataframe([_init_time_result()])
+        assert list(df.columns) == outputs.OUTPUT_COLUMNS
+
+    def test_forecast_variable_is_dropped(self):
+        df = outputs.results_to_dataframe([_lead_time_result()])
+        assert "forecast_variable" not in df.columns
+
+    def test_extra_coords_survive_as_trailing_columns(self):
+        init_times = pd.date_range("2021-06-20", periods=2, freq="D")
+        result = xr.DataArray(
+            data=[3.0, 4.0], dims=["init_time"], coords={"init_time": init_times}
+        )
+        result = result.assign_coords(
+            forecast_landfall_latitude=("init_time", [10.0, 11.0]),
+            forecast_landfall_longitude=("init_time", [-80.0, -81.0]),
+        )
+        annotated = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+        df = outputs.results_to_dataframe([annotated])
+
+        expected_extra = ["forecast_landfall_latitude", "forecast_landfall_longitude"]
+        assert list(df.columns) == outputs.OUTPUT_COLUMNS + expected_extra
+
+    def test_regression_guard_matches_prior_schema(self):
+        """Guards the pre-refactor pandas schema: columns, order, dtypes, values."""
+        lead_times = [0, 6, 12]
+        values = [1.5, 2.5, 3.5]
+        result = xr.DataArray(
+            data=values, dims=["lead_time"], coords={"lead_time": lead_times}
+        )
+        annotated = outputs.annotate_metric_result(
+            result,
+            metric="RMSE",
+            target_variable="2m_temperature",
+            forecast_variable="surface_air_temperature",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=7,
+            event_type="heat_wave",
+        )
+
+        df = outputs.results_to_dataframe([annotated])
+
+        expected = pd.DataFrame(
+            {
+                "value": pd.Series(values, dtype="float64"),
+                "lead_time": pd.Series(lead_times, dtype="int64"),
+                "init_time": pd.Series([np.nan, np.nan, np.nan], dtype="float64"),
+                "target_variable": ["2m_temperature"] * 3,
+                "metric": ["RMSE"] * 3,
+                "forecast_source": ["test_forecast"] * 3,
+                "target_source": ["test_target"] * 3,
+                "case_id_number": pd.Series([7, 7, 7], dtype="int64"),
+                "event_type": ["heat_wave"] * 3,
+            }
+        )
+
+        assert list(df.columns) == list(expected.columns)
+        pd.testing.assert_frame_equal(df, expected)
+
+    def test_empty_list_returns_empty_output_columns(self):
+        df = outputs.results_to_dataframe([])
+        assert list(df.columns) == outputs.OUTPUT_COLUMNS
+        assert len(df) == 0
+
+    def test_list_with_empty_result_is_dropped(self):
+        empty_result = xr.DataArray(
+            data=[], dims=["lead_time"], coords={"lead_time": []}
+        )
+        annotated_empty = outputs.annotate_metric_result(
+            empty_result, **METADATA_KWARGS
+        )
+        good = _lead_time_result()
+
+        df = outputs.results_to_dataframe([annotated_empty, good])
+
+        assert len(df) == good.sizes["lead_time"]
+        assert df["metric"].notna().all()
+
+
+class TestSafeConcat:
+    """Test the moved _safe_concat helper."""
+
+    def test_filters_empty_and_all_na_frames(self):
+        good = pd.DataFrame({"value": [1.0], "metric": ["RMSE"]})
+        empty = pd.DataFrame(columns=["value", "metric"])
+        all_na = pd.DataFrame({"value": [np.nan], "metric": [np.nan]})
+
+        result = outputs._safe_concat([empty, all_na, good], ignore_index=True)
+
+        assert len(result) == 1
+        assert result["metric"].iloc[0] == "RMSE"
+
+    def test_all_invalid_frames_returns_empty_output_columns(self):
+        empty = pd.DataFrame(columns=["value"])
+        all_na = pd.DataFrame({"value": [np.nan]})
+
+        result = outputs._safe_concat([empty, all_na], ignore_index=True)
+
+        assert list(result.columns) == outputs.OUTPUT_COLUMNS
+        assert len(result) == 0
+
+    def test_empty_list_returns_empty_output_columns(self):
+        result = outputs._safe_concat([], ignore_index=True)
+        assert list(result.columns) == outputs.OUTPUT_COLUMNS
+        assert len(result) == 0
+
+
+class TestEnsureOutputSchema:
+    """Test the moved _ensure_output_schema helper."""
+
+    def test_warns_when_a_non_time_column_is_missing(self, caplog):
+        df = pd.DataFrame({"value": [1.0], "lead_time": [0]})
+        with caplog.at_level(logging.WARNING, logger="extremeweatherbench.outputs"):
+            result = outputs._ensure_output_schema(df)
+
+        assert any("Missing expected columns" in r.getMessage() for r in caplog.records)
+        assert "target_source" in result.columns
+
+    def test_does_not_warn_when_only_lead_time_or_init_time_is_missing(self, caplog):
+        df = pd.DataFrame(
+            {
+                "value": [1.0],
+                "lead_time": [0],
+                "target_variable": ["2m_temperature"],
+                "metric": ["RMSE"],
+                "forecast_source": ["fc"],
+                "target_source": ["tg"],
+                "case_id_number": [1],
+                "event_type": ["heat_wave"],
+            }
+        )
+        with caplog.at_level(logging.WARNING, logger="extremeweatherbench.outputs"):
+            outputs._ensure_output_schema(df)
+
+        assert not any(
+            "Missing expected columns" in r.getMessage() for r in caplog.records
+        )
+
+    def test_reorders_columns_and_preserves_extras(self):
+        df = pd.DataFrame(
+            {
+                "extra": [1],
+                "lead_time": [0],
+                "value": [1.0],
+            }
+        )
+        result = outputs._ensure_output_schema(df)
+        assert list(result.columns) == outputs.OUTPUT_COLUMNS + ["extra"]
+
+
+@pytest.mark.parametrize(
+    "coord",
+    [
+        "metric",
+        "target_variable",
+        "forecast_variable",
+        "forecast_source",
+        "target_source",
+        "case_id_number",
+        "event_type",
+    ],
+)
+def test_metadata_coords_contains_expected_names(coord):
+    assert coord in outputs.METADATA_COORDS
+
+
+def _result(dims="lead_time", values=(1.0, 2.0), coord_values=None, **overrides):
+    metadata = {**METADATA_KWARGS, **overrides}
+    if dims == "lead_time":
+        coord_values = list(coord_values) if coord_values is not None else [0, 6]
+        result = xr.DataArray(
+            data=list(values),
+            dims=["lead_time"],
+            coords={"lead_time": coord_values},
+        )
+    elif dims == "init_time":
+        coord_values = (
+            coord_values
+            if coord_values is not None
+            else pd.date_range("2021-06-20", periods=len(values), freq="D")
+        )
+        result = xr.DataArray(
+            data=list(values), dims=["init_time"], coords={"init_time": coord_values}
+        )
+    else:
+        raise ValueError(f"Unsupported dims kind: {dims}")
+    return outputs.annotate_metric_result(result, **metadata)
+
+
+class TestResultsToDataset:
+    """Test the flat-Dataset builder for a whole run's results."""
+
+    def test_empty_list_returns_empty_dataset(self):
+        ds = outputs.results_to_dataset([])
+        assert isinstance(ds, xr.Dataset)
+        assert len(ds.data_vars) == 0
+        assert len(ds.dims) == 0
+
+    def test_dims_include_metadata_dims_and_own_dims(self):
+        ds = outputs.results_to_dataset([_result()])
+        assert set(ds.dims) >= {
+            "case_id_number",
+            "metric",
+            "forecast_source",
+            "target_source",
+            "lead_time",
+        }
+        assert ds.sizes["case_id_number"] == 1
+        assert ds.sizes["metric"] == 1
+        assert ds.sizes["lead_time"] == 2
+
+    def test_target_and_forecast_variable_are_dropped(self):
+        ds = outputs.results_to_dataset([_result()])
+        assert "target_variable" not in ds.dims
+        assert "target_variable" not in ds.coords
+        assert "forecast_variable" not in ds.coords
+
+    def test_matching_variable_names_produce_single_named_data_var(self):
+        result = _result(
+            target_variable="2m_temperature", forecast_variable="2m_temperature"
+        )
+        ds = outputs.results_to_dataset([result])
+        assert list(ds.data_vars) == ["2m_temperature"]
+
+    def test_differing_variable_names_produce_merged_data_var_name(self):
+        result = _result(
+            target_variable="2m_temperature",
+            forecast_variable="surface_air_temperature",
+        )
+        ds = outputs.results_to_dataset([result])
+        assert list(ds.data_vars) == ["surface_air_temperature_vs_2m_temperature"]
+
+    def test_event_type_is_a_non_dim_coord_along_case_id_number(self):
+        result_1 = _result(case_id_number=1, event_type="heat_wave")
+        result_2 = _result(case_id_number=2, event_type="freeze")
+        ds = outputs.results_to_dataset([result_1, result_2])
+
+        assert "event_type" not in ds.dims
+        assert ds.coords["event_type"].dims == ("case_id_number",)
+        by_case = dict(
+            zip(ds.coords["case_id_number"].values, ds.coords["event_type"].values)
+        )
+        assert by_case == {1: "heat_wave", 2: "freeze"}
+
+    def test_two_metrics_on_one_variable_merge_along_metric_dim(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        rmse = _result(
+            metric="RMSE", coord_values=(0, 6), values=(1.0, 2.0), **same_var
+        )
+        mae = _result(metric="MAE", coord_values=(6, 12), values=(3.0, 4.0), **same_var)
+        ds = outputs.results_to_dataset([rmse, mae])
+
+        assert ds.sizes["metric"] == 2
+        df = ds["2m_temperature"].to_dataframe(name="value").reset_index()
+        df = df.dropna(subset=["value"])
+
+        rmse_rows = df[df["metric"] == "RMSE"]
+        assert dict(zip(rmse_rows["lead_time"], rmse_rows["value"])) == {0: 1.0, 6: 2.0}
+        mae_rows = df[df["metric"] == "MAE"]
+        assert dict(zip(mae_rows["lead_time"], mae_rows["value"])) == {6: 3.0, 12: 4.0}
+
+    def test_lead_time_and_init_time_metrics_coexist_with_nan_padding(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result])
+
+        assert "lead_time" in ds.dims
+        assert "init_time" in ds.dims
+
+        df = ds["2m_temperature"].to_dataframe(name="value").reset_index()
+        df = df.dropna(subset=["value"])
+        rmse_rows = df[df["metric"] == "RMSE"]
+        assert sorted(rmse_rows["value"]) == [1.0, 2.0]
+        assert sorted(rmse_rows["lead_time"]) == [0, 6]
+
+        onset_rows = df[df["metric"] == "OnsetError"]
+        assert sorted(onset_rows["value"]) == [5.0, 6.0]
+
+    def test_landfall_extra_coords_are_promoted_and_preserved_per_case(self):
+        def make(case_id, lat_val, lon_val):
+            init_times = pd.date_range("2021-06-20", periods=2, freq="D")
+            result = xr.DataArray(
+                data=[1.0, 2.0], dims=["init_time"], coords={"init_time": init_times}
+            )
+            result = result.assign_coords(
+                forecast_landfall_latitude=("init_time", [lat_val, lat_val + 1]),
+                forecast_landfall_longitude=("init_time", [lon_val, lon_val + 1]),
+            )
+            return outputs.annotate_metric_result(
+                result,
+                metric="LandfallDisplacement",
+                target_variable="surface_wind_speed",
+                forecast_variable="surface_wind_speed",
+                forecast_source="test_forecast",
+                target_source="test_target",
+                case_id_number=case_id,
+                event_type="tropical_cyclone",
+            )
+
+        result_1 = make(1, 10.0, -80.0)
+        result_2 = make(2, 50.0, -170.0)
+
+        ds = outputs.results_to_dataset([result_1, result_2])
+
+        assert "forecast_landfall_latitude" in ds.data_vars
+        assert "forecast_landfall_latitude" not in ds.coords
+
+        df = ds["forecast_landfall_latitude"].to_dataframe(name="value").reset_index()
+        df = df.dropna(subset=["value"])
+        case_1_vals = sorted(df[df["case_id_number"] == 1]["value"])
+        case_2_vals = sorted(df[df["case_id_number"] == 2]["value"])
+        assert case_1_vals == [10.0, 11.0]
+        assert case_2_vals == [50.0, 51.0]
+
+    def test_dataset_values_match_dataframe_values_for_each_result(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        results = [
+            _result(
+                metric="RMSE",
+                case_id_number=1,
+                values=(1.0, 2.0),
+                coord_values=(0, 6),
+                **same_var,
+            ),
+            _result(
+                dims="init_time",
+                metric="OnsetError",
+                case_id_number=2,
+                values=(5.0, 6.0),
+                **same_var,
+            ),
+        ]
+        df = outputs.results_to_dataframe(results)
+        ds = outputs.results_to_dataset(results)
+
+        for result in results:
+            metadata = {
+                c: result.coords[c].item()
+                for c in (
+                    "metric",
+                    "forecast_source",
+                    "target_source",
+                    "case_id_number",
+                )
+            }
+            var_name = outputs._variable_name(
+                result.coords["forecast_variable"].item(),
+                result.coords["target_variable"].item(),
+            )
+            own_dim = result.dims[0]
+
+            for coord_value, value in zip(result.coords[own_dim].values, result.values):
+                selectors = dict(metadata)
+                selectors[own_dim] = coord_value
+                for other_dim in ("lead_time", "init_time"):
+                    if other_dim != own_dim and other_dim in ds.dims:
+                        selectors[other_dim] = outputs._sentinel_for_dtype(
+                            ds.coords[other_dim].dtype
+                        )
+                dataset_value = ds[var_name].sel(**selectors).compute().item()
+                assert dataset_value == pytest.approx(value)
+
+                df_row = df[
+                    (df["metric"] == metadata["metric"])
+                    & (df["case_id_number"] == metadata["case_id_number"])
+                    & (df[own_dim] == coord_value)
+                ]
+                assert df_row["value"].iloc[0] == pytest.approx(dataset_value)
+
+    def test_sparse_true_produces_sparse_backed_data_with_correct_values(self):
+        result_1 = _result(case_id_number=1, values=(1.0, 2.0))
+        result_2 = _result(case_id_number=2, values=(3.0, 4.0))
+        ds = outputs.results_to_dataset([result_1, result_2], sparse=True)
+
+        var = ds["surface_air_temperature_vs_2m_temperature"]
+        assert isinstance(var.data, sparse.COO)
+        assert np.isnan(var.data.fill_value)
+        assert np.nansum(var.data.todense()) == pytest.approx(10.0)
+
+    def test_sparse_true_works_when_results_have_mixed_dims(self):
+        """Regression test: mixing lead_time- and init_time-preserving
+        metrics on the same variable used to raise AttributeError from
+        sparse 0.19.1 lacking a module-level transpose (see xr.merge's
+        compat="no_conflicts" fillna combine path)."""
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result], sparse=True)
+
+        var = ds["2m_temperature"]
+        assert isinstance(var.data, sparse.COO)
+        assert np.nansum(var.data.todense()) == pytest.approx(14.0)
+
+    def test_result_is_dask_backed_by_default(self):
+        ds = outputs.results_to_dataset([_result(case_id_number=1)])
+        var = ds["surface_air_temperature_vs_2m_temperature"]
+        assert isinstance(var.data, da.Array)
+
+    def test_already_dask_backed_inputs_stay_dask_backed(self):
+        result = _result(case_id_number=1)
+        result = result.chunk()
+        ds = outputs.results_to_dataset([result])
+        var = ds["surface_air_temperature_vs_2m_temperature"]
+        assert isinstance(var.data, da.Array)
+
+    def test_warns_when_estimated_dense_size_exceeds_threshold(self, caplog):
+        latitudes = np.arange(2000)
+        longitudes = np.arange(2000)
+        data = np.zeros((len(latitudes), len(longitudes)))
+        result = xr.DataArray(
+            data=data,
+            dims=["latitude", "longitude"],
+            coords={"latitude": latitudes, "longitude": longitudes},
+        )
+        result = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+        with caplog.at_level(logging.WARNING, logger="extremeweatherbench.outputs"):
+            outputs.results_to_dataset([result], sparse=False)
+
+        assert any("sparse=True" in r.getMessage() for r in caplog.records)
+
+    def test_no_dense_size_warning_for_small_results(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="extremeweatherbench.outputs"):
+            outputs.results_to_dataset([_result()], sparse=False)
+
+        assert not any("sparse=True" in r.getMessage() for r in caplog.records)
+
+
+def _peak_result(
+    values=(1.0, 2.0),
+    init_times=None,
+    lead_times=(0, 6),
+    metric="MaximumMeanAbsoluteError",
+    **overrides,
+):
+    init_times = (
+        init_times
+        if init_times is not None
+        else pd.date_range("2021-06-20", periods=len(values), freq="D")
+    )
+    result = xr.DataArray(
+        data=list(values),
+        dims=["init_time"],
+        coords={
+            "init_time": init_times,
+            "lead_time": ("init_time", list(lead_times)),
+        },
+    )
+    metadata = {**METADATA_KWARGS, "metric": metric, **overrides}
+    return outputs.annotate_metric_result(result, **metadata)
+
+
+class TestResultsToDatasetPeakTimeCoord:
+    """Test peak metrics carrying both init_time and lead_time."""
+
+    def test_peak_alone_gets_both_dims_at_true_positions(self):
+        result = _peak_result(values=(1.0, 2.0), lead_times=(6, 12))
+        ds = outputs.results_to_dataset([result])
+        df = outputs.results_to_dataframe([result])
+
+        var = ds["surface_air_temperature_vs_2m_temperature"]
+        assert "lead_time" in var.dims
+        assert "init_time" in var.dims
+
+        computed = var.compute()
+        n_real = int(computed.notnull().sum())
+        assert n_real == len(df)
+
+        for init_time, lead_time, value in zip(
+            result.coords["init_time"].values,
+            result.coords["lead_time"].values,
+            result.values,
+        ):
+            selected = computed.sel(init_time=init_time, lead_time=lead_time).item()
+            assert selected == pytest.approx(value)
+
+    def test_peak_alone_shape_matches_peak_combined_with_rmse(self):
+        """A peak result's own (init_time, lead_time) shape, after
+        dropping placeholder padding, must not depend on what else ran
+        alongside it."""
+        peak = _peak_result(values=(1.0, 2.0), lead_times=(6, 12))
+        rmse = _lead_time_result(values=(3.0, 4.0), lead_times=(0, 6))
+
+        alone = outputs.results_to_dataset([peak])
+        combined = outputs.results_to_dataset([peak, rmse])
+        var_name = "surface_air_temperature_vs_2m_temperature"
+
+        selectors = {
+            "case_id_number": 1,
+            "forecast_source": "test_forecast",
+            "target_source": "test_target",
+            "metric": "MaximumMeanAbsoluteError",
+        }
+        alone_peak = outputs.drop_empty_slices(alone[var_name].sel(**selectors))
+        combined_peak = outputs.drop_empty_slices(combined[var_name].sel(**selectors))
+
+        assert dict(alone_peak.sizes) == dict(combined_peak.sizes)
+        xr.testing.assert_equal(
+            alone_peak.sortby(list(alone_peak.dims)).compute(),
+            combined_peak.sortby(list(combined_peak.dims)).compute(),
+        )
+
+    def test_peak_combined_with_rmse_does_not_raise_and_values_agree(self):
+        peak = _peak_result(
+            values=(1.0, 2.0),
+            init_times=pd.date_range("2021-06-20", periods=2, freq="D"),
+            lead_times=(6, 12),
+            metric="MaximumMeanAbsoluteError",
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+        )
+        rmse = _result(
+            dims="lead_time",
+            metric="RootMeanSquaredError",
+            values=(10.0, 20.0),
+            coord_values=(0, 6),
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+        )
+
+        ds = outputs.results_to_dataset([peak, rmse])
+        df = outputs.results_to_dataframe([peak, rmse])
+        var = ds["2m_temperature"].compute()
+
+        n_real = int(var.notnull().sum())
+        assert n_real == len(df)
+
+        peak_selection = var.sel(metric="MaximumMeanAbsoluteError")
+        for init_time, lead_time, value in zip(
+            peak.coords["init_time"].values,
+            peak.coords["lead_time"].values,
+            peak.values,
+        ):
+            selected = peak_selection.sel(
+                init_time=init_time, lead_time=lead_time
+            ).item()
+            assert selected == pytest.approx(value)
+
+        rmse_selection = outputs.drop_empty_slices(
+            var.sel(
+                metric="RootMeanSquaredError",
+                case_id_number=1,
+                forecast_source="test_forecast",
+                target_source="test_target",
+            )
+        )
+        assert rmse_selection.dims == ("lead_time",)
+        np.testing.assert_array_equal(
+            rmse_selection.compute().sortby("lead_time").values, [10.0, 20.0]
+        )
+
+    def test_repeated_verifying_lead_time_across_init_times(self):
+        result = _peak_result(
+            values=(1.0, 2.0, 3.0),
+            init_times=pd.date_range("2021-06-20", periods=3, freq="D"),
+            lead_times=(6, 6, 12),
+        )
+        ds = outputs.results_to_dataset([result])
+        df = outputs.results_to_dataframe([result])
+        var = ds["surface_air_temperature_vs_2m_temperature"].compute()
+
+        assert int(var.notnull().sum()) == len(df)
+        assert var.sizes["lead_time"] == 2
+
+        for init_time, lead_time, value in zip(
+            result.coords["init_time"].values,
+            result.coords["lead_time"].values,
+            result.values,
+        ):
+            assert var.sel(
+                init_time=init_time, lead_time=lead_time
+            ).item() == pytest.approx(value)
+
+    def test_distinct_verifying_lead_times_across_init_times(self):
+        result = _peak_result(
+            values=(1.0, 2.0, 3.0),
+            init_times=pd.date_range("2021-06-20", periods=3, freq="D"),
+            lead_times=(0, 6, 12),
+        )
+        ds = outputs.results_to_dataset([result])
+        var = ds["surface_air_temperature_vs_2m_temperature"].compute()
+
+        assert var.sizes["lead_time"] == 3
+        assert var.sizes["init_time"] == 3
+        assert int(var.notnull().sum()) == 3
+
+    def test_station_latitude_longitude_stay_data_variables_not_dims(self):
+        stations = np.array([1, 2, 3])
+        result = xr.DataArray(
+            data=[1.0, 2.0, 3.0], dims=["station"], coords={"station": stations}
+        )
+        result = result.assign_coords(
+            latitude=("station", [10.0, 20.0, 30.0]),
+            longitude=("station", [-80.0, -90.0, -100.0]),
+        )
+        annotated = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+
+        ds = outputs.results_to_dataset([annotated])
+
+        assert "latitude" not in ds.dims
+        assert "longitude" not in ds.dims
+        assert "latitude" in ds.data_vars
+        assert "longitude" in ds.data_vars
+
+    def test_landfall_extra_coords_still_promoted_alongside_peak_metric(self):
+        landfall = _landfall_result(1, 10.0, -80.0, "2021-06-20T12:00")
+        peak = _peak_result(
+            values=(1.0, 2.0),
+            init_times=pd.date_range("2021-06-20", periods=2, freq="D"),
+            lead_times=(6, 12),
+            target_variable="surface_wind_speed",
+            forecast_variable="surface_wind_speed",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="tropical_cyclone",
+        )
+
+        ds = outputs.results_to_dataset([landfall, peak])
+
+        assert "forecast_landfall_latitude" in ds.data_vars
+        assert "forecast_landfall_latitude" not in ds.coords
+        assert "lead_time" in ds.dims
+        assert "init_time" in ds.dims
+
+    def test_drop_empty_slices_on_scattered_peak_result(self):
+        result = _peak_result(values=(1.0, 2.0), lead_times=(6, 12))
+        ds = outputs.results_to_dataset([result])
+        selection = ds["surface_air_temperature_vs_2m_temperature"].sel(
+            metric="MaximumMeanAbsoluteError",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert set(collapsed.dims) == {"init_time", "lead_time"}
+        assert int(collapsed.compute().notnull().sum()) == 2
+
+
+class TestResultsToDatasetPeakTimeCoordSparseDenseEquivalence:
+    """sparse=True must match sparse=False for peak metrics too."""
+
+    def _assert_equivalent(self, results):
+        dense = outputs.results_to_dataset(results).compute()
+        sparse_ds = outputs.results_to_dataset(results, sparse=True)
+        densified = sparse_ds.map(utils.maybe_densify_dataarray).compute()
+        xr.testing.assert_identical(densified, dense)
+
+    def test_peak_alone(self):
+        self._assert_equivalent([_peak_result(values=(1.0, 2.0), lead_times=(6, 12))])
+
+    def test_peak_combined_with_rmse(self):
+        peak = _peak_result(
+            values=(1.0, 2.0),
+            lead_times=(6, 12),
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+        )
+        rmse = _result(
+            dims="lead_time",
+            metric="RootMeanSquaredError",
+            values=(10.0, 20.0),
+            coord_values=(0, 6),
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+        )
+        self._assert_equivalent([peak, rmse])
+
+    def test_repeated_verifying_lead_times(self):
+        self._assert_equivalent(
+            [
+                _peak_result(
+                    values=(1.0, 2.0, 3.0),
+                    init_times=pd.date_range("2021-06-20", periods=3, freq="D"),
+                    lead_times=(6, 6, 12),
+                )
+            ]
+        )
+
+    def test_distinct_verifying_lead_times(self):
+        self._assert_equivalent(
+            [
+                _peak_result(
+                    values=(1.0, 2.0, 3.0),
+                    init_times=pd.date_range("2021-06-20", periods=3, freq="D"),
+                    lead_times=(0, 6, 12),
+                )
+            ]
+        )
+
+
+def _landfall_result(case_id, lat, lon, valid_time, **overrides):
+    init_times = pd.date_range("2021-06-20", periods=2, freq="D")
+    result = xr.DataArray(
+        data=[1.0, 2.0], dims=["init_time"], coords={"init_time": init_times}
+    )
+    result = result.assign_coords(
+        forecast_landfall_latitude=("init_time", [lat, lat + 1]),
+        forecast_landfall_longitude=("init_time", [lon, lon + 1]),
+        forecast_landfall_valid_time=(
+            "init_time",
+            pd.to_datetime([valid_time, valid_time]),
+        ),
+    )
+    metadata = {
+        "metric": "LandfallDisplacement",
+        "target_variable": "surface_wind_speed",
+        "forecast_variable": "surface_wind_speed",
+        "forecast_source": "test_forecast",
+        "target_source": "test_target",
+        "case_id_number": case_id,
+        "event_type": "tropical_cyclone",
+        **overrides,
+    }
+    return outputs.annotate_metric_result(result, **metadata)
+
+
+class TestResultsToDatasetSparseDenseEquivalence:
+    """sparse=True densified must equal sparse=False's Dataset exactly."""
+
+    def _assert_equivalent(self, results):
+        dense = outputs.results_to_dataset(results).compute()
+        sparse_ds = outputs.results_to_dataset(results, sparse=True)
+        densified = sparse_ds.map(utils.maybe_densify_dataarray).compute()
+        xr.testing.assert_identical(densified, dense)
+
+    def test_empty_list(self):
+        self._assert_equivalent([])
+
+    def test_single_result(self):
+        self._assert_equivalent([_result(case_id_number=1)])
+
+    def test_same_dims_two_metrics_on_one_variable(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        self._assert_equivalent(
+            [
+                _result(
+                    metric="RMSE", coord_values=(0, 6), values=(1.0, 2.0), **same_var
+                ),
+                _result(
+                    metric="MAE", coord_values=(6, 12), values=(3.0, 4.0), **same_var
+                ),
+            ]
+        )
+
+    def test_mixed_dims_lead_time_and_init_time(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        self._assert_equivalent(
+            [
+                _result(dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var),
+                _result(
+                    dims="init_time",
+                    metric="OnsetError",
+                    values=(5.0, 6.0),
+                    **same_var,
+                ),
+            ]
+        )
+
+    def test_mixed_dims_across_multiple_cases(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        self._assert_equivalent(
+            [
+                _result(
+                    metric="RMSE",
+                    case_id_number=1,
+                    values=(1.0, 2.0),
+                    coord_values=(0, 6),
+                    **same_var,
+                ),
+                _result(
+                    dims="init_time",
+                    metric="OnsetError",
+                    case_id_number=2,
+                    values=(5.0, 6.0),
+                    **same_var,
+                ),
+            ]
+        )
+
+    def test_spatial_dims(self):
+        latitudes = np.array([10.0, 11.0])
+        longitudes = np.array([-80.0, -79.0])
+        result = xr.DataArray(
+            data=np.arange(4, dtype=float).reshape(2, 2),
+            dims=["latitude", "longitude"],
+            coords={"latitude": latitudes, "longitude": longitudes},
+        )
+        result = outputs.annotate_metric_result(result, **METADATA_KWARGS)
+        self._assert_equivalent([result])
+
+    def test_multiple_variable_pairs(self):
+        result_1 = _result(
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+            metric="RMSE",
+            case_id_number=1,
+        )
+        result_2 = _result(
+            target_variable="10m_wind_speed",
+            forecast_variable="10m_wind_speed",
+            metric="MAE",
+            case_id_number=1,
+        )
+        self._assert_equivalent([result_1, result_2])
+
+    def test_landfall_extra_vars_with_mixed_dims(self):
+        landfall = _landfall_result(1, 10.0, -80.0, "2021-06-20T12:00")
+        rmse = outputs.annotate_metric_result(
+            xr.DataArray([1.0, 2.0], dims="lead_time", coords={"lead_time": [0, 6]}),
+            metric="RMSE",
+            target_variable="surface_wind_speed",
+            forecast_variable="surface_wind_speed",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="tropical_cyclone",
+        )
+        self._assert_equivalent([landfall, rmse])
+
+
+class TestResultsToDatasetSparseLandfallExtras:
+    """The landfall metadata includes datetime dtypes; verify they sparsify."""
+
+    def test_float_and_datetime_extras_are_sparse_backed(self):
+        landfall = _landfall_result(1, 10.0, -80.0, "2021-06-20T12:00")
+        rmse = outputs.annotate_metric_result(
+            xr.DataArray([1.0, 2.0], dims="lead_time", coords={"lead_time": [0, 6]}),
+            metric="RMSE",
+            target_variable="surface_wind_speed",
+            forecast_variable="surface_wind_speed",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="tropical_cyclone",
+        )
+        ds = outputs.results_to_dataset([landfall, rmse], sparse=True)
+
+        lat_var = ds["forecast_landfall_latitude"]
+        assert isinstance(lat_var.data, sparse.COO)
+        assert np.isnan(lat_var.data.fill_value)
+
+        valid_time_var = ds["forecast_landfall_valid_time"]
+        assert isinstance(valid_time_var.data, sparse.COO)
+        assert pd.isnull(valid_time_var.data.fill_value)
+        assert valid_time_var.data.nnz == 2
+
+    def test_event_type_stays_dense_under_sparse_true(self):
+        result_1 = _result(case_id_number=1, event_type="heat_wave")
+        result_2 = _result(case_id_number=2, event_type="freeze")
+        ds = outputs.results_to_dataset([result_1, result_2], sparse=True)
+
+        assert not isinstance(ds.coords["event_type"].data, sparse.COO)
+        by_case = dict(
+            zip(ds.coords["case_id_number"].values, ds.coords["event_type"].values)
+        )
+        assert by_case == {1: "heat_wave", 2: "freeze"}
+
+
+class TestDropEmptySlices:
+    """Test the drop_empty_slices helper for collapsing padding placeholders."""
+
+    def test_lead_time_selection_collapses_init_time_placeholder(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result])
+        selection = ds["2m_temperature"].sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert collapsed.dims == ("lead_time",)
+        assert collapsed.sizes["lead_time"] == 2
+        np.testing.assert_array_equal(collapsed.compute().values, [1.0, 2.0])
+
+    def test_init_time_selection_collapses_lead_time_placeholder(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result])
+        selection = ds["2m_temperature"].sel(
+            metric="OnsetError",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert collapsed.dims == ("init_time",)
+        assert collapsed.sizes["init_time"] == 2
+        np.testing.assert_array_equal(collapsed.compute().values, [5.0, 6.0])
+
+    def test_is_close_to_a_no_op_on_the_full_unselected_cube(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(dims="lead_time", metric="RMSE", **same_var)
+        init_result = _result(dims="init_time", metric="OnsetError", **same_var)
+        ds = outputs.results_to_dataset([lead_result, init_result])
+
+        collapsed = outputs.drop_empty_slices(ds)
+
+        assert dict(collapsed.sizes) == dict(ds.sizes)
+
+    def test_works_on_a_dataset_not_just_a_dataarray(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result])
+        selection = ds.sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert isinstance(collapsed, xr.Dataset)
+        assert set(collapsed.dims) == {"lead_time"}
+
+    def test_works_on_dask_backed_input(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result])
+        selection = ds["2m_temperature"].sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        assert isinstance(selection.data, da.Array)
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert isinstance(collapsed.data, da.Array)
+        np.testing.assert_array_equal(collapsed.compute().values, [1.0, 2.0])
+
+    def test_works_on_dense_numpy_backed_input(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result]).compute()
+        selection = ds["2m_temperature"].sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert collapsed.dims == ("lead_time",)
+        np.testing.assert_array_equal(collapsed.values, [1.0, 2.0])
+
+    def test_real_valued_placeholder_only_labels_are_not_dropped(self):
+        result = _result(dims="lead_time", metric="RMSE", case_id_number=1)
+        ds = outputs.results_to_dataset([result])
+        selection = ds["surface_air_temperature_vs_2m_temperature"].sel(
+            metric="RMSE", case_id_number=1
+        )
+
+        collapsed = outputs.drop_empty_slices(selection)
+
+        assert "forecast_source" in collapsed.dims
+        assert "target_source" in collapsed.dims
+        assert collapsed.sizes["forecast_source"] == 1
+        assert collapsed.sizes["target_source"] == 1
+
+    def test_raises_on_sparse_backed_input_without_densifying_first(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result], sparse=True)
+        selection = ds["2m_temperature"].sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        assert isinstance(selection.data, sparse.COO)
+
+        with pytest.raises(RuntimeError, match="Cannot convert a sparse array"):
+            outputs.drop_empty_slices(selection)
+
+    def test_works_on_sparse_backed_input_once_densified(self):
+        same_var = {
+            "target_variable": "2m_temperature",
+            "forecast_variable": "2m_temperature",
+        }
+        lead_result = _result(
+            dims="lead_time", metric="RMSE", values=(1.0, 2.0), **same_var
+        )
+        init_result = _result(
+            dims="init_time", metric="OnsetError", values=(5.0, 6.0), **same_var
+        )
+        ds = outputs.results_to_dataset([lead_result, init_result], sparse=True)
+        selection = ds["2m_temperature"].sel(
+            metric="RMSE",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        densified = utils.maybe_densify_dataarray(selection)
+
+        collapsed = outputs.drop_empty_slices(densified)
+
+        assert collapsed.dims == ("lead_time",)
+        np.testing.assert_array_equal(collapsed.values, [1.0, 2.0])
+
+
+def _build_real_metric_case_operator(
+    case_id_number: int, event_type: str
+) -> "cases.CaseOperator":
+    """Build a CaseOperator around real, small, in-memory forecast/target data.
+
+    Uses real RootMeanSquaredError (lead_time-preserving) and MeanError
+    with preserve_dims="init_time" (init_time-preserving) metrics, so the
+    output-conversion path is exercised by real metric output rather than
+    hand-built annotated arrays. Only _build_datasets is bypassed, since
+    the input-loading pipeline is not what this test targets.
+    """
+    init_time = pd.date_range("2021-06-20", periods=3, freq="D")
+    lead_time = np.array([0, 6, 12, 18])
+    latitude = np.array([40.0, 41.0])
+    longitude = np.array([-100.0, -99.0])
+    shape = (len(init_time), len(lead_time), len(latitude), len(longitude))
+    rng = np.random.default_rng(case_id_number)
+
+    forecast_ds = xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                rng.random(shape) + 273.0,
+            )
+        },
+        coords={
+            "init_time": init_time,
+            "lead_time": lead_time,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+    )
+    target_ds = xr.Dataset(
+        {
+            "2m_temperature": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                rng.random(shape) + 273.0,
+            )
+        },
+        coords=forecast_ds.coords,
+    )
+
+    mock_target = mock.Mock(spec=inputs.TargetBase)
+    mock_target.name = "test_target"
+    mock_target.variables = ["2m_temperature"]
+    mock_target.maybe_align_forecast_to_target.return_value = (
+        forecast_ds,
+        target_ds,
+    )
+
+    mock_forecast = mock.Mock(spec=inputs.ForecastBase)
+    mock_forecast.name = "test_forecast"
+    mock_forecast.variables = ["surface_air_temperature"]
+
+    metric_list = [
+        metrics.RootMeanSquaredError(
+            forecast_variable="surface_air_temperature",
+            target_variable="2m_temperature",
+        ),
+        metrics.MeanError(
+            preserve_dims="init_time",
+            forecast_variable="surface_air_temperature",
+            target_variable="2m_temperature",
+        ),
+    ]
+
+    case_metadata = cases.IndividualCase(
+        case_id_number=case_id_number,
+        title=f"Case {case_id_number}",
+        start_date=datetime.datetime(2021, 6, 20),
+        end_date=datetime.datetime(2021, 6, 25),
+        location=regions.CenteredRegion(
+            latitude=45.0, longitude=-120.0, bounding_box_degrees=5.0
+        ),
+        event_type=event_type,
+    )
+    return cases.CaseOperator(
+        case_metadata=case_metadata,
+        metric_list=metric_list,
+        target=mock_target,
+        forecast=mock_forecast,
+    )
+
+
+class TestXarrayOutputEndToEnd:
+    """Run a real evaluation with real metrics, checking pandas/xarray agree.
+
+    _build_datasets is bypassed with pre-built, small, in-memory forecast
+    and target data (no network access); everything downstream, including
+    metric computation, is real.
+    """
+
+    @pytest.fixture
+    def results(self):
+        case_operators = [
+            _build_real_metric_case_operator(1, "heat_wave"),
+            _build_real_metric_case_operator(2, "freeze"),
+        ]
+        all_results = []
+        for case_operator in case_operators:
+            forecast_ds, target_ds = (
+                case_operator.target.maybe_align_forecast_to_target.return_value
+            )
+            with mock.patch(
+                "extremeweatherbench.evaluate._build_datasets",
+                return_value=(forecast_ds, target_ds),
+            ):
+                all_results.extend(
+                    evaluate._compute_case_operator_results(case_operator)
+                )
+        return all_results
+
+    def test_dims_data_variable_and_event_type_coord(self, results):
+        ds = outputs.results_to_dataset(results)
+        var_name = "surface_air_temperature_vs_2m_temperature"
+
+        assert list(ds.data_vars) == [var_name]
+        assert set(ds.dims) == {
+            "case_id_number",
+            "metric",
+            "forecast_source",
+            "target_source",
+            "lead_time",
+            "init_time",
+        }
+        assert "event_type" not in ds.dims
+        assert ds.coords["event_type"].dims == ("case_id_number",)
+        by_case = dict(
+            zip(ds.coords["case_id_number"].values, ds.coords["event_type"].values)
+        )
+        assert by_case == {1: "heat_wave", 2: "freeze"}
+
+    def test_dataset_and_dataframe_agree_on_every_value(self, results):
+        df = outputs.results_to_dataframe(results)
+        ds = outputs.results_to_dataset(results)
+        var_name = "surface_air_temperature_vs_2m_temperature"
+        computed = ds[var_name].compute()
+
+        non_missing = int(computed.notnull().sum())
+        assert non_missing == len(df)
+
+        for _, row in df.iterrows():
+            selectors = {
+                "metric": row["metric"],
+                "case_id_number": row["case_id_number"],
+                "forecast_source": row["forecast_source"],
+                "target_source": row["target_source"],
+            }
+            for dim in ("lead_time", "init_time"):
+                selectors[dim] = (
+                    outputs._sentinel_for_dtype(ds.coords[dim].dtype)
+                    if pd.isna(row[dim])
+                    else row[dim]
+                )
+            value = ds[var_name].sel(**selectors).compute().item()
+            assert value == pytest.approx(row["value"])
+
+    def test_drop_empty_slices_collapses_each_metric_selection(self, results):
+        df = outputs.results_to_dataframe(results)
+        ds = outputs.results_to_dataset(results)
+        var_name = "surface_air_temperature_vs_2m_temperature"
+
+        rmse_selection = ds[var_name].sel(
+            metric="RootMeanSquaredError",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        clean_rmse = outputs.drop_empty_slices(rmse_selection)
+        assert clean_rmse.dims == ("lead_time",)
+        expected_rmse = (
+            df[(df["metric"] == "RootMeanSquaredError") & (df["case_id_number"] == 1)]
+            .sort_values("lead_time")["value"]
+            .to_numpy(dtype=float)
+        )
+        actual_rmse = clean_rmse.compute().sortby("lead_time").values
+        np.testing.assert_allclose(actual_rmse, expected_rmse)
+
+        me_selection = ds[var_name].sel(
+            metric="MeanError",
+            case_id_number=2,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        clean_me = outputs.drop_empty_slices(me_selection)
+        assert clean_me.dims == ("init_time",)
+        expected_me = (
+            df[(df["metric"] == "MeanError") & (df["case_id_number"] == 2)]
+            .sort_values("init_time")["value"]
+            .to_numpy(dtype=float)
+        )
+        actual_me = clean_me.compute().sortby("init_time").values
+        np.testing.assert_allclose(actual_me, expected_me)
+
+
+class TestWriteResults:
+    """Test write_results dispatching and on-disk round trips."""
+
+    def test_unknown_output_format_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="csv"):
+            outputs.write_results(
+                [_result()], tmp_path / "out", output_format="parquet"
+            )
+
+    def test_csv_output_matches_dataframe_bytes(self, tmp_path):
+        results = [_result(case_id_number=1)]
+        expected_path = tmp_path / "expected.csv"
+        outputs.results_to_dataframe(results).to_csv(expected_path, index=False)
+
+        out_path = tmp_path / "out.csv"
+        outputs.write_results(results, out_path, output_format="csv")
+
+        assert out_path.read_bytes() == expected_path.read_bytes()
+
+    def test_netcdf_round_trip_preserves_values_and_coords(self, tmp_path):
+        results = [
+            _result(metric="RMSE", case_id_number=1, values=(1.0, 2.0)),
+            _result(
+                dims="init_time",
+                metric="OnsetError",
+                case_id_number=2,
+                values=(5.0, 6.0),
+            ),
+        ]
+        expected_ds = outputs.results_to_dataset(results).compute()
+
+        out_path = tmp_path / "out.nc"
+        outputs.write_results(results, out_path, output_format="netcdf")
+
+        actual = xr.open_dataset(out_path).compute()
+        xr.testing.assert_allclose(expected_ds, actual, check_dim_order=False)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -976,6 +976,92 @@ class TestResultsToDatasetSparseLandfallExtras:
         )
         assert by_case == {1: "heat_wave", 2: "freeze"}
 
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_empty_lead_time_fallback_before_timedelta_rmse(self, sparse):
+        empty = outputs.annotate_metric_result(
+            utils._create_nan_dataarray("lead_time"),
+            metric="MaximumMeanAbsoluteError",
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="heat_wave",
+        )
+        lead_times = pd.to_timedelta([0, 6], unit="h")
+        rmse = outputs.annotate_metric_result(
+            xr.DataArray(
+                [1.0, 2.0], dims=["lead_time"], coords={"lead_time": lead_times}
+            ),
+            metric="RootMeanSquaredError",
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="heat_wave",
+        )
+
+        ds = outputs.results_to_dataset([empty, rmse], sparse=sparse)
+        var = ds["2m_temperature"]
+        if sparse:
+            var = utils.maybe_densify_dataarray(var)
+
+        assert np.issubdtype(ds.coords["lead_time"].dtype, np.timedelta64)
+        selected = var.sel(
+            metric="RootMeanSquaredError",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        collapsed = outputs.drop_empty_slices(selected)
+        np.testing.assert_array_equal(
+            collapsed.compute().sortby("lead_time").values, [1.0, 2.0]
+        )
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_empty_init_time_fallback_before_datetime_metric(self, sparse):
+        empty = outputs.annotate_metric_result(
+            utils._create_nan_dataarray("init_time"),
+            metric="LandfallDisplacement",
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="tropical_cyclone",
+        )
+        init_times = pd.date_range("2021-06-20", periods=2, freq="D")
+        onset = outputs.annotate_metric_result(
+            xr.DataArray(
+                [5.0, 6.0], dims=["init_time"], coords={"init_time": init_times}
+            ),
+            metric="DurationMeanError",
+            target_variable="2m_temperature",
+            forecast_variable="2m_temperature",
+            forecast_source="test_forecast",
+            target_source="test_target",
+            case_id_number=1,
+            event_type="tropical_cyclone",
+        )
+
+        ds = outputs.results_to_dataset([empty, onset], sparse=sparse)
+        var = ds["2m_temperature"]
+        if sparse:
+            var = utils.maybe_densify_dataarray(var)
+
+        assert np.issubdtype(ds.coords["init_time"].dtype, np.datetime64)
+        selected = var.sel(
+            metric="DurationMeanError",
+            case_id_number=1,
+            forecast_source="test_forecast",
+            target_source="test_target",
+        )
+        collapsed = outputs.drop_empty_slices(selected)
+        np.testing.assert_array_equal(
+            collapsed.compute().sortby("init_time").values, [5.0, 6.0]
+        )
+
 
 class TestDropEmptySlices:
     """Test the drop_empty_slices helper for collapsing padding placeholders."""

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1523,6 +1523,62 @@ class TestRegionSubsetter:
         case_ids = set(subset_results["case_id_number"])
         assert case_ids == {1, 2}
 
+    def test_subset_results_to_region_dataset(self, target_region, sample_cases):
+        """Test subsetting results Dataset by case_id_number."""
+        results_ds = xr.Dataset(
+            {
+                "rmse": (
+                    ("case_id_number", "metric"),
+                    [[0.1, 0.4], [0.2, 0.5], [0.3, 0.6]],
+                )
+            },
+            coords={"case_id_number": [1, 2, 3], "metric": ["mae", "rmse"]},
+        )
+
+        subsetter = regions.RegionSubsetter(region=target_region, method="intersects")
+
+        subset_results = regions.subset_results_to_region(
+            subsetter, results_ds, sample_cases
+        )
+
+        assert isinstance(subset_results, xr.Dataset)
+        assert list(subset_results["case_id_number"].values) == [1, 2]
+        assert subset_results.sizes["metric"] == 2
+
+    def test_subset_results_to_region_dataset_preserves_order(
+        self, target_region, sample_cases
+    ):
+        """Test that Dataset case_id_number ordering is preserved after subsetting."""
+        results_ds = xr.Dataset(
+            {"rmse": (("case_id_number",), [0.3, 0.1, 0.2])},
+            coords={"case_id_number": [3, 1, 2]},
+        )
+
+        subsetter = regions.RegionSubsetter(region=target_region, method="intersects")
+
+        subset_results = regions.subset_results_to_region(
+            subsetter, results_ds, sample_cases
+        )
+
+        assert list(subset_results["case_id_number"].values) == [1, 2]
+
+    def test_subset_results_to_region_dataset_missing_case_id(
+        self, target_region, sample_cases
+    ):
+        """Test Dataset missing an in-region case_id_number doesn't raise."""
+        results_ds = xr.Dataset(
+            {"rmse": (("case_id_number",), [0.1])},
+            coords={"case_id_number": [1]},
+        )
+
+        subsetter = regions.RegionSubsetter(region=target_region, method="intersects")
+
+        subset_results = regions.subset_results_to_region(
+            subsetter, results_ds, sample_cases
+        )
+
+        assert list(subset_results["case_id_number"].values) == [1]
+
     def test_invalid_method_raises_error(self, target_region):
         """Test that invalid method raises ValueError."""
         subsetter = regions.RegionSubsetter(region=target_region, method="intersects")

--- a/tests/test_tropical_cyclone.py
+++ b/tests/test_tropical_cyclone.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from extremeweatherbench import derived
+from extremeweatherbench import calc, derived
 from extremeweatherbench.events import tropical_cyclone
 
 
@@ -295,6 +295,17 @@ class TestUtilityFunctions:
         assert isinstance(mask, np.ndarray)
         assert mask.shape == (3, 3)  # lat x lon
         assert mask.dtype == bool
+
+        lat_grid, lon_grid = np.meshgrid(lat_coords, lon_coords, indexing="ij")
+        expected = np.zeros_like(lat_grid, dtype=bool)
+        for _, row in nearby_ibtracs.iterrows():
+            distances = calc.haversine_distance(
+                [lat_grid, lon_grid],
+                [row["latitude"], row["longitude"]],
+                units="degrees",
+            )
+            expected |= distances <= max_distance
+        np.testing.assert_array_equal(mask, expected)
 
 
 class TestDimensionHandling:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1193,6 +1193,15 @@ class TestConvertDayYearofDayToTime:
         # Should still be a DataArray
         assert isinstance(result, xr.DataArray)
 
+    def test_non_january_dayofyear(self):
+        """Times come from dayofyear and hour, not a Jan 1 date_range."""
+        ds = xr.Dataset(
+            {"temperature": (["dayofyear", "hour"], [[1.0], [2.0]])},
+            coords={"dayofyear": [171, 172], "hour": [0]},
+        )
+        result = utils.convert_day_yearofday_to_time(ds, year=2021)
+        assert result.valid_time.values[0] == np.datetime64("2021-06-20")
+        assert result.valid_time.values[1] == np.datetime64("2021-06-21")
 
     def test_dataarray_preserves_data_values(self):
         """Test that DataArray data values are preserved."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -454,6 +454,41 @@ def test_convert_init_time_to_valid_time():
     assert "init_time" not in result.dims or "valid_time" in result.dims
 
 
+def test_convert_init_time_to_valid_time_matches_outer_concat():
+    """Dense fixture must match concat of swapped leads with join='outer'."""
+    inits = pd.date_range("2020-01-01", periods=4, freq="12h")
+    leads = pd.to_timedelta([0, 6, 12, 18, 24], unit="h")
+    temp = np.arange(4 * 5 * 3 * 4, dtype=float).reshape(4, 5, 3, 4)
+    ds = xr.Dataset(
+        {
+            "temp": (
+                ["init_time", "lead_time", "latitude", "longitude"],
+                temp,
+            )
+        },
+        coords={
+            "init_time": inits,
+            "lead_time": leads,
+            "latitude": np.linspace(0, 10, 3),
+            "longitude": np.linspace(0, 20, 4),
+            "cycle": ("init_time", ["a", "b", "c", "d"]),
+        },
+    )
+    expected = ds.assign_coords(valid_time=ds.init_time + ds.lead_time)
+    expected = xr.concat(
+        [
+            expected.sel(lead_time=lead).swap_dims({"init_time": "valid_time"})
+            for lead in expected.lead_time
+        ],
+        "lead_time",
+        coords="different",
+        compat="equals",
+        join="outer",
+    )
+    result = utils.convert_init_time_to_valid_time(ds)
+    xr.testing.assert_equal(result, expected)
+
+
 def test_maybe_get_closest_timestamp_to_center_of_valid_times_single_output():
     """Test passthrough behavior with single output time."""
     # Create valid_time values (center will be middle value)
@@ -1157,6 +1192,7 @@ class TestConvertDayYearofDayToTime:
         assert len(result.valid_time) == 6
         # Should still be a DataArray
         assert isinstance(result, xr.DataArray)
+
 
     def test_dataarray_preserves_data_values(self):
         """Test that DataArray data values are preserved."""


### PR DESCRIPTION
## Intent

PR feat/xarray-results-output into develop now, with a simplified summary. The goal is to land xarray-native evaluation results on develop: keep metric results as annotated DataArrays internally instead of flattening to pandas per metric, add an optional xarray Dataset output (results_to_dataset / write_results) dimensioned by case, metric, source, and the dims each metric preserved, and support writing netCDF or zarr from the library and CLI (--output-format, --sparse) while leaving the public pandas DataFrame default unchanged. Also add drop_empty_slices so padded placeholder time labels collapse when selecting one metric, document the xarray output, build sparse results without xr.merge (which crashed on mixed dim-order slabs), and place peak metric results at their verifying lead time. Target develop, not main. Keep the PR description short and simple rather than a long commit-by-commit writeup. The branch currently also carries recent main performance work that is not yet on develop (event-agnostic eval speedups, temperature climatology, AR labeling, TC spatial masks, LSR parquet filters); include that history as it exists on the branch rather than stripping it.

## What Changed

- Keep metric results as annotated DataArrays internally and add optional xarray Dataset output (`results_to_dataset` / `write_results`) dimensioned by case, metric, source, and the dims each metric preserved. Library and CLI can write netCDF or zarr (`--output-format`, `--sparse`); the public pandas DataFrame default is unchanged.
- Add `drop_empty_slices` so padded placeholder time labels collapse when selecting one metric, build sparse results without `xr.merge`, and place peak metric results at their verifying lead time.
- Include recent evaluation performance work from main: event-agnostic eval reuse, temperature climatology indexing, cheaper AR labeling, vectorized TC spatial masks, and LSR parquet time filters.

## Risk Assessment

✅ Low: The xarray output path is well-bounded with the pandas default unchanged, and the prior import and empty-fallback dtype-merge failures are closed at the shared padding boundary.

## Testing

Focused output/CLI tests passed, then a live in-memory ExtremeWeatherBench run showed the pandas default still returned a DataFrame, xarray output dimensioned by case/metric/source, peak MAE at the 18h verifying lead, drop_empty_slices collapsing RMSE padding, sparse mixed-dim assembly without xr.merge, and reopenable netCDF/zarr from the library and CLI; no screenshot was captured because this is a library/CLI data-output change rather than a rendered UI.

<details>
<summary>Evidence: Live run_evaluation pandas default and xarray Dataset</summary>

`output_format='pandas' returns a DataFrame; MaximumMeanAbsoluteError sits at lead 18:00 / init 2021-06-20. output_format='xarray' Dataset dims: lead_time, init_time, metric, forecast_source, target_source, case_id_number.`

```text
Live ExtremeWeatherBench.run_evaluation on in-memory forecast/target:

output_format='pandas' (default) type=DataFrame
    value       lead_time           init_time         target_variable                   metric forecast_source target_source case_id_number event_type valid_time_mask          valid_time
 1.122086 0 days 00:00:00                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave             NaN                 NaN
 1.207536 0 days 06:00:00                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave             NaN                 NaN
  1.03776 0 days 12:00:00                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave             NaN                 NaN
  1.00042 0 days 18:00:00                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave             NaN                 NaN
 0.919426 1 days 00:00:00                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave             NaN                 NaN
      1.0 0 days 18:00:00 2021-06-20 00:00:00 surface_air_temperature MaximumMeanAbsoluteError   demo_forecast   demo_target              1  heat_wave             1.0 2021-06-20 18:00:00

output_format='xarray':
results_to_dataset / run_evaluation(output_format='xarray')
<xarray.Dataset> Size: 724B
Dimensions:                  (lead_time: 5, init_time: 2, metric: 2,
                              target_source: 1, forecast_source: 1,
                              case_id_number: 1)
Coordinates:
  * lead_time                (lead_time) timedelta64[ns] 40B 00:00:00 ... 1 d...
  * init_time                (init_time) datetime64[ns] 16B 2021-06-20 NaT
  * metric                   (metric) <U24 192B 'MaximumMeanAbsoluteError' 'R...
  * target_source            (target_source) <U11 44B 'demo_target'
  * forecast_source          (forecast_source) <U13 52B 'demo_forecast'
  * case_id_number           (case_id_number) int64 8B 1
    event_type               (case_id_number) <U9 36B 'heat_wave'
Data variables:
    surface_air_temperature  (case_id_number, metric, forecast_source, target_source, init_time, lead_time) float64 160B ...
    valid_time_mask          (case_id_number, metric, forecast_source, target_source, lead_time, init_time) float64 160B ...
    valid_time               (case_id_number, metric, forecast_source, target_source) datetime64[ns] 16B ...

dims: {'lead_time': 5, 'init_time': 2, 'metric': 2, 'target_source': 1, 'forecast_source': 1, 'case_id_number': 1}
data_vars: ['surface_air_temperature', 'valid_time_mask', 'valid_time']
coords: ['lead_time', 'init_time', 'metric', 'target_source', 'forecast_source', 'case_id_number', 'event_type']
```
</details>
<details>
<summary>Evidence: Live peak metric at verifying lead time</summary>

`MaximumMeanAbsoluteError after drop_empty_slices: init_time=2021-06-20, lead_time=18:00:00, value=1.0`

```text
Live MaximumMeanAbsoluteError after drop_empty_slices:
<xarray.DataArray 'surface_air_temperature' (case_id_number: 1,
                                             forecast_source: 1,
                                             target_source: 1, init_time: 1,
                                             lead_time: 1)> Size: 8B
array([[[[[1.]]]]])
Coordinates:
  * case_id_number   (case_id_number) int64 8B 1
    event_type       (case_id_number) <U9 36B 'heat_wave'
  * forecast_source  (forecast_source) <U13 52B 'demo_forecast'
  * target_source    (target_source) <U11 44B 'demo_target'
  * init_time        (init_time) datetime64[ns] 8B 2021-06-20
  * lead_time        (lead_time) timedelta64[ns] 8B 18:00:00
    metric           <U24 96B 'MaximumMeanAbsoluteError'

values:
[[[[[1.]]]]]
```
</details>
<details>
<summary>Evidence: drop_empty_slices collapsing RMSE placeholder time labels</summary>

`RMSE selection padded to (init_time: 3, lead_time: 5) with NaNs; drop_empty_slices collapses it to lead_time [0, 6, 12] with values [0.41, 0.49, 0.45].`

```text
RMSE selection before drop_empty_slices:
<xarray.DataArray 'surface_air_temperature' (init_time: 3, lead_time: 5)> Size: 120B
array([[ nan,  nan,  nan,  nan,  nan],
       [ nan,  nan,  nan,  nan,  nan],
       [0.41, 0.49, 0.45,  nan,  nan]])
Coordinates:
  * init_time        (init_time) datetime64[ns] 24B 2021-06-20 2021-06-21 NaT
  * lead_time        (lead_time) float64 40B 0.0 6.0 12.0 18.0 nan
    metric           <U24 96B 'RootMeanSquaredError'
    forecast_source  <U13 52B 'demo_forecast'
    target_source    <U11 44B 'demo_target'
    case_id_number   int64 8B 1
    event_type       <U9 36B 'heat_wave'

values:
[[ nan  nan  nan  nan  nan]
 [ nan  nan  nan  nan  nan]
 [0.41 0.49 0.45  nan  nan]]

After drop_empty_slices (placeholder time labels collapsed):
<xarray.DataArray 'surface_air_temperature' (lead_time: 3)> Size: 24B
array([0.41, 0.49, 0.45])
Coordinates:
  * lead_time        (lead_time) float64 24B 0.0 6.0 12.0
    metric           <U24 96B 'RootMeanSquaredError'
    forecast_source  <U13 52B 'demo_forecast'
    target_source    <U11 44B 'demo_target'
    case_id_number   int64 8B 1
    event_type       <U9 36B 'heat_wave'

values:
[0.41 0.49 0.45]
```
</details>
<details>
<summary>Evidence: results_to_dataset cube (case, metric, source, preserved dims)</summary>

```text
results_to_dataset / run_evaluation(output_format='xarray')
<xarray.Dataset> Size: 852B
Dimensions:                  (lead_time: 5, init_time: 3, metric: 3,
                              forecast_source: 1, target_source: 1,
                              case_id_number: 1)
Coordinates:
  * lead_time                (lead_time) float64 40B 0.0 6.0 12.0 18.0 nan
  * init_time                (init_time) datetime64[ns] 24B 2021-06-20 ... NaT
  * metric                   (metric) <U24 288B 'MaximumMeanAbsoluteError' .....
  * forecast_source          (forecast_source) <U13 52B 'demo_forecast'
  * target_source            (target_source) <U11 44B 'demo_target'
  * case_id_number           (case_id_number) int64 8B 1
    event_type               (case_id_number) <U9 36B 'heat_wave'
Data variables:
    surface_air_temperature  (case_id_number, metric, forecast_source, target_source, init_time, lead_time) float64 360B ...

dims: {'lead_time': 5, 'init_time': 3, 'metric': 3, 'forecast_source': 1, 'target_source': 1, 'case_id_number': 1}
data_vars: ['surface_air_temperature']
coords: ['lead_time', 'init_time', 'metric', 'forecast_source', 'target_source', 'case_id_number', 'event_type']
```
</details>
<details>
<summary>Evidence: Unchanged public pandas DataFrame default</summary>

```text
Default output_format='pandas' (public DataFrame unchanged):
value lead_time           init_time         target_variable                   metric forecast_source target_source case_id_number event_type
 0.41       0.0                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave
 0.49       6.0                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave
 0.45      12.0                 NaN surface_air_temperature     RootMeanSquaredError   demo_forecast   demo_target              1  heat_wave
  5.0       NaN 2021-06-20 00:00:00 surface_air_temperature               OnsetError   demo_forecast   demo_target              1  heat_wave
  6.0       NaN 2021-06-21 00:00:00 surface_air_temperature               OnsetError   demo_forecast   demo_target              1  heat_wave
  1.2      18.0 2021-06-20 00:00:00 surface_air_temperature MaximumMeanAbsoluteError   demo_forecast   demo_target              1  heat_wave
  0.8      12.0 2021-06-21 00:00:00 surface_air_temperature MaximumMeanAbsoluteError   demo_forecast   demo_target              1  heat_wave
```
</details>
- Evidence: Library-written netCDF results (local file: <code>/tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/evaluation_results.nc</code>)
- Evidence: Library-written zarr results (local file: <code>/tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/evaluation_results.zarr</code>)
- Evidence: Live evaluation netCDF (local file: <code>/tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/live_evaluation_results.nc</code>)
<details>
<summary>Evidence: sparse=True mixed lead_time/init_time slabs without xr.merge</summary>

`COO-backed surface_air_temperature, nnz=5, fill_value=nan, dims case/metric/source/init_time/lead_time.`

```text
results_to_dataset(sparse=True) with lead_time + init_time slabs (no xr.merge):
<xarray.Dataset> Size: 636B
Dimensions:                  (case_id_number: 1, metric: 2, forecast_source: 1,
                              target_source: 1, init_time: 3, lead_time: 4)
Coordinates:
  * case_id_number           (case_id_number) int64 8B 1
    event_type               (case_id_number) <U9 36B 'heat_wave'
  * metric                   (metric) <U20 160B 'OnsetError' 'RootMeanSquared...
  * forecast_source          (forecast_source) <U13 52B 'demo_forecast'
  * target_source            (target_source) <U11 44B 'demo_target'
  * init_time                (init_time) datetime64[ns] 24B 2021-06-20 ... NaT
  * lead_time                (lead_time) float64 32B 0.0 6.0 12.0 nan
Data variables:
    surface_air_temperature  (case_id_number, metric, forecast_source, target_source, init_time, lead_time) float64 280B <COO: nnz=5, fill_value=nan>

backed by: COO
fill_value: nan
nnz: 5
dims: {'case_id_number': 1, 'metric': 2, 'forecast_source': 1, 'target_source': 1, 'init_time': 3, 'lead_time': 4}
```
</details>
<details>
<summary>Evidence: CLI --output-format csv/netcdf/zarr and --sparse usage error</summary>

`ewb --output-format csv|netcdf|zarr writes evaluation_results.{csv,nc,zarr}; --sparse with csv exits 2: '--sparse is only valid with --output-format netcdf or zarr'.`

```text
$ ewb --default --output-dir <evidence>/cli_out --output-format csv 
exit_code=0
Using default Brightband evaluation objects...
Found 0 case operators to evaluate
Running evaluation...
Results saved to /tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/cli_out/evaluation_results.csv
Evaluated 7 cases

$ ewb --default --output-dir <evidence>/cli_out --output-format netcdf 
exit_code=0
Using default Brightband evaluation objects...
Found 0 case operators to evaluate
Running evaluation...
Results saved to /tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/cli_out/evaluation_results.nc
Evaluated 1 cases

$ ewb --default --output-dir <evidence>/cli_out --output-format zarr --sparse
exit_code=0
Using default Brightband evaluation objects...
Found 0 case operators to evaluate
Running evaluation...
Results saved to /tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/cli_out/evaluation_results.zarr
Evaluated 1 cases
/home/taylor/.no-mistakes/worktrees/4bfc1cf56fa6/01M01FA70WP96FMPJ9J5ZGDKYS/.venv/lib/python3.12/site-packages/zarr/api/asynchronous.py:246: ZarrUserWarning: Consolidated metadata is currently not part in the Zarr format 3 specification. It may not be supported by other zarr implementations and may change in the future.
  warnings.warn(

$ ewb --default --output-format csv --sparse
exit_code=2
Usage: cli-runner [OPTIONS]
Try 'cli-runner --help' for help.

Error: --sparse is only valid with --output-format netcdf or zarr
```
</details>
<details>
<summary>Evidence: ewb --help showing --output-format and --sparse</summary>

```text
Usage: ewb [OPTIONS]

  ExtremeWeatherBench command line interface.

  This CLI supports two main modes:

  1. Default mode (--default): Uses the predefined Brightband evaluation
  objects for    comprehensive weather event evaluation including heat waves,
  freeze events,    [severe convection, atmospheric rivers, and tropical
  cyclones] (bracketed events    are not yet implemented).

  2. Custom mode (--config-file): Uses a Python config file containing custom
  evaluation objects defined by the user.

  The CLI can run evaluations in serial or parallel using joblib, and
  optionally save CaseOperator objects for later use or inspection.

  Args:     default: Use default Brightband evaluation objects with current
  directory         as output.     config_file: Path to a config.py file
  containing evaluation objects.     output_dir: Directory for analysis
  outputs (default: current directory).     cache_dir: Optional directory for
  caching intermediate data. When set,         datasets or dataarrays are
  computed and cached as zarrs.     n_jobs: Number of parallel jobs to run
  (default: 1 for serial execution).     parallel_config: Advanced parallel
  configuration using joblib. Takes         precedence over n_jobs if
  provided.     save_case_operators: Save CaseOperator objects to a pickle
  file at this         path.     no_progress: Disable all progress bars.
  output_format: Format for saving results: "csv", "netcdf", or "zarr"
  (default: "csv").     sparse: Store xarray results as sparse arrays. Only
  valid with         --output-format netcdf or zarr. Examples:     # Use
  default evaluation objects     $ ewb --default

      # Use custom config file with parallel execution     $ ewb --config-file
      my_config.py --n-jobs 4

      # Save case operators to pickle file     $ ewb --default --save-case-
      operators case_ops.pkl

      # Use custom output and cache directories (cache enables zarr storage)
      $ ewb --default --output-dir ./results --cache-dir ./cache

      # Use custom parallel configuration     $ ewb --default --parallel-
      config '{"backend": "dask", "n_jobs": 4}'

      # Save results as a NetCDF Dataset instead of a CSV     $ ewb --default
      --output-format netcdf

      # Save results as a sparse zarr Dataset     $ ewb --default --output-
      format zarr --sparse

Options:
  --default                       Use default Brightband evaluation objects
                                  with current directory as output
  --config-file PATH              Path to a config.py file containing
                                  evaluation objects
  --output-dir PATH               Directory for analysis outputs (default:
                                  current directory)
  --cache-dir PATH                Optional directory for caching intermediate
                                  data
  --n-jobs INTEGER                Number of parallel jobs to run (default: 1
                                  for serial execution)
  -p, --parallel-config DICT      Advanced parallel configuration using
                                  joblib. Takes precedence over --n-jobs if
                                  provided.
  --save-case-operators PATH      Save CaseOperator objects to a pickle file
                                  at this path
  --no-progress                   Disable all progress bars
  --output-format [csv|netcdf|zarr]
                                  Format for saving evaluation results
                                  (default: csv)
  --sparse                        Store xarray results as sparse arrays
                                  (netcdf/zarr formats only)
  --help                          Show this message and exit.
```
</details>
- Evidence: CLI-written csv/netcdf/zarr outputs (local file: <code>/tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/cli_out</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e719dfa209d4fda77d34b2f0dd445d8d6ad7e9ad","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/extremeweatherbench/__init__.py:20` - The new outputs module is not listed in lazy.attach submodules, so the documented `from extremeweatherbench import outputs` / `ewb.outputs` path raises AttributeError. `import extremeweatherbench.outputs` still works. Add &#34;outputs&#34; next to &#34;progress&#34;.
- ⚠️ `src/extremeweatherbench/outputs.py:231` - _collect_own_dim_dtypes keeps the first-seen dtype. Peak/landfall empty fallbacks from _create_nan_dataarray use a RangeIndex (lead_time/init_time=[0], int64). Default heatwave runs MaximumMeanAbsoluteError before RMSE; an all-NaN target therefore records lead_time as int64, then results_to_dataset merges that with RMSE&#39;s timedelta lead_time and can fail (TypeError, or IndexError in _positions_in_union when get_indexer cannot match). Prefer a real temporal dtype already present on that dim, or rewrite untyped time dims to the typed sentinel inside _result_to_padded_dataset — do not change _create_nan_dataarray, which would alter the pandas default.

🔧 Fix: Fix outputs import and temporal dim dtypes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pytest tests/test_outputs.py tests/test_evaluate_cli.py::TestOutputFormats tests/test_evaluate.py::TestOutputFormatWiring tests/test_evaluate.py::TestComputeCaseOperatorOutputFormat -q --tb=short`
- <code>`python /tmp/no-mistakes-evidence/01M01FA70WP96FMPJ9J5ZGDKYS/demo_xarray_results.py` (live `ExtremeWeatherBench.run_evaluation` pandas+xarray, `write_results` netCDF/zarr, `drop_empty_slices`, sparse mixed-dim Dataset, Click CLI `--output-format`/`--sparse`)</code>
- `ewb --help`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `src/extremeweatherbench` - mypy still reports 45 errors in 10 modules other than outputs.py (inputs, calc, metrics, evaluate, derived, and event helpers). outputs.py is clean; a full typing pass is out of scope here.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
