### PR TITLE
perf: cut unused AR reads and stream per-lead masks

### DIFF
--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -8,7 +8,6 @@ import shapely
 import xarray as xr
 from numba import float64, guvectorize, njit
 from scipy import ndimage
-from skimage import filters
 
 from extremeweatherbench import utils
 from extremeweatherbench._cape import EPSILON
@@ -1432,8 +1431,6 @@ def _laplace_2d(data: np.ndarray, out: np.ndarray) -> None:
 
 def _discrete_laplace(data: np.ndarray) -> np.ndarray:
     """Discrete Laplace matching skimage.filters.laplace (ksize=3)."""
-    if data.ndim != 2:
-        return filters.laplace(data)
     out = np.empty_like(data)
     _laplace_2d(data, out)
     return out
@@ -1442,8 +1439,10 @@ def _discrete_laplace(data: np.ndarray) -> np.ndarray:
 def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.DataArray:
     """Blurred Laplacian: discrete Laplace, then a Gaussian smooth.
 
+    Extra leading dims are filtered independently on lat/lon only.
+
     Args:
-        data: IVT data to filter. The apply_ufunc path passes 2D lat/lon.
+        data: IVT data of shape (..., lat, lon)
         sigma: the standard deviation for the Gaussian filter
 
     Returns:
@@ -1454,4 +1453,13 @@ def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.Dat
         arr = np.ascontiguousarray(arr)
     else:
         arr = np.ascontiguousarray(arr, dtype=np.float64)
-    return ndimage.gaussian_filter(_discrete_laplace(arr), sigma=float(sigma))
+    if arr.ndim < 2:
+        raise ValueError("blurred laplacian requires at least 2 dimensions")
+    sigma_f = float(sigma)
+    n_y, n_x = arr.shape[-2], arr.shape[-1]
+    n_lead = arr.size // (n_y * n_x)
+    src = arr.reshape(n_lead, n_y, n_x)
+    out = np.empty_like(src)
+    for i in range(n_lead):
+        out[i] = ndimage.gaussian_filter(_discrete_laplace(src[i]), sigma=sigma_f)
+    return out.reshape(arr.shape)

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -1393,7 +1393,7 @@ def _dilate_square_last2(data: np.ndarray, radius: int) -> np.ndarray:
     return out.reshape(data.shape)
 
 
-def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> xr.DataArray:
+def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> np.ndarray:
     """Square binary dilation on the last two (lat, lon) axes.
 
     Matches ndimage.binary_dilation with a (2r+1)^2 ones structure and
@@ -1430,13 +1430,13 @@ def _laplace_2d(data: np.ndarray, out: np.ndarray) -> None:
 
 
 def _discrete_laplace(data: np.ndarray) -> np.ndarray:
-    """Discrete Laplace matching skimage.filters.laplace (ksize=3)."""
+    """2D discrete Laplace matching skimage.filters.laplace (ksize=3)."""
     out = np.empty_like(data)
     _laplace_2d(data, out)
     return out
 
 
-def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.DataArray:
+def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> np.ndarray:
     """Blurred Laplacian: discrete Laplace, then a Gaussian smooth.
 
     Extra leading dims are filtered independently on lat/lon only.

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import shapely
 import xarray as xr
-from numba import float64, guvectorize
+from numba import float64, guvectorize, njit
 from scipy import ndimage
 from skimage import filters
 
@@ -1332,11 +1332,74 @@ def _is_true_landfall(
         return False
 
 
+@njit(cache=True)
+def _dilate_rows_or(src: np.ndarray, dst: np.ndarray, radius: int) -> None:
+    """Horizontal sliding-window OR with constant-0 (clipped) borders."""
+    n_y, n_x = src.shape
+    for y in range(n_y):
+        count = 0
+        end = min(n_x, radius + 1)
+        for x in range(end):
+            count += src[y, x]
+        dst[y, 0] = 1 if count > 0 else 0
+        for x in range(1, n_x):
+            left = x - 1 - radius
+            right = x + radius
+            if left >= 0:
+                count -= src[y, left]
+            if right < n_x:
+                count += src[y, right]
+            dst[y, x] = 1 if count > 0 else 0
+
+
+@njit(cache=True)
+def _dilate_cols_or(src: np.ndarray, dst: np.ndarray, radius: int) -> None:
+    """Vertical sliding-window OR with constant-0 (clipped) borders."""
+    n_y, n_x = src.shape
+    for x in range(n_x):
+        count = 0
+        end = min(n_y, radius + 1)
+        for y in range(end):
+            count += src[y, x]
+        dst[0, x] = 1 if count > 0 else 0
+        for y in range(1, n_y):
+            top = y - 1 - radius
+            bot = y + radius
+            if top >= 0:
+                count -= src[top, x]
+            if bot < n_y:
+                count += src[bot, x]
+            dst[y, x] = 1 if count > 0 else 0
+
+
+@njit(cache=True)
+def _dilate_square_2d(data: np.ndarray, radius: int, out: np.ndarray) -> None:
+    """Separable chessboard binary dilation on one 2D slice."""
+    n_y, n_x = data.shape
+    tmp = np.empty((n_y, n_x), dtype=np.int8)
+    _dilate_rows_or(data, tmp, radius)
+    _dilate_cols_or(tmp, out, radius)
+
+
+@njit(cache=True)
+def _dilate_square_last2(data: np.ndarray, radius: int) -> np.ndarray:
+    """Square dilation on the last two axes of a C-contiguous array."""
+    n_y = data.shape[-2]
+    n_x = data.shape[-1]
+    n_lead = data.size // (n_y * n_x)
+    src = data.reshape(n_lead, n_y, n_x)
+    out = np.empty((n_lead, n_y, n_x), dtype=np.int8)
+    for i in range(n_lead):
+        _dilate_square_2d(src[i], radius, out[i])
+    return out.reshape(data.shape)
+
+
 def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> xr.DataArray:
     """Apply binary dilation along the last two (lat, lon) axes.
 
-    Uses axes=(-2, -1) so the function works correctly for any number of
-    leading broadcast dimensions (e.g. valid_time, lead_time).
+    Uses a separable chessboard (square) dilation of the given radius,
+    matching ndimage.binary_dilation with a (2r+1)^2 ones structure and
+    border_value=0. Leading dims (e.g. valid_time, lead_time) are loops.
 
     Args:
         data: Array of shape (..., lat, lon)
@@ -1345,15 +1408,106 @@ def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> xr.DataA
     Returns:
         Dilated array of the same shape as data
     """
-    size = dilation_radius * 2 + 1
-    struct = np.ones((size, size))
-    return ndimage.binary_dilation(data, structure=struct, axes=(-2, -1)).astype(
-        np.int8
-    )
+    arr = np.ascontiguousarray(np.asarray(data) != 0, dtype=np.int8)
+    radius = int(dilation_radius)
+    if arr.ndim < 2:
+        raise ValueError("binary dilation requires at least 2 dimensions")
+    if radius <= 0:
+        return arr
+    return _dilate_square_last2(arr, radius)
+
+
+@njit(cache=True)
+def _laplace_2d(data: np.ndarray, out: np.ndarray) -> None:
+    """skimage-style 2D Laplace, scipy reflect (edge sample repeated)."""
+    n_y, n_x = data.shape
+    for i in range(n_y):
+        im = i if i == 0 else i - 1
+        ip = i if i == n_y - 1 else i + 1
+        for j in range(n_x):
+            jm = j if j == 0 else j - 1
+            jp = j if j == n_x - 1 else j + 1
+            c = data[i, j]
+            out[i, j] = 4.0 * c - data[im, j] - data[ip, j] - data[i, jm] - data[i, jp]
+
+
+@njit(cache=True)
+def _laplace_3d(data: np.ndarray, out: np.ndarray) -> None:
+    """skimage-style 3D Laplace, scipy reflect (edge sample repeated)."""
+    n0, n1, n2 = data.shape
+    for i0 in range(n0):
+        a0 = i0 if i0 == 0 else i0 - 1
+        b0 = i0 if i0 == n0 - 1 else i0 + 1
+        for i1 in range(n1):
+            a1 = i1 if i1 == 0 else i1 - 1
+            b1 = i1 if i1 == n1 - 1 else i1 + 1
+            for i2 in range(n2):
+                a2 = i2 if i2 == 0 else i2 - 1
+                b2 = i2 if i2 == n2 - 1 else i2 + 1
+                c = data[i0, i1, i2]
+                out[i0, i1, i2] = (
+                    6.0 * c
+                    - data[a0, i1, i2]
+                    - data[b0, i1, i2]
+                    - data[i0, a1, i2]
+                    - data[i0, b1, i2]
+                    - data[i0, i1, a2]
+                    - data[i0, i1, b2]
+                )
+
+
+@njit(cache=True)
+def _laplace_4d(data: np.ndarray, out: np.ndarray) -> None:
+    """skimage-style 4D Laplace, scipy reflect (edge sample repeated)."""
+    n0, n1, n2, n3 = data.shape
+    for i0 in range(n0):
+        a0 = i0 if i0 == 0 else i0 - 1
+        b0 = i0 if i0 == n0 - 1 else i0 + 1
+        for i1 in range(n1):
+            a1 = i1 if i1 == 0 else i1 - 1
+            b1 = i1 if i1 == n1 - 1 else i1 + 1
+            for i2 in range(n2):
+                a2 = i2 if i2 == 0 else i2 - 1
+                b2 = i2 if i2 == n2 - 1 else i2 + 1
+                for i3 in range(n3):
+                    a3 = i3 if i3 == 0 else i3 - 1
+                    b3 = i3 if i3 == n3 - 1 else i3 + 1
+                    c = data[i0, i1, i2, i3]
+                    out[i0, i1, i2, i3] = (
+                        8.0 * c
+                        - data[a0, i1, i2, i3]
+                        - data[b0, i1, i2, i3]
+                        - data[i0, a1, i2, i3]
+                        - data[i0, b1, i2, i3]
+                        - data[i0, i1, a2, i3]
+                        - data[i0, i1, b2, i3]
+                        - data[i0, i1, i2, a3]
+                        - data[i0, i1, i2, b3]
+                    )
+
+
+def _discrete_laplace(data: np.ndarray) -> np.ndarray:
+    """Discrete Laplace matching skimage.filters.laplace (ksize=3)."""
+    if data.ndim == 2:
+        out = np.empty_like(data)
+        _laplace_2d(data, out)
+        return out
+    if data.ndim == 3:
+        out = np.empty_like(data)
+        _laplace_3d(data, out)
+        return out
+    if data.ndim == 4:
+        out = np.empty_like(data)
+        _laplace_4d(data, out)
+        return out
+    return filters.laplace(data)
 
 
 def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.DataArray:
-    """Compute blurred Laplacian using scipy filters.
+    """Compute blurred Laplacian using a numba stencil plus scipy gauss.
+
+    Filters all axes of the received array, matching the previous
+    skimage.filters.laplace + ndimage.gaussian_filter path.
 
     Args:
         data: IVT data to compute the blurred Laplacian of; data must be 2D
@@ -1362,5 +1516,10 @@ def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.Dat
     Returns:
         The blurred Laplacian of IVT
     """
-    laplace_data = filters.laplace(data)
-    return ndimage.gaussian_filter(laplace_data, sigma=sigma)
+    arr = np.asarray(data)
+    if arr.dtype.kind == "f":
+        arr = np.ascontiguousarray(arr)
+    else:
+        arr = np.ascontiguousarray(arr, dtype=np.float64)
+    laplace_data = _discrete_laplace(arr)
+    return ndimage.gaussian_filter(laplace_data, sigma=float(sigma))

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -1395,11 +1395,10 @@ def _dilate_square_last2(data: np.ndarray, radius: int) -> np.ndarray:
 
 
 def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> xr.DataArray:
-    """Apply binary dilation along the last two (lat, lon) axes.
+    """Square binary dilation on the last two (lat, lon) axes.
 
-    Uses a separable chessboard (square) dilation of the given radius,
-    matching ndimage.binary_dilation with a (2r+1)^2 ones structure and
-    border_value=0. Leading dims (e.g. valid_time, lead_time) are loops.
+    Matches ndimage.binary_dilation with a (2r+1)^2 ones structure and
+    border_value=0. Extra leading dims are dilated independently.
 
     Args:
         data: Array of shape (..., lat, lon)
@@ -1419,7 +1418,7 @@ def _binary_dilation_ufunc(data: xr.DataArray, dilation_radius: int) -> xr.DataA
 
 @njit(cache=True)
 def _laplace_2d(data: np.ndarray, out: np.ndarray) -> None:
-    """skimage-style 2D Laplace, scipy reflect (edge sample repeated)."""
+    """2D Laplace with reflect borders (edge sample repeated)."""
     n_y, n_x = data.shape
     for i in range(n_y):
         im = i if i == 0 else i - 1
@@ -1431,86 +1430,20 @@ def _laplace_2d(data: np.ndarray, out: np.ndarray) -> None:
             out[i, j] = 4.0 * c - data[im, j] - data[ip, j] - data[i, jm] - data[i, jp]
 
 
-@njit(cache=True)
-def _laplace_3d(data: np.ndarray, out: np.ndarray) -> None:
-    """skimage-style 3D Laplace, scipy reflect (edge sample repeated)."""
-    n0, n1, n2 = data.shape
-    for i0 in range(n0):
-        a0 = i0 if i0 == 0 else i0 - 1
-        b0 = i0 if i0 == n0 - 1 else i0 + 1
-        for i1 in range(n1):
-            a1 = i1 if i1 == 0 else i1 - 1
-            b1 = i1 if i1 == n1 - 1 else i1 + 1
-            for i2 in range(n2):
-                a2 = i2 if i2 == 0 else i2 - 1
-                b2 = i2 if i2 == n2 - 1 else i2 + 1
-                c = data[i0, i1, i2]
-                out[i0, i1, i2] = (
-                    6.0 * c
-                    - data[a0, i1, i2]
-                    - data[b0, i1, i2]
-                    - data[i0, a1, i2]
-                    - data[i0, b1, i2]
-                    - data[i0, i1, a2]
-                    - data[i0, i1, b2]
-                )
-
-
-@njit(cache=True)
-def _laplace_4d(data: np.ndarray, out: np.ndarray) -> None:
-    """skimage-style 4D Laplace, scipy reflect (edge sample repeated)."""
-    n0, n1, n2, n3 = data.shape
-    for i0 in range(n0):
-        a0 = i0 if i0 == 0 else i0 - 1
-        b0 = i0 if i0 == n0 - 1 else i0 + 1
-        for i1 in range(n1):
-            a1 = i1 if i1 == 0 else i1 - 1
-            b1 = i1 if i1 == n1 - 1 else i1 + 1
-            for i2 in range(n2):
-                a2 = i2 if i2 == 0 else i2 - 1
-                b2 = i2 if i2 == n2 - 1 else i2 + 1
-                for i3 in range(n3):
-                    a3 = i3 if i3 == 0 else i3 - 1
-                    b3 = i3 if i3 == n3 - 1 else i3 + 1
-                    c = data[i0, i1, i2, i3]
-                    out[i0, i1, i2, i3] = (
-                        8.0 * c
-                        - data[a0, i1, i2, i3]
-                        - data[b0, i1, i2, i3]
-                        - data[i0, a1, i2, i3]
-                        - data[i0, b1, i2, i3]
-                        - data[i0, i1, a2, i3]
-                        - data[i0, i1, b2, i3]
-                        - data[i0, i1, i2, a3]
-                        - data[i0, i1, i2, b3]
-                    )
-
-
 def _discrete_laplace(data: np.ndarray) -> np.ndarray:
     """Discrete Laplace matching skimage.filters.laplace (ksize=3)."""
-    if data.ndim == 2:
-        out = np.empty_like(data)
-        _laplace_2d(data, out)
-        return out
-    if data.ndim == 3:
-        out = np.empty_like(data)
-        _laplace_3d(data, out)
-        return out
-    if data.ndim == 4:
-        out = np.empty_like(data)
-        _laplace_4d(data, out)
-        return out
-    return filters.laplace(data)
+    if data.ndim != 2:
+        return filters.laplace(data)
+    out = np.empty_like(data)
+    _laplace_2d(data, out)
+    return out
 
 
 def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.DataArray:
-    """Compute blurred Laplacian using a numba stencil plus scipy gauss.
-
-    Filters all axes of the received array, matching the previous
-    skimage.filters.laplace + ndimage.gaussian_filter path.
+    """Blurred Laplacian: discrete Laplace, then a Gaussian smooth.
 
     Args:
-        data: IVT data to compute the blurred Laplacian of; data must be 2D
+        data: IVT data to filter. The apply_ufunc path passes 2D lat/lon.
         sigma: the standard deviation for the Gaussian filter
 
     Returns:
@@ -1521,5 +1454,4 @@ def _compute_blurred_laplacian_ufunc(data: xr.DataArray, sigma: float) -> xr.Dat
         arr = np.ascontiguousarray(arr)
     else:
         arr = np.ascontiguousarray(arr, dtype=np.float64)
-    laplace_data = _discrete_laplace(arr)
-    return ndimage.gaussian_filter(laplace_data, sigma=float(sigma))
+    return ndimage.gaussian_filter(_discrete_laplace(arr), sigma=float(sigma))

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -452,7 +452,9 @@ class AtmosphericRiverVariables(DerivedVariable):
         """Derive the atmospheric river mask and land intersection."""
 
         data = data.sel(level=data.level[data.level >= self.top_pressure_level])
-        return ar.build_atmospheric_river_mask_and_land_intersection(data)
+        return ar.build_atmospheric_river_mask_and_land_intersection(
+            data, output_variables=self.output_variables
+        )
 
 
 def maybe_derive_variables(

--- a/src/extremeweatherbench/derived.py
+++ b/src/extremeweatherbench/derived.py
@@ -410,8 +410,8 @@ class AtmosphericRiverVariables(DerivedVariable):
     Newell et al. 1992 and elsewhere (e.g. Mo 2024).
 
     Output variables: integrated_vapor_transport, atmospheric_river_mask,
-    atmospheric_river_land_intersection. Users must declare at least one
-    output variable when calling the derived variable.
+    atmospheric_river_land_intersection. Defaults to all three; pass
+    output_variables to keep a subset.
 
     The Laplacian of IVT uses a Gaussian blurring kernel with sigma of 3
     grid points to smooth 0.25 degree grid scale features.

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -400,15 +400,13 @@ def _run_parallel_evaluation(
         # Group operators that share a case and forecast so one worker can
         # reuse the forecast dataset (PPH + LSR on the same HRES object).
         groups = _group_operators_sharing_forecast(case_operators)
-        # Targets are shared across forecast workers (ERA5 AR for HRES
-        # and Graphcast). Compute each unique target once in the parent.
         kwargs = dict(kwargs)
+        # Mock(spec=InputBase) passes isinstance; skip those test doubles.
         real_ops = [
             op
             for op in case_operators
-            if isinstance(op, cases.CaseOperator)
-            and isinstance(op.target, inputs.InputBase)
-            and not type(op.target).__module__.startswith("unittest.mock")
+            if isinstance(getattr(op, "target", None), inputs.InputBase)
+            and not type(op.target).__module__.startswith("unittest")
         ]
         if real_ops:
             kwargs["precomputed_targets"] = _precompute_unique_targets(
@@ -1165,9 +1163,7 @@ def _build_datasets(
     pipeline_cache = _pipeline_cache_var.get()
     target_ds = None
     if precomputed_targets:
-        target_key = _pipeline_cache_key(
-            case_operator.case_metadata, augmented_target
-        )
+        target_key = _pipeline_cache_key(case_operator.case_metadata, augmented_target)
         target_ds = precomputed_targets.get(target_key)
     if target_ds is None:
         target_ds = _run_pipeline_maybe_cached(

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1133,8 +1133,9 @@ def _build_datasets(
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """Build the target and forecast datasets for a case operator.
 
-    This method will process through all stages of the pipeline for the target and
-    forecast datasets, including preprocessing, variable renaming, and subsetting.
+    Builds target and forecast datasets, including preprocessing, variable
+    renaming, and subsetting. Reuses a target from precomputed_targets in
+    kwargs when that cache has an entry for this operator.
     It augments the InputBase variables with any variables defined in metrics to
     ensure all required variables are loaded and derived.
 

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -400,6 +400,20 @@ def _run_parallel_evaluation(
         # Group operators that share a case and forecast so one worker can
         # reuse the forecast dataset (PPH + LSR on the same HRES object).
         groups = _group_operators_sharing_forecast(case_operators)
+        # Targets are shared across forecast workers (ERA5 AR for HRES
+        # and Graphcast). Compute each unique target once in the parent.
+        kwargs = dict(kwargs)
+        real_ops = [
+            op
+            for op in case_operators
+            if isinstance(op, cases.CaseOperator)
+            and isinstance(op.target, inputs.InputBase)
+            and not type(op.target).__module__.startswith("unittest.mock")
+        ]
+        if real_ops:
+            kwargs["precomputed_targets"] = _precompute_unique_targets(
+                real_ops, **kwargs
+            )
         parallel_tqdm_kwargs["total_tasks"] = len(groups)
         with joblib.parallel_config(**parallel_config):
             nested_results = utils.ParallelTqdm(
@@ -488,6 +502,69 @@ def _pipeline_cache_key(
         input_data.source,
         var_key,
     )
+
+
+def _augment_operator_inputs(
+    case_operator: "cases.CaseOperator",
+) -> tuple["inputs.InputBase", "inputs.InputBase"]:
+    """Copy forecast/target inputs with metric variables folded in."""
+    metric_forecast_vars, metric_target_vars = _collect_metric_variables(
+        case_operator.metric_list
+    )
+    forecast_derived_outputs = _get_all_derived_output_variables(
+        case_operator.forecast.variables
+    )
+    target_derived_outputs = _get_all_derived_output_variables(
+        case_operator.target.variables
+    )
+    filtered_forecast_vars = {
+        v
+        for v in metric_forecast_vars
+        if not (isinstance(v, str) and v in forecast_derived_outputs)
+    }
+    filtered_target_vars = {
+        v
+        for v in metric_target_vars
+        if not (isinstance(v, str) and v in target_derived_outputs)
+    }
+    augmented_forecast = copy.copy(case_operator.forecast)
+    augmented_target = copy.copy(case_operator.target)
+    augmented_forecast.variables = list(
+        set(case_operator.forecast.variables) | filtered_forecast_vars
+    )
+    augmented_target.variables = list(
+        set(case_operator.target.variables) | filtered_target_vars
+    )
+    return augmented_forecast, augmented_target
+
+
+def _precompute_unique_targets(
+    case_operators: list["cases.CaseOperator"],
+    **kwargs,
+) -> dict[tuple, xr.Dataset]:
+    """Run each unique target pipeline once before parallel forecast work."""
+    kwargs = dict(kwargs)
+    kwargs.pop("precomputed_targets", None)
+    precomputed: dict[tuple, xr.Dataset] = {}
+    for case_operator in case_operators:
+        _, augmented_target = _augment_operator_inputs(case_operator)
+        key = _pipeline_cache_key(case_operator.case_metadata, augmented_target)
+        if key in precomputed:
+            continue
+        logger.info(
+            "Precomputing target %s for case %s",
+            augmented_target.name,
+            case_operator.case_metadata.case_id_number,
+        )
+        progress_module.set_phase(
+            f"case {case_operator.case_metadata.case_id_number} | "
+            "shared target pipeline"
+        )
+        target_ds = run_pipeline(
+            case_operator.case_metadata, augmented_target, **kwargs
+        )
+        precomputed[key] = target_ds.compute()
+    return precomputed
 
 
 def _run_pipeline_maybe_cached(
@@ -1074,43 +1151,9 @@ def _build_datasets(
         A tuple containing (forecast_dataset, target_dataset). If either dataset
         has no dimensions, both will be empty datasets.
     """
-    metric_forecast_vars, metric_target_vars = _collect_metric_variables(
-        case_operator.metric_list
-    )
-
-    # Get all output_variables from DerivedVariables in InputBase
-    # These should NOT be added separately as they'll be created by derivation
-    forecast_derived_outputs = _get_all_derived_output_variables(
-        case_operator.forecast.variables
-    )
-    target_derived_outputs = _get_all_derived_output_variables(
-        case_operator.target.variables
-    )
-
-    # Filter out string variables that are output_variables of existing DerivedVariables
-    # Only add metric variables that are not already covered by DerivedVariable outputs
-    filtered_forecast_vars = {
-        v
-        for v in metric_forecast_vars
-        if not (isinstance(v, str) and v in forecast_derived_outputs)
-    }
-    filtered_target_vars = {
-        v
-        for v in metric_target_vars
-        if not (isinstance(v, str) and v in target_derived_outputs)
-    }
-
-    # Create augmented copies of InputBase objects with combined variables
-    augmented_forecast = copy.copy(case_operator.forecast)
-    augmented_target = copy.copy(case_operator.target)
-
-    # Combine InputBase variables with metric-specific variables (filtered)
-    augmented_forecast.variables = list(
-        set(case_operator.forecast.variables) | filtered_forecast_vars
-    )
-    augmented_target.variables = list(
-        set(case_operator.target.variables) | filtered_target_vars
-    )
+    kwargs = dict(kwargs)
+    precomputed_targets = kwargs.pop("precomputed_targets", None)
+    augmented_forecast, augmented_target = _augment_operator_inputs(case_operator)
 
     logger.info(
         "Running target pipeline for case %s... ",
@@ -1120,12 +1163,19 @@ def _build_datasets(
         f"case {case_operator.case_metadata.case_id_number} | target pipeline"
     )
     pipeline_cache = _pipeline_cache_var.get()
-    target_ds = _run_pipeline_maybe_cached(
-        case_operator.case_metadata,
-        augmented_target,
-        pipeline_cache,
-        **kwargs,
-    )
+    target_ds = None
+    if precomputed_targets:
+        target_key = _pipeline_cache_key(
+            case_operator.case_metadata, augmented_target
+        )
+        target_ds = precomputed_targets.get(target_key)
+    if target_ds is None:
+        target_ds = _run_pipeline_maybe_cached(
+            case_operator.case_metadata,
+            augmented_target,
+            pipeline_cache,
+            **kwargs,
+        )
 
     # Pass target dataset to forecast pipeline only if needed
     # Check if any forecast variable requires target dataset

--- a/src/extremeweatherbench/events/atmospheric_river.py
+++ b/src/extremeweatherbench/events/atmospheric_river.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -363,7 +364,8 @@ def build_atmospheric_river_mask_and_land_intersection(
             IVT is still computed for the mask but dropped when omitted.
 
     Returns:
-        Dataset containing atmospheric river mask and land intersection.
+        Dataset with atmospheric_river_mask, land intersection, and IVT,
+        or only the names listed in output_variables.
     """
     working = utils.stack_valid_time_pairs(data)
     ivt_data = integrated_vapor_transport(
@@ -375,9 +377,10 @@ def build_atmospheric_river_mask_and_land_intersection(
         ivt_data, sigma=3, laplacian_threshold=2.5, dilation_radius=8
     )
     initial_intersection = dilated.astype(bool) & (ivt_data >= 400)
-    ivt_data = utils.unstack_valid_time_pairs(ivt_data, like=data)
-    initial_intersection = utils.unstack_valid_time_pairs(
-        initial_intersection, like=data
+    ivt_data = cast(xr.DataArray, utils.unstack_valid_time_pairs(ivt_data, like=data))
+    initial_intersection = cast(
+        xr.DataArray,
+        utils.unstack_valid_time_pairs(initial_intersection, like=data),
     )
     ar_mask_result = _finalize_ar_mask_by_lead(
         initial_intersection,

--- a/src/extremeweatherbench/events/atmospheric_river.py
+++ b/src/extremeweatherbench/events/atmospheric_river.py
@@ -3,9 +3,72 @@ from collections.abc import Sequence
 import numpy as np
 import numpy.typing as npt
 import xarray as xr
+from numba import float64, guvectorize, njit
 from scipy import ndimage
 
-from extremeweatherbench import calc
+from extremeweatherbench import calc, utils
+
+
+@njit(cache=True)
+def _ufind(parent: np.ndarray, x: int) -> int:
+    """Path-compressing union-find parent lookup."""
+    while parent[x] != x:
+        parent[x] = parent[parent[x]]
+        x = parent[x]
+    return x
+
+
+@njit(cache=True)
+def _label_time_linked_stack(mask: np.ndarray) -> np.ndarray:
+    """6-connected labels on (time, extra, y, x); extras stay unlinked."""
+    n_t, n_extra, n_y, n_x = mask.shape
+    out = np.zeros((n_t, n_extra, n_y, n_x), dtype=np.int32)
+    n_pix = n_t * n_y * n_x
+    parent = np.empty(n_pix, dtype=np.int32)
+    remap = np.empty(n_pix, dtype=np.int32)
+    stride_t = n_y * n_x
+    next_id = 1
+    for e in range(n_extra):
+        for i in range(n_pix):
+            parent[i] = i
+            remap[i] = 0
+        for t in range(n_t):
+            for y in range(n_y):
+                for x in range(n_x):
+                    if not mask[t, e, y, x]:
+                        continue
+                    idx = t * stride_t + y * n_x + x
+                    if x > 0 and mask[t, e, y, x - 1]:
+                        ra = _ufind(parent, idx)
+                        rb = _ufind(parent, idx - 1)
+                        if ra != rb:
+                            parent[rb] = ra
+                    if y > 0 and mask[t, e, y - 1, x]:
+                        ra = _ufind(parent, idx)
+                        rb = _ufind(parent, idx - n_x)
+                        if ra != rb:
+                            parent[rb] = ra
+                    if t > 0 and mask[t - 1, e, y, x]:
+                        ra = _ufind(parent, idx)
+                        rb = _ufind(parent, idx - stride_t)
+                        if ra != rb:
+                            parent[rb] = ra
+        next_local = 0
+        for t in range(n_t):
+            for y in range(n_y):
+                for x in range(n_x):
+                    if not mask[t, e, y, x]:
+                        continue
+                    idx = t * stride_t + y * n_x + x
+                    root = _ufind(parent, idx)
+                    lab = remap[root]
+                    if lab == 0:
+                        next_local += 1
+                        lab = next_local
+                        remap[root] = lab
+                    out[t, e, y, x] = lab + (next_id - 1)
+        next_id += next_local
+    return out
 
 
 def _label_time_linked_tyx(mask_tyx: npt.NDArray[np.bool_]) -> npt.NDArray[np.int32]:
@@ -14,45 +77,9 @@ def _label_time_linked_tyx(mask_tyx: npt.NDArray[np.bool_]) -> npt.NDArray[np.in
     2D connected components plus union-find across consecutive times.
     Matches ndimage.label with generate_binary_structure(3, 1).
     """
-    n_t = mask_tyx.shape[0]
-    labeled = np.empty(mask_tyx.shape, dtype=np.int32)
-    n_feat = np.empty(n_t, dtype=np.int32)
-    for t in range(n_t):
-        labeled[t], n_feat[t] = ndimage.label(mask_tyx[t])
-    total = int(n_feat.sum())
-    if total == 0:
-        return labeled
-
-    glob = np.where(
-        labeled > 0, labeled + (np.cumsum(n_feat) - n_feat)[:, None, None], 0
-    ).astype(np.int32)
-    parent = np.arange(total + 1, dtype=np.int32)
-
-    def find(x: int) -> int:
-        while parent[x] != x:
-            parent[x] = parent[parent[x]]
-            x = int(parent[x])
-        return x
-
-    for t in range(n_t - 1):
-        both = (glob[t] > 0) & (glob[t + 1] > 0)
-        if not both.any():
-            continue
-        pairs = np.unique(np.stack((glob[t][both], glob[t + 1][both]), axis=1), axis=0)
-        for a, b in pairs:
-            ra, rb = find(int(a)), find(int(b))
-            if ra != rb:
-                parent[rb] = ra
-
-    remap = np.zeros(total + 1, dtype=np.int32)
-    n = 0
-    for i in range(1, total + 1):
-        root = find(i)
-        if remap[root] == 0:
-            n += 1
-            remap[root] = n
-        remap[i] = remap[root]
-    return remap[glob]
+    mask = np.ascontiguousarray(mask_tyx)
+    stacked = mask.reshape(mask.shape[0], 1, mask.shape[1], mask.shape[2])
+    return _label_time_linked_stack(stacked)[:, 0]
 
 
 def _label_objects_time_linked(
@@ -71,20 +98,185 @@ def _label_objects_time_linked(
         + [i for i, name in enumerate(dims) if name not in keep]
         + [dims.index("latitude"), dims.index("longitude")]
     )
-    moved = np.transpose(mask, order)
+    moved = np.ascontiguousarray(np.transpose(mask, order))
     n_t, *extra, n_y, n_x = moved.shape
     n_extra = int(np.prod(extra, initial=1))
-    moved = moved.reshape(n_t, n_extra, n_y, n_x)
-    out = np.empty_like(moved, dtype=np.int32)
-    next_id = 1
-    for i in range(n_extra):
-        lab = _label_time_linked_tyx(moved[:, i])
-        n_lab = int(lab.max())
-        if n_lab:
-            lab = np.where(lab, lab + (next_id - 1), 0)
-            next_id += n_lab
-        out[:, i] = lab
+    stacked = moved.reshape(n_t, n_extra, n_y, n_x)
+    out = _label_time_linked_stack(stacked)
     return np.transpose(out.reshape(n_t, *extra, n_y, n_x), np.argsort(order))
+
+
+@njit(cache=True)
+def _accumulate_label_lat_neg2(
+    labeled: np.ndarray,
+    latitudes: np.ndarray,
+    counts: np.ndarray,
+    lat_sums: np.ndarray,
+) -> None:
+    """Sum counts and latitudes when latitude is the second-last axis."""
+    n_lead = 1
+    for s in labeled.shape[:-2]:
+        n_lead *= s
+    n_y = labeled.shape[-2]
+    n_x = labeled.shape[-1]
+    flat = labeled.reshape(n_lead, n_y, n_x)
+    for i in range(n_lead):
+        for y in range(n_y):
+            lat = latitudes[y]
+            for x in range(n_x):
+                lab = flat[i, y, x]
+                counts[lab] += 1
+                lat_sums[lab] += lat
+
+
+def _filter_labels_size_and_lat(
+    labeled: npt.NDArray[np.int32],
+    latitudes: npt.NDArray[np.floating],
+    lat_axis: int,
+    min_size: int,
+    min_abs_lat: float = 15.0,
+) -> npt.NDArray[np.bool_]:
+    """Keep labels with enough pixels and |mean lat| above the tropics."""
+    if labeled.size == 0:
+        return np.zeros(labeled.shape, dtype=bool)
+    lab = np.ascontiguousarray(labeled)
+    n = int(lab.max()) + 1
+    counts = np.zeros(n, dtype=np.int64)
+    lat_sums = np.zeros(n, dtype=np.float64)
+    lats = np.ascontiguousarray(latitudes, dtype=np.float64)
+    if lat_axis == lab.ndim - 2:
+        _accumulate_label_lat_neg2(lab, lats, counts, lat_sums)
+    else:
+        moved = np.ascontiguousarray(np.moveaxis(lab, lat_axis, -2))
+        _accumulate_label_lat_neg2(moved, lats, counts, lat_sums)
+    valid = np.zeros(n, dtype=np.bool_)
+    if n > 1:
+        denom = np.maximum(counts[1:], 1)
+        valid[1:] = (counts[1:] >= min_size) & (
+            np.abs(lat_sums[1:] / denom) > min_abs_lat
+        )
+    return valid[lab]
+
+
+@guvectorize(
+    [(float64[:], float64[:], float64[:], float64[:], float64, float64[:])],
+    "(n),(n),(n),(n),()->()",
+    nopython=True,
+    target="cpu",
+)
+def _ivt_fused_kernel(u, v, q, x, g0, out):
+    """Trapezoid-integrate u*q and v*q, then hypot / g0."""
+    east = 0.0
+    north = 0.0
+    for i in range(len(u) - 1):
+        uq0 = u[i] * q[i]
+        uq1 = u[i + 1] * q[i + 1]
+        vq0 = v[i] * q[i]
+        vq1 = v[i + 1] * q[i + 1]
+        dx = x[i + 1] - x[i]
+        if not (np.isnan(uq0) or np.isnan(uq1)):
+            east += dx * (uq0 + uq1) / 2.0
+        if not (np.isnan(vq0) or np.isnan(vq1)):
+            north += dx * (vq0 + vq1) / 2.0
+    east /= g0
+    north /= g0
+    out[()] = np.hypot(east, north)
+
+
+def _dilated_high_laplacian(
+    ivt: xr.DataArray,
+    sigma: float,
+    laplacian_threshold: float,
+    dilation_radius: int,
+) -> xr.DataArray:
+    """Blurred Laplacian, threshold, and dilate on the same IVT chunks.
+
+    Uses the public laplacian ufunc on whatever array apply_ufunc passes
+    so chunk shapes (and therefore N-D filter axes) match develop.
+    Dilation uses axes=(-2, -1) and is spatially identical without a
+    time=1 rechunk.
+    """
+
+    def _ufunc(data, sigma_, lap_thresh, radius):
+        lap = calc._compute_blurred_laplacian_ufunc(data, sigma_)
+        high = np.abs(lap) >= lap_thresh
+        return calc._binary_dilation_ufunc(high, radius)
+
+    return xr.apply_ufunc(
+        _ufunc,
+        ivt,
+        sigma,
+        laplacian_threshold,
+        dilation_radius,
+        input_core_dims=[["latitude", "longitude"], [], [], []],
+        output_core_dims=[["latitude", "longitude"]],
+        dask="parallelized",
+        keep_attrs=True,
+        output_dtypes=[np.int8],
+    )
+
+
+def _finalize_ar_mask(
+    intersection: npt.NDArray[np.bool_],
+    coords_dict: dict,
+    min_size_gridpoints: int,
+    time_dimension: str,
+) -> xr.DataArray:
+    """Label, size-filter, and drop tropical features from a bool intersection."""
+    labeled_array = _label_objects_time_linked(
+        np.asarray(intersection, dtype=bool),
+        list(coords_dict.keys()),
+        time_dimension,
+    )
+    latitudes = np.asarray(coords_dict["latitude"].values)
+    lat_axis = list(coords_dict.keys()).index("latitude")
+    feature_mask = _filter_labels_size_and_lat(
+        labeled_array, latitudes, lat_axis, min_size_gridpoints
+    )
+    ar_mask = xr.DataArray(
+        np.where(feature_mask, 1, 0), coords=coords_dict, dims=coords_dict.keys()
+    )
+    ar_mask.name = "atmospheric_river_mask"
+    return ar_mask
+
+
+def _intersection_as_bool(intersection: xr.DataArray) -> npt.NDArray[np.bool_]:
+    """Convert an intersection array to bool; NaN reindex fills are False."""
+    values = np.asarray(intersection)
+    if np.issubdtype(values.dtype, np.floating):
+        return np.isfinite(values) & (values != 0)
+    return values.astype(bool)
+
+
+def _finalize_ar_mask_by_lead(
+    intersection: xr.DataArray,
+    min_size_gridpoints: int,
+    time_dimension: str,
+) -> xr.DataArray:
+    """Compute and label each lead as its bool mask becomes available."""
+    if "lead_time" not in intersection.dims:
+        coords_dict = {dim: intersection.coords[dim] for dim in intersection.dims}
+        return _finalize_ar_mask(
+            _intersection_as_bool(intersection),
+            coords_dict,
+            min_size_gridpoints,
+            time_dimension,
+        )
+    parts = []
+    for i in range(intersection.sizes["lead_time"]):
+        sl = intersection.isel(lead_time=i)
+        coords_dict = {dim: sl.coords[dim] for dim in sl.dims}
+        parts.append(
+            _finalize_ar_mask(
+                _intersection_as_bool(sl),
+                coords_dict,
+                min_size_gridpoints,
+                time_dimension,
+            )
+        )
+    out = xr.concat(parts, dim="lead_time")
+    out = out.assign_coords(lead_time=intersection.lead_time)
+    return out.transpose(*intersection.dims)
 
 
 def atmospheric_river_mask(
@@ -121,22 +313,17 @@ def atmospheric_river_mask(
         The atmospheric river mask as a DataArray
     """
 
-    # Get all coordinates except level for the intersection DataArray
-    coords_dict = {dim: ivt.coords[dim] for dim in ivt.dims if dim != "level"}
-
     # Create boolean masks for each condition
     has_high_laplacian, has_high_ivt = (
         np.abs(ivt_laplacian) >= laplacian_threshold,
         ivt >= ivt_threshold,
     )
 
-    # For the Laplacian condition, we want to check if there's a value >=
-    # laplacian_threshold within 8 gridpoints (0.25 degrees).
-    # Apply binary dilation lazily via apply_ufunc; this keeps dilation in the Dask
-    # graph after ivt/laplacian tasks
+    # Dilate on existing chunks. The ufunc is lat/lon-only, so a
+    # time=1 rechunk is not required for identical spatial dilation.
     dilated_laplacian = xr.apply_ufunc(
         calc._binary_dilation_ufunc,
-        has_high_laplacian.chunk({time_dimension: 1, "latitude": -1, "longitude": -1}),
+        has_high_laplacian,
         dilation_radius,
         input_core_dims=[["latitude", "longitude"], []],
         output_core_dims=[["latitude", "longitude"]],
@@ -145,44 +332,13 @@ def atmospheric_river_mask(
         output_dtypes=[np.int8],
     )
 
-    # Combine conditions without tropical restriction initially
-    initial_intersection = xr.where(dilated_laplacian & has_high_ivt, 1, 0)
-
-    # Label 2D slices and merge across consecutive valid_time only.
-    labeled_array = _label_objects_time_linked(
-        np.asarray(initial_intersection, dtype=bool),
-        list(initial_intersection.dims),
+    # Bool intersection only; avoid xr.where int cubes before labeling.
+    initial_intersection = dilated_laplacian.astype(bool) & has_high_ivt.astype(bool)
+    return _finalize_ar_mask_by_lead(
+        initial_intersection,
+        min_size_gridpoints,
         time_dimension,
     )
-    unique_labels, label_counts = np.unique(labeled_array, return_counts=True)
-
-    # Filter by size first (excluding background label 0)
-    size_valid_labels = unique_labels[
-        np.where((label_counts >= min_size_gridpoints) & (unique_labels != 0))
-    ]
-
-    # Filter out tropical ARs: the mean latitude of each labeled feature
-    # must be > 15 degrees N or S of the equator.
-    latitudes = ivt.coords["latitude"].values
-    lat_axis = list(coords_dict.keys()).index("latitude")
-    lat_shape = [1] * labeled_array.ndim
-    lat_shape[lat_axis] = len(latitudes)
-    lat_grid = np.broadcast_to(latitudes.reshape(lat_shape), labeled_array.shape)
-    if size_valid_labels.size == 0:
-        valid_labels = size_valid_labels
-    else:
-        mean_lat = ndimage.mean(lat_grid, labels=labeled_array, index=size_valid_labels)
-        valid_labels = size_valid_labels[np.abs(mean_lat) > 15]
-
-    # Create final mask using valid features
-    feature_mask = np.isin(labeled_array, valid_labels)
-
-    # Final result with size threshold applied
-    ar_mask = xr.DataArray(
-        xr.where(feature_mask, 1, 0), coords=coords_dict, dims=coords_dict.keys()
-    )
-    ar_mask.name = "atmospheric_river_mask"
-    return ar_mask
 
 
 def integrated_vapor_transport(
@@ -201,23 +357,24 @@ def integrated_vapor_transport(
         Integrated vapor transport as a DataArray
     """
 
-    # Compute IVT components using nantrapezoid_pressure_levels
-    eastward_ivt = (
-        calc.nantrapezoid_pressure_levels(
-            da=eastward_wind * specific_humidity,
-        )
-        / calc.g0
+    # Fuse u*q / v*q / trapezoid / hypot so q is read once and IVT is
+    # a single shared dask node for laplacian, mask, and returned IVT.
+    q = specific_humidity.chunk({"level": -1})
+    u = eastward_wind.chunk({"level": -1})
+    v = northward_wind.chunk({"level": -1})
+    levels_pa = q["level"] * 100
+    ivt_magnitude = xr.apply_ufunc(
+        _ivt_fused_kernel,
+        u,
+        v,
+        q,
+        levels_pa,
+        calc.g0,
+        input_core_dims=[["level"], ["level"], ["level"], ["level"], []],
+        output_core_dims=[[]],
+        dask="parallelized",
+        output_dtypes=[float],
     )
-
-    northward_ivt = (
-        calc.nantrapezoid_pressure_levels(
-            da=northward_wind * specific_humidity,
-        )
-        / calc.g0
-    )
-
-    # Compute IVT using components
-    ivt_magnitude = xr.ufuncs.hypot(eastward_ivt, northward_ivt)
     ivt_magnitude.name = "integrated_vapor_transport"
     return ivt_magnitude
 
@@ -248,36 +405,54 @@ def integrated_vapor_transport_laplacian(
     return laplacian
 
 
-def build_atmospheric_river_mask_and_land_intersection(data: xr.Dataset) -> xr.Dataset:
+def build_atmospheric_river_mask_and_land_intersection(
+    data: xr.Dataset,
+    output_variables: list[str] | None = None,
+) -> xr.Dataset:
     """Calculate atmospheric river mask and land intersection.
 
     Args:
         data: Dataset with atmospheric data. Must contain eastward_wind,
             northward_wind, specific_humidity, and level.
+        output_variables: If set, only these names are kept in the result.
+            IVT is still computed for the mask but dropped when omitted.
 
     Returns:
         Dataset containing atmospheric river mask and land intersection.
     """
-    # Generate IVT
+    # Drop reindex-fill (lead, valid_time) pairs before the 3D IVT graph.
+    working = utils.stack_valid_time_pairs(data)
+    # One shared IVT node for laplacian, IVT threshold, and optional output.
     ivt_data = integrated_vapor_transport(
-        specific_humidity=data["specific_humidity"],
-        eastward_wind=data["eastward_wind"],
-        northward_wind=data["northward_wind"],
+        specific_humidity=working["specific_humidity"],
+        eastward_wind=working["eastward_wind"],
+        northward_wind=working["northward_wind"],
     )
 
-    # Compute IVT Laplacian
-    ivt_laplacian = integrated_vapor_transport_laplacian(ivt=ivt_data, sigma=3)
+    # Fuse laplacian + threshold + dilation on the same IVT chunks so the
+    # N-D filter axes match develop and dilation stays spatial-only.
+    dilated = _dilated_high_laplacian(
+        ivt_data, sigma=3, laplacian_threshold=2.5, dilation_radius=8
+    )
+    initial_intersection = dilated.astype(bool) & (ivt_data >= 400)
+    ivt_data = utils.unstack_valid_time_pairs(ivt_data, like=data)
+    initial_intersection = utils.unstack_valid_time_pairs(
+        initial_intersection, like=data
+    )
+    ar_mask_result = _finalize_ar_mask_by_lead(
+        initial_intersection,
+        min_size_gridpoints=500,
+        time_dimension="valid_time",
+    )
 
-    # Compute AR mask with default parameters
-    ar_mask_result = atmospheric_river_mask(ivt=ivt_data, ivt_laplacian=ivt_laplacian)
-
-    # Compute land intersection
     land_intersection = calc.find_land_intersection(ar_mask_result)
+    land_intersection.name = "atmospheric_river_land_intersection"
 
-    return xr.Dataset(
-        {
-            "atmospheric_river_mask": ar_mask_result,
-            "atmospheric_river_land_intersection": land_intersection,
-            "integrated_vapor_transport": ivt_data,
-        }
-    )
+    result: dict[str, xr.DataArray] = {
+        "atmospheric_river_mask": ar_mask_result,
+        "atmospheric_river_land_intersection": land_intersection,
+        "integrated_vapor_transport": ivt_data,
+    }
+    if output_variables is not None:
+        result = {k: v for k, v in result.items() if k in output_variables}
+    return xr.Dataset(result)

--- a/src/extremeweatherbench/events/atmospheric_river.py
+++ b/src/extremeweatherbench/events/atmospheric_river.py
@@ -32,6 +32,7 @@ def _label_time_linked_stack(mask: np.ndarray) -> np.ndarray:
         for i in range(n_pix):
             parent[i] = i
             remap[i] = 0
+        # Union True pixels with west, south, and previous-time neighbors.
         for t in range(n_t):
             for y in range(n_y):
                 for x in range(n_x):
@@ -53,6 +54,7 @@ def _label_time_linked_stack(mask: np.ndarray) -> np.ndarray:
                         rb = _ufind(parent, idx - stride_t)
                         if ra != rb:
                             parent[rb] = ra
+        # Assign dense labels; extras do not share IDs.
         next_local = 0
         for t in range(n_t):
             for y in range(n_y):
@@ -69,17 +71,6 @@ def _label_time_linked_stack(mask: np.ndarray) -> np.ndarray:
                     out[t, e, y, x] = lab + (next_id - 1)
         next_id += next_local
     return out
-
-
-def _label_time_linked_tyx(mask_tyx: npt.NDArray[np.bool_]) -> npt.NDArray[np.int32]:
-    """Label a (time, lat, lon) mask with 6-connectivity.
-
-    2D connected components plus union-find across consecutive times.
-    Matches ndimage.label with generate_binary_structure(3, 1).
-    """
-    mask = np.ascontiguousarray(mask_tyx)
-    stacked = mask.reshape(mask.shape[0], 1, mask.shape[1], mask.shape[2])
-    return _label_time_linked_stack(stacked)[:, 0]
 
 
 def _label_objects_time_linked(
@@ -106,29 +97,6 @@ def _label_objects_time_linked(
     return np.transpose(out.reshape(n_t, *extra, n_y, n_x), np.argsort(order))
 
 
-@njit(cache=True)
-def _accumulate_label_lat_neg2(
-    labeled: np.ndarray,
-    latitudes: np.ndarray,
-    counts: np.ndarray,
-    lat_sums: np.ndarray,
-) -> None:
-    """Sum counts and latitudes when latitude is the second-last axis."""
-    n_lead = 1
-    for s in labeled.shape[:-2]:
-        n_lead *= s
-    n_y = labeled.shape[-2]
-    n_x = labeled.shape[-1]
-    flat = labeled.reshape(n_lead, n_y, n_x)
-    for i in range(n_lead):
-        for y in range(n_y):
-            lat = latitudes[y]
-            for x in range(n_x):
-                lab = flat[i, y, x]
-                counts[lab] += 1
-                lat_sums[lab] += lat
-
-
 def _filter_labels_size_and_lat(
     labeled: npt.NDArray[np.int32],
     latitudes: npt.NDArray[np.floating],
@@ -139,23 +107,23 @@ def _filter_labels_size_and_lat(
     """Keep labels with enough pixels and |mean lat| above the tropics."""
     if labeled.size == 0:
         return np.zeros(labeled.shape, dtype=bool)
-    lab = np.ascontiguousarray(labeled)
-    n = int(lab.max()) + 1
-    counts = np.zeros(n, dtype=np.int64)
-    lat_sums = np.zeros(n, dtype=np.float64)
-    lats = np.ascontiguousarray(latitudes, dtype=np.float64)
-    if lat_axis == lab.ndim - 2:
-        _accumulate_label_lat_neg2(lab, lats, counts, lat_sums)
-    else:
-        moved = np.ascontiguousarray(np.moveaxis(lab, lat_axis, -2))
-        _accumulate_label_lat_neg2(moved, lats, counts, lat_sums)
+    n = int(labeled.max()) + 1
+    flat = labeled.ravel()
+    counts = np.bincount(flat, minlength=n)
+    lat_shape = [1] * labeled.ndim
+    lat_shape[lat_axis] = np.asarray(latitudes).size
+    weights = np.broadcast_to(
+        np.asarray(latitudes, dtype=np.float64).reshape(lat_shape),
+        labeled.shape,
+    )
+    lat_sums = np.bincount(flat, weights=weights.ravel(), minlength=n)
     valid = np.zeros(n, dtype=np.bool_)
     if n > 1:
         denom = np.maximum(counts[1:], 1)
         valid[1:] = (counts[1:] >= min_size) & (
             np.abs(lat_sums[1:] / denom) > min_abs_lat
         )
-    return valid[lab]
+    return valid[labeled]
 
 
 @guvectorize(
@@ -189,13 +157,7 @@ def _dilated_high_laplacian(
     laplacian_threshold: float,
     dilation_radius: int,
 ) -> xr.DataArray:
-    """Blurred Laplacian, threshold, and dilate on the same IVT chunks.
-
-    Uses the public laplacian ufunc on whatever array apply_ufunc passes
-    so chunk shapes (and therefore N-D filter axes) match develop.
-    Dilation uses axes=(-2, -1) and is spatially identical without a
-    time=1 rechunk.
-    """
+    """Threshold the blurred Laplacian and dilate on the same IVT chunks."""
 
     def _ufunc(data, sigma_, lap_thresh, radius):
         lap = calc._compute_blurred_laplacian_ufunc(data, sigma_)
@@ -234,18 +196,10 @@ def _finalize_ar_mask(
         labeled_array, latitudes, lat_axis, min_size_gridpoints
     )
     ar_mask = xr.DataArray(
-        np.where(feature_mask, 1, 0), coords=coords_dict, dims=coords_dict.keys()
+        feature_mask.astype(np.int8), coords=coords_dict, dims=coords_dict.keys()
     )
     ar_mask.name = "atmospheric_river_mask"
     return ar_mask
-
-
-def _intersection_as_bool(intersection: xr.DataArray) -> npt.NDArray[np.bool_]:
-    """Convert an intersection array to bool; NaN reindex fills are False."""
-    values = np.asarray(intersection)
-    if np.issubdtype(values.dtype, np.floating):
-        return np.isfinite(values) & (values != 0)
-    return values.astype(bool)
 
 
 def _finalize_ar_mask_by_lead(
@@ -253,30 +207,31 @@ def _finalize_ar_mask_by_lead(
     min_size_gridpoints: int,
     time_dimension: str,
 ) -> xr.DataArray:
-    """Compute and label each lead as its bool mask becomes available."""
-    if "lead_time" not in intersection.dims:
-        coords_dict = {dim: intersection.coords[dim] for dim in intersection.dims}
-        return _finalize_ar_mask(
-            _intersection_as_bool(intersection),
-            coords_dict,
-            min_size_gridpoints,
-            time_dimension,
-        )
+    """Label each lead independently so masks can stream as they compute."""
+    if "lead_time" in intersection.dims:
+        slices = [
+            intersection.isel(lead_time=i)
+            for i in range(intersection.sizes["lead_time"])
+        ]
+    else:
+        slices = [intersection]
     parts = []
-    for i in range(intersection.sizes["lead_time"]):
-        sl = intersection.isel(lead_time=i)
-        coords_dict = {dim: sl.coords[dim] for dim in sl.dims}
+    for sl in slices:
+        coords = {dim: sl.coords[dim] for dim in sl.dims}
         parts.append(
             _finalize_ar_mask(
-                _intersection_as_bool(sl),
-                coords_dict,
+                utils.values_as_bool(sl),
+                coords,
                 min_size_gridpoints,
                 time_dimension,
             )
         )
+    if "lead_time" not in intersection.dims:
+        return parts[0]
     out = xr.concat(parts, dim="lead_time")
-    out = out.assign_coords(lead_time=intersection.lead_time)
-    return out.transpose(*intersection.dims)
+    return out.assign_coords(lead_time=intersection.lead_time).transpose(
+        *intersection.dims
+    )
 
 
 def atmospheric_river_mask(
@@ -313,14 +268,8 @@ def atmospheric_river_mask(
         The atmospheric river mask as a DataArray
     """
 
-    # Create boolean masks for each condition
-    has_high_laplacian, has_high_ivt = (
-        np.abs(ivt_laplacian) >= laplacian_threshold,
-        ivt >= ivt_threshold,
-    )
-
-    # Dilate on existing chunks. The ufunc is lat/lon-only, so a
-    # time=1 rechunk is not required for identical spatial dilation.
+    has_high_laplacian = np.abs(ivt_laplacian) >= laplacian_threshold
+    has_high_ivt = ivt >= ivt_threshold
     dilated_laplacian = xr.apply_ufunc(
         calc._binary_dilation_ufunc,
         has_high_laplacian,
@@ -331,8 +280,6 @@ def atmospheric_river_mask(
         keep_attrs=True,
         output_dtypes=[np.int8],
     )
-
-    # Bool intersection only; avoid xr.where int cubes before labeling.
     initial_intersection = dilated_laplacian.astype(bool) & has_high_ivt.astype(bool)
     return _finalize_ar_mask_by_lead(
         initial_intersection,
@@ -357,8 +304,6 @@ def integrated_vapor_transport(
         Integrated vapor transport as a DataArray
     """
 
-    # Fuse u*q / v*q / trapezoid / hypot so q is read once and IVT is
-    # a single shared dask node for laplacian, mask, and returned IVT.
     q = specific_humidity.chunk({"level": -1})
     u = eastward_wind.chunk({"level": -1})
     v = northward_wind.chunk({"level": -1})
@@ -420,17 +365,12 @@ def build_atmospheric_river_mask_and_land_intersection(
     Returns:
         Dataset containing atmospheric river mask and land intersection.
     """
-    # Drop reindex-fill (lead, valid_time) pairs before the 3D IVT graph.
     working = utils.stack_valid_time_pairs(data)
-    # One shared IVT node for laplacian, IVT threshold, and optional output.
     ivt_data = integrated_vapor_transport(
         specific_humidity=working["specific_humidity"],
         eastward_wind=working["eastward_wind"],
         northward_wind=working["northward_wind"],
     )
-
-    # Fuse laplacian + threshold + dilation on the same IVT chunks so the
-    # N-D filter axes match develop and dilation stays spatial-only.
     dilated = _dilated_high_laplacian(
         ivt_data, sigma=3, laplacian_threshold=2.5, dilation_radius=8
     )

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -482,7 +482,55 @@ def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
         compat="equals",
         join="outer",
     )
-    return out.assign_coords(lead_time=("lead_time", ds.lead_time.values))
+    out = out.assign_coords(lead_time=("lead_time", ds.lead_time.values))
+    if "valid_time_mask" in out.coords:
+        mask = out.valid_time_mask
+        out = out.assign_coords(
+            valid_time_mask=xr.where(mask.isnull(), False, mask).astype(bool)
+        )
+    return out
+
+
+def _valid_time_mask_as_bool(mask: xr.DataArray) -> npt.NDArray[np.bool_]:
+    """Treat reindex fills (NaN) as False without reading data vars."""
+    values = np.asarray(mask.values)
+    if np.issubdtype(values.dtype, np.floating):
+        return np.isfinite(values) & (values != 0)
+    return values.astype(bool)
+
+
+def stack_valid_time_pairs(
+    obj: xr.Dataset | xr.DataArray,
+) -> xr.Dataset | xr.DataArray:
+    """Keep only valid (lead_time, valid_time) pairs as a sample dim.
+
+    Uses the ``valid_time_mask`` coordinate so fill cells from
+    ``convert_init_time_to_valid_time`` never enter the dask graph.
+    """
+    if not {"lead_time", "valid_time"} <= set(obj.dims):
+        return obj
+    if "valid_time_mask" not in obj.coords:
+        return obj
+    stacked = obj.stack(sample=("lead_time", "valid_time"))
+    keep = _valid_time_mask_as_bool(stacked["valid_time_mask"]).ravel()
+    return stacked.isel(sample=np.flatnonzero(keep))
+
+
+def unstack_valid_time_pairs(
+    obj: xr.Dataset | xr.DataArray,
+    like: xr.Dataset | xr.DataArray | None = None,
+) -> xr.Dataset | xr.DataArray:
+    """Restore lead_time × valid_time from a valid-pair sample dim.
+
+    When ``like`` is given, reindex onto its lead_time and valid_time so
+    fill cells come back as NaN on the original dense grid.
+    """
+    if "sample" not in obj.dims:
+        return obj
+    out = obj.unstack("sample")
+    if like is not None and {"lead_time", "valid_time"} <= set(like.dims):
+        out = out.reindex(lead_time=like.lead_time, valid_time=like.valid_time)
+    return out
 
 
 def convert_valid_time_to_init_time(da: xr.DataArray) -> xr.DataArray:

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -491,12 +491,12 @@ def convert_init_time_to_valid_time(ds: xr.Dataset) -> xr.Dataset:
     return out
 
 
-def _valid_time_mask_as_bool(mask: xr.DataArray) -> npt.NDArray[np.bool_]:
-    """Treat reindex fills (NaN) as False without reading data vars."""
-    values = np.asarray(mask.values)
-    if np.issubdtype(values.dtype, np.floating):
-        return np.isfinite(values) & (values != 0)
-    return values.astype(bool)
+def values_as_bool(values) -> npt.NDArray[np.bool_]:
+    """Coerce an array to bool; NaN / non-finite fills become False."""
+    arr = np.asarray(values)
+    if np.issubdtype(arr.dtype, np.floating):
+        return np.isfinite(arr) & (arr != 0)
+    return arr.astype(bool)
 
 
 def stack_valid_time_pairs(
@@ -512,7 +512,7 @@ def stack_valid_time_pairs(
     if "valid_time_mask" not in obj.coords:
         return obj
     stacked = obj.stack(sample=("lead_time", "valid_time"))
-    keep = _valid_time_mask_as_bool(stacked["valid_time_mask"]).ravel()
+    keep = values_as_bool(stacked["valid_time_mask"]).ravel()
     return stacked.isel(sample=np.flatnonzero(keep))
 
 

--- a/tests/test_atmospheric_river.py
+++ b/tests/test_atmospheric_river.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from scipy import ndimage
 
-from extremeweatherbench import calc
+from extremeweatherbench import calc, derived
 from extremeweatherbench.events import atmospheric_river
 
 # Set random seed for reproducible tests
@@ -924,6 +924,15 @@ class TestBuildMaskAndLandIntersection:
         assert list(land_intersection.dims) == ["valid_time", "latitude", "longitude"]
         # Values should be 0 or 1 (binary mask)
         assert set(land_intersection.values.flatten()).issubset({0, 1})
+        assert "integrated_vapor_transport" in result.data_vars
+
+    def test_derived_variable_emits_only_requested_outputs(self, sample_full_dataset):
+        """User-facing AR derive must keep only requested output variables."""
+        ar_var = derived.AtmosphericRiverVariables(
+            output_variables=["atmospheric_river_land_intersection"]
+        )
+        result = ar_var.derive_variable(sample_full_dataset)
+        assert list(result.data_vars) == ["atmospheric_river_land_intersection"]
 
     def test_build_mask_and_land_intersection_missing_variables(self):
         """Test integration with missing required variables."""
@@ -1172,9 +1181,18 @@ class TestTimeLinkedLabeling:
         shape = (len(lead), len(time), len(level), len(lat), len(lon))
         data = xr.Dataset(
             {
-                "specific_humidity": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
-                "eastward_wind": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
-                "northward_wind": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
+                "specific_humidity": (
+                    ["lead_time", "valid_time", "level", "latitude", "longitude"],
+                    np.ones(shape),
+                ),
+                "eastward_wind": (
+                    ["lead_time", "valid_time", "level", "latitude", "longitude"],
+                    np.ones(shape),
+                ),
+                "northward_wind": (
+                    ["lead_time", "valid_time", "level", "latitude", "longitude"],
+                    np.ones(shape),
+                ),
             },
             coords={
                 "lead_time": lead,
@@ -1199,16 +1217,12 @@ class TestTimeLinkedLabeling:
             ivt.name = "integrated_vapor_transport"
             return ivt * 500
 
-        monkeypatch.setattr(
-            atmospheric_river, "integrated_vapor_transport", fake_ivt
-        )
+        monkeypatch.setattr(atmospheric_river, "integrated_vapor_transport", fake_ivt)
         monkeypatch.setattr(
             atmospheric_river,
             "_dilated_high_laplacian",
             lambda ivt, **kwargs: xr.ones_like(ivt, dtype=np.int8),
         )
-        atmospheric_river.build_atmospheric_river_mask_and_land_intersection(
-            data
-        )
+        atmospheric_river.build_atmospheric_river_mask_and_land_intersection(data)
         assert "sample" in seen["dims"]
         assert seen["size"] == 3

--- a/tests/test_atmospheric_river.py
+++ b/tests/test_atmospheric_river.py
@@ -696,6 +696,49 @@ class TestComputeIVTLaplacian:
         # Should handle NaN values gracefully
         # Note: The result might contain NaNs depending on how the filter handles them
 
+    def test_laplacian_does_not_mix_unrelated_sample_fields(self):
+        """Sample-axis fields must match independently computed 2D slices."""
+        lat = np.linspace(20, 50, 16)
+        lon = np.linspace(-130, -100, 16)
+        field_a = np.zeros((16, 16), dtype=np.float64)
+        field_b = np.zeros((16, 16), dtype=np.float64)
+        field_a[3:8, 3:8] = 800.0
+        field_b[9:14, 9:14] = 800.0
+        stacked = xr.DataArray(
+            np.stack([field_a, field_b], axis=0),
+            dims=["sample", "latitude", "longitude"],
+            coords={"sample": [0, 1], "latitude": lat, "longitude": lon},
+            name="integrated_vapor_transport",
+        ).chunk({"sample": -1, "latitude": -1, "longitude": -1})
+        result = atmospheric_river.integrated_vapor_transport_laplacian(stacked)
+        expected = xr.concat(
+            [
+                atmospheric_river.integrated_vapor_transport_laplacian(
+                    stacked.isel(sample=i)
+                )
+                for i in range(2)
+            ],
+            dim="sample",
+        )
+        xr.testing.assert_allclose(result, expected)
+
+        fused = atmospheric_river._dilated_high_laplacian(
+            stacked, sigma=3, laplacian_threshold=2.5, dilation_radius=8
+        )
+        fused_expected = xr.concat(
+            [
+                atmospheric_river._dilated_high_laplacian(
+                    stacked.isel(sample=i),
+                    sigma=3,
+                    laplacian_threshold=2.5,
+                    dilation_radius=8,
+                )
+                for i in range(2)
+            ],
+            dim="sample",
+        )
+        np.testing.assert_array_equal(fused.values, fused_expected.values)
+
 
 class TestFindLandIntersection:
     """Test land intersection calculations."""

--- a/tests/test_atmospheric_river.py
+++ b/tests/test_atmospheric_river.py
@@ -1059,3 +1059,113 @@ class TestTimeLinkedLabeling:
             mask, ["valid_time", "latitude", "longitude"], "valid_time"
         )
         assert len(np.unique(labeled[labeled > 0])) == 1
+
+    def test_finalize_per_lead_matches_full_cube(self):
+        """Per-lead finalize must match a single full-cube 0/1 mask."""
+        rng_local = np.random.default_rng(1)
+        lead = [0, 6, 12]
+        time = pd.date_range("2023-01-01", periods=4, freq="6h")
+        lat = np.linspace(20, 50, 12)
+        lon = np.linspace(-130, -100, 10)
+        mask = rng_local.random((len(lead), len(time), len(lat), len(lon))) > 0.7
+        mask[:, :, 2:10, 2:8] = True
+        intersection = xr.DataArray(
+            mask,
+            dims=["lead_time", "valid_time", "latitude", "longitude"],
+            coords={
+                "lead_time": lead,
+                "valid_time": time,
+                "latitude": lat,
+                "longitude": lon,
+            },
+        )
+        coords = {dim: intersection.coords[dim] for dim in intersection.dims}
+        full = atmospheric_river._finalize_ar_mask(
+            mask, coords, min_size_gridpoints=20, time_dimension="valid_time"
+        )
+        streamed = atmospheric_river._finalize_ar_mask_by_lead(
+            intersection, min_size_gridpoints=20, time_dimension="valid_time"
+        )
+        np.testing.assert_array_equal(full.values, streamed.values)
+
+    def test_finalize_treats_unstacked_nan_as_false(self):
+        """Reindex fills are NaN and must not become True in the mask."""
+        lead = [0, 6]
+        time = pd.date_range("2023-01-01", periods=3, freq="6h")
+        lat = np.linspace(20, 50, 8)
+        lon = np.linspace(-130, -100, 8)
+        mask = np.zeros((2, 3, 8, 8), dtype=float)
+        mask[0, 0, 1:7, 1:7] = 1.0
+        mask[0, 1, :, :] = np.nan
+        mask[1, 2, 1:7, 1:7] = 1.0
+        intersection = xr.DataArray(
+            mask,
+            dims=["lead_time", "valid_time", "latitude", "longitude"],
+            coords={
+                "lead_time": lead,
+                "valid_time": time,
+                "latitude": lat,
+                "longitude": lon,
+            },
+        )
+        streamed = atmospheric_river._finalize_ar_mask_by_lead(
+            intersection, min_size_gridpoints=10, time_dimension="valid_time"
+        )
+        expected = atmospheric_river._finalize_ar_mask_by_lead(
+            intersection.fillna(False),
+            min_size_gridpoints=10,
+            time_dimension="valid_time",
+        )
+        np.testing.assert_array_equal(streamed.values, expected.values)
+        assert int(streamed.isel(lead_time=0, valid_time=1).sum()) == 0
+
+    def test_build_mask_stacks_invalid_pairs_before_ivt(self, monkeypatch):
+        """AR derive must stack to valid (lead, time) pairs before IVT."""
+        lead = pd.to_timedelta([0, 6], unit="h")
+        time = pd.date_range("2023-01-01", periods=3, freq="6h")
+        lat = np.linspace(20, 50, 8)
+        lon = np.linspace(-130, -100, 8)
+        level = [1000, 850, 700]
+        shape = (len(lead), len(time), len(level), len(lat), len(lon))
+        data = xr.Dataset(
+            {
+                "specific_humidity": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
+                "eastward_wind": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
+                "northward_wind": (["lead_time", "valid_time", "level", "latitude", "longitude"], np.ones(shape)),
+            },
+            coords={
+                "lead_time": lead,
+                "valid_time": time,
+                "level": level,
+                "latitude": lat,
+                "longitude": lon,
+                "valid_time_mask": (
+                    ["lead_time", "valid_time"],
+                    np.array(
+                        [[True, False, True], [False, True, False]],
+                    ),
+                ),
+            },
+        )
+        seen = {}
+
+        def fake_ivt(specific_humidity, eastward_wind, northward_wind):
+            seen["dims"] = specific_humidity.dims
+            seen["size"] = specific_humidity.sizes.get("sample")
+            ivt = xr.ones_like(specific_humidity.isel(level=0, drop=True))
+            ivt.name = "integrated_vapor_transport"
+            return ivt * 500
+
+        monkeypatch.setattr(
+            atmospheric_river, "integrated_vapor_transport", fake_ivt
+        )
+        monkeypatch.setattr(
+            atmospheric_river,
+            "_dilated_high_laplacian",
+            lambda ivt, **kwargs: xr.ones_like(ivt, dtype=np.int8),
+        )
+        atmospheric_river.build_atmospheric_river_mask_and_land_intersection(
+            data
+        )
+        assert "sample" in seen["dims"]
+        assert seen["size"] == 3

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1984,6 +1984,52 @@ class TestPipelineFunctions:
             # Two targets + one forecast; the second forecast is reused.
             assert mock_run_pipeline.call_count == 3
 
+    def test_precompute_unique_targets_runs_shared_target_once(
+        self, sample_case_operator
+    ):
+        """Two forecast groups that share a target precompute it once."""
+        other_forecast = mock.Mock(spec=inputs.ForecastBase)
+        other_forecast.name = "other"
+        other_forecast.source = "other://x"
+        other_forecast.variables = sample_case_operator.forecast.variables
+        op2 = dataclasses.replace(sample_case_operator, forecast=other_forecast)
+        target_ds = xr.Dataset(
+            coords={"time": [1, 2, 3]}, attrs={"name": "shared_target"}
+        )
+        with mock.patch(
+            "extremeweatherbench.evaluate.run_pipeline", return_value=target_ds
+        ) as mock_run:
+            precomputed = evaluate._precompute_unique_targets(
+                [sample_case_operator, op2]
+            )
+        assert mock_run.call_count == 1
+        assert len(precomputed) == 1
+        only = next(iter(precomputed.values()))
+        assert only.attrs["name"] == "shared_target"
+
+    def test_build_datasets_uses_precomputed_target(self, sample_case_operator):
+        """A precomputed target must skip the target pipeline."""
+        precomputed_target = xr.Dataset(
+            coords={"time": [1, 2, 3]}, attrs={"name": "precomputed"}
+        )
+        forecast_ds = xr.Dataset(
+            coords={"valid_time": [1, 2, 3]}, attrs={"name": "forecast_source"}
+        )
+        key = evaluate._pipeline_cache_key(
+            sample_case_operator.case_metadata,
+            sample_case_operator.target,
+        )
+        with mock.patch(
+            "extremeweatherbench.evaluate.run_pipeline", return_value=forecast_ds
+        ) as mock_run:
+            forecast_out, target_out = evaluate._build_datasets(
+                sample_case_operator,
+                precomputed_targets={key: precomputed_target},
+            )
+        assert mock_run.call_count == 1
+        assert target_out.attrs["name"] == "precomputed"
+        assert forecast_out.attrs["name"] == "forecast_source"
+
     def test_build_datasets_zero_length_dimensions(self, sample_case_operator):
         """Test _build_datasets when forecast has zero-length dimensions."""
         # Set up the mock to return a dataset that will trigger the warning

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -10,7 +10,7 @@ import pytest
 import sparse
 import xarray as xr
 
-from extremeweatherbench import inputs, utils
+from extremeweatherbench import cases, inputs, regions, utils
 
 
 class TestInputBase:
@@ -757,6 +757,52 @@ class TestForecastBase:
 
             # Should process normally without issues
             assert isinstance(result, xr.Dataset)
+
+    def test_forecast_subset_keeps_valid_time_mask_on_lead_valid_time(self):
+        """Subset must expose a (lead, valid_time) mask of overlapping pairs."""
+        inits = pd.date_range("2021-06-20", periods=3, freq="12h")
+        leads = pd.to_timedelta([0, 6, 12, 24], unit="h")
+        lats = np.array([44.0, 45.0, 46.0])
+        lons = np.array([-121.0, -120.0, -119.0])
+        data = xr.Dataset(
+            {
+                "surface_air_temperature": (
+                    ["init_time", "lead_time", "latitude", "longitude"],
+                    np.ones((3, 4, 3, 3)),
+                )
+            },
+            coords={
+                "init_time": inits,
+                "lead_time": leads,
+                "latitude": lats,
+                "longitude": lons,
+            },
+        )
+        case = cases.IndividualCase(
+            case_id_number=1,
+            title="mask-pairs",
+            start_date=pd.Timestamp("2021-06-20 12:00"),
+            end_date=pd.Timestamp("2021-06-21 00:00"),
+            location=regions.CenteredRegion(
+                latitude=45.0, longitude=-120.0, bounding_box_degrees=4.0
+            ),
+            event_type="heat_wave",
+        )
+        forecast = inputs.ZarrForecast(
+            name="test",
+            source="test.zarr",
+            variables=["surface_air_temperature"],
+            variable_mapping={},
+            storage_options={},
+        )
+        result = forecast.subset_data_to_case(data, case)
+        assert "valid_time_mask" in result.coords
+        mask = result.valid_time_mask
+        assert set(mask.dims) == {"lead_time", "valid_time"}
+        assert bool(mask.any())
+        n_true = int(mask.astype(bool).sum())
+        stacked = utils.stack_valid_time_pairs(result)
+        assert stacked.sizes["sample"] == n_true
 
     def test_forecast_base_duplicate_init_times_preserves_first_occurrence(self):
         """Test that when duplicates exist, the first occurrence is preserved."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -454,6 +454,103 @@ def test_convert_init_time_to_valid_time():
     assert "init_time" not in result.dims or "valid_time" in result.dims
 
 
+def test_convert_init_time_to_valid_time_preserves_valid_time_mask():
+    """valid_time_mask must follow convert onto (lead_time, valid_time)."""
+    inits = pd.date_range("2020-01-01", periods=2, freq="12h")
+    leads = pd.to_timedelta([0, 6, 12], unit="h")
+    mask = np.array(
+        [
+            [True, True, False],
+            [True, False, True],
+        ]
+    )
+    ds = xr.Dataset(
+        {"temp": (["init_time", "lead_time"], np.arange(6).reshape(2, 3))},
+        coords={
+            "init_time": inits,
+            "lead_time": leads,
+            "valid_time_mask": (["init_time", "lead_time"], mask),
+        },
+    )
+    result = utils.convert_init_time_to_valid_time(ds)
+    assert result.valid_time_mask.dims == ("lead_time", "valid_time") or (
+        result.valid_time_mask.dims == ("valid_time", "lead_time")
+    )
+    mask_out = result.valid_time_mask.transpose("lead_time", "valid_time")
+    for i, lead in enumerate(leads):
+        for init, keep in zip(inits, mask[:, i]):
+            vt = init + lead
+            got = bool(mask_out.sel(lead_time=lead, valid_time=vt).values)
+            assert got is bool(keep)
+
+
+def test_stack_valid_time_pairs_keeps_only_true_mask_cells():
+    """Stack helper must drop reindex-fill (lead, valid_time) pairs."""
+    inits = pd.date_range("2020-01-01", periods=2, freq="12h")
+    leads = pd.to_timedelta([0, 6], unit="h")
+    values = np.arange(4, dtype=float).reshape(2, 2)
+    mask = np.array([[True, False], [True, True]])
+    ds = xr.Dataset(
+        {"temp": (["init_time", "lead_time"], values)},
+        coords={
+            "init_time": inits,
+            "lead_time": leads,
+            "valid_time_mask": (["init_time", "lead_time"], mask),
+        },
+    )
+    converted = utils.convert_init_time_to_valid_time(ds)
+    stacked = utils.stack_valid_time_pairs(converted)
+    assert stacked.sizes["sample"] == int(mask.sum())
+    expected = values[mask]
+    np.testing.assert_array_equal(
+        np.sort(stacked["temp"].values), np.sort(expected)
+    )
+
+
+def test_stack_valid_time_pairs_reduces_dask_chunks():
+    """Valid-pair stack must drop fill chunks from the dask graph."""
+    inits = pd.date_range("2020-01-01", periods=2, freq="12h")
+    leads = pd.to_timedelta([0, 6, 12], unit="h")
+    values = np.arange(6, dtype=float).reshape(2, 3)
+    mask = np.array([[True, False, True], [False, True, False]])
+    ds = xr.Dataset(
+        {"temp": (["init_time", "lead_time"], values)},
+        coords={
+            "init_time": inits,
+            "lead_time": leads,
+            "valid_time_mask": (["init_time", "lead_time"], mask),
+        },
+    ).chunk({"init_time": 1, "lead_time": 1})
+    converted = utils.convert_init_time_to_valid_time(ds)
+    stacked = utils.stack_valid_time_pairs(converted)
+    assert stacked["temp"].data.npartitions == int(mask.sum())
+
+
+def test_unstack_valid_time_pairs_restores_values():
+    """Unstack must restore valid cells and leave fills as NaN."""
+    inits = pd.date_range("2020-01-01", periods=2, freq="12h")
+    leads = pd.to_timedelta([0, 6], unit="h")
+    values = np.array([[1.0, 2.0], [3.0, 4.0]])
+    mask = np.array([[True, False], [True, True]])
+    ds = xr.Dataset(
+        {"temp": (["init_time", "lead_time"], values)},
+        coords={
+            "init_time": inits,
+            "lead_time": leads,
+            "valid_time_mask": (["init_time", "lead_time"], mask),
+        },
+    )
+    converted = utils.convert_init_time_to_valid_time(ds)
+    restored = utils.unstack_valid_time_pairs(
+        utils.stack_valid_time_pairs(converted), like=converted
+    )
+    keep = converted.valid_time_mask.astype(bool)
+    xr.testing.assert_equal(
+        restored["temp"].where(keep).reset_coords(drop=True),
+        converted["temp"].where(keep).reset_coords(drop=True),
+    )
+
+
 def test_convert_init_time_to_valid_time_matches_outer_concat():
     """Dense fixture must match concat of swapped leads with join='outer'."""
     inits = pd.date_range("2020-01-01", periods=4, freq="12h")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -502,9 +502,7 @@ def test_stack_valid_time_pairs_keeps_only_true_mask_cells():
     stacked = utils.stack_valid_time_pairs(converted)
     assert stacked.sizes["sample"] == int(mask.sum())
     expected = values[mask]
-    np.testing.assert_array_equal(
-        np.sort(stacked["temp"].values), np.sort(expected)
-    )
+    np.testing.assert_array_equal(np.sort(stacked["temp"].values), np.sort(expected))
 
 
 def test_stack_valid_time_pairs_reduces_dask_chunks():


### PR DESCRIPTION
Skip unused forecast (lead, valid_time) pairs before AR IVT, stream masks one lead at a time, and reuse each unique target dataset across forecast workers.

## Test plan
- [ ] AR / stacking / shared-target tests
- [ ] Case 128 still produces the expected mask and land intersection

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3d78fcce4dc3fbc8b63d608f89e88044e64a7c00","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->