### PR TITLE
fix: sample station observations at stations, not a lat/lon mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,10 @@ commits. Prefer this changelog when writing GitHub release notes.
 - `outputs` is exported from the package loader, and empty-fallback
   time dims no longer poison Dataset dtypes
   ([#407](https://github.com/brightbandtech/ExtremeWeatherBench/pull/407)).
+- Point observations (GHCN, LSR) use a `location` dimension instead of
+  a unique-lat × unique-lon mesh. Alignment samples the forecast at
+  those stations, which avoids out-of-memory on large freeze cases and
+  makes spatial-mean metrics average stations only.
 
 ## [1.0.2.post1] - 2026-04-30
 

--- a/docs/recipes/your_own_target.md
+++ b/docs/recipes/your_own_target.md
@@ -100,7 +100,6 @@ dataset stored in parquet format:
 import dataclasses
 import pandas as pd
 import polars as pl
-import xarray as xr
 import extremeweatherbench as ewb
 from extremeweatherbench import inputs, cases, utils
 
@@ -136,10 +135,7 @@ class MyStationObs(inputs.TargetBase):
         # EWB calls this when it needs an xr.Dataset from the LazyFrame
         df = data.collect(engine="streaming").to_pandas()
         df["longitude"] = utils.convert_longitude_to_360(df["longitude"])
-        df = df.set_index(["valid_time", "latitude", "longitude"])
-        return xr.Dataset.from_dataframe(
-            df[~df.index.duplicated(keep="first")], sparse=True
-        )
+        return utils.point_frame_to_dataset(df)
 
     def maybe_align_forecast_to_target(self, forecast_data, target_data):
         return inputs.align_forecast_to_target(forecast_data, target_data)
@@ -150,10 +146,12 @@ class MyStationObs(inputs.TargetBase):
 > The base `TargetBase` implementation handles `xr.Dataset` and
 > `xr.DataArray` natively; for any other type (polars `LazyFrame`,
 > pandas `DataFrame`) you must override `_custom_convert_to_dataset` to
-> produce an `xr.Dataset` with `valid_time`, `latitude`, and `longitude`
-> as index dimensions. `align_forecast_to_target` then interpolates the
-> forecast to the target's spatial coordinates using nearest-neighbour
-> interpolation.
+> produce an `xr.Dataset`. For station data, use
+> `utils.point_frame_to_dataset`: that keeps one row per station as a
+> `location` dimension, with `latitude` and `longitude` as coordinates.
+> Do not index by unique latitude and longitude — that builds a full
+> lat × lon mesh and can run out of memory. `align_forecast_to_target`
+> then samples a gridded forecast at those station pairs.
 
 ## Tips
 
@@ -178,7 +176,6 @@ import datetime
 import dataclasses
 import pandas as pd
 import polars as pl
-import xarray as xr
 import extremeweatherbench as ewb
 from extremeweatherbench import inputs, utils
 from extremeweatherbench.cases import IndividualCase
@@ -230,10 +227,7 @@ class CustomGHCN(inputs.TargetBase):
         df = data.collect().to_pandas()
         df["surface_air_temperature"] += 273.15
         df["longitude"] = utils.convert_longitude_to_360(df["longitude"])
-        df = df.set_index(["valid_time", "latitude", "longitude"])
-        return xr.Dataset.from_dataframe(
-            df[~df.index.duplicated(keep="first")], sparse=True
-        )
+        return utils.point_frame_to_dataset(df)
 
     def maybe_align_forecast_to_target(self, forecast_data, target_data):
         return inputs.align_forecast_to_target(forecast_data, target_data)

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -1206,9 +1206,51 @@ def align_forecast_to_target(
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """Put forecast and target on a shared sample geometry.
 
-    Two grids: remap forecast onto the target grid. If either side is
-    points, sample the field at those (lat, lon) pairs instead of
-    expanding onto a unique-lat x unique-lon mesh.
+    Two grids: remap the forecast onto the target grid. If either side
+    is points (station samples or a sparse lat × lon cube), sample the
+    field at those (lat, lon) pairs instead of expanding onto a
+    unique-lat × unique-lon mesh.
+
+    Args:
+        forecast_data: Forecast Dataset, gridded or point samples.
+        target_data: Target Dataset, gridded or point samples.
+        method: Spatial interpolation method. ``"nearest"`` or
+            ``"linear"``. Defaults to ``"nearest"``.
+
+    Returns:
+        Tuple of ``(aligned_forecast, aligned_target)`` with a shared
+        time range. Point alignments use a ``location`` dimension;
+        grid alignments keep latitude and longitude dims from the
+        target.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import xarray as xr
+        >>> from extremeweatherbench import utils
+        >>> from extremeweatherbench.inputs import align_forecast_to_target
+        >>> times = pd.date_range("2021-01-01", periods=1, freq="6h")
+        >>> t2m = [[[0.0, 1.0]]]
+        >>> forecast = xr.Dataset(
+        ...     {"t2m": (("valid_time", "latitude", "longitude"), t2m)},
+        ...     coords={
+        ...         "valid_time": times,
+        ...         "latitude": [10.0],
+        ...         "longitude": [20.0, 30.0],
+        ...     },
+        ... )
+        >>> stations = utils.point_frame_to_dataset(
+        ...     pd.DataFrame(
+        ...         {
+        ...             "valid_time": [times[0]],
+        ...             "latitude": [10.0],
+        ...             "longitude": [20.0],
+        ...             "t2m": [0.0],
+        ...         }
+        ...     )
+        ... )
+        >>> fc, tg = align_forecast_to_target(forecast, stations)
+        >>> fc.sizes["location"] == tg.sizes["location"]
+        True
     """
     fc_layout = utils.infer_spatial_layout(forecast_data)
     tg_layout = utils.infer_spatial_layout(target_data)

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -674,14 +674,9 @@ class GHCN(TargetBase):
                 data = data.with_columns(pl.col("surface_air_temperature").add(273.15))
             data = data.collect(engine="streaming").to_pandas()
             data["longitude"] = utils.convert_longitude_to_360(data["longitude"])
-
-            data = data.set_index(["valid_time", "latitude", "longitude"])
-            # GHCN data can have duplicate values right now, dropping here if it occurs
             try:
-                data = xr.Dataset.from_dataframe(
-                    data[~data.index.duplicated(keep="first")], sparse=True
-                )
-            except (ValueError, TypeError, KeyError) as e:
+                data = utils.point_frame_to_dataset(data)
+            except (ValueError, TypeError, KeyError, IndexError) as e:
                 logger.warning(
                     "Error converting GHCN data to xarray: %s, returning empty Dataset",
                     e,
@@ -797,13 +792,14 @@ class LSR(TargetBase):
 
         # Convert longitude back to 0 - 360
         data.loc[:, "longitude"] = utils.convert_longitude_to_360(data["longitude"])
-        data = data.set_index(["valid_time", "latitude", "longitude"])
-
-        data = xr.Dataset.from_dataframe(
-            data[~data.index.duplicated(keep="first")], sparse=True
-        )
-        data.attrs["report_type_mapping"] = report_type_mapping
-        return data
+        data = data[
+            ~data.duplicated(
+                subset=["valid_time", "latitude", "longitude"], keep="first"
+            )
+        ]
+        converted = utils.point_frame_to_dataset(data)
+        converted.attrs["report_type_mapping"] = report_type_mapping
+        return converted
 
     def maybe_align_forecast_to_target(
         self,
@@ -1208,51 +1204,107 @@ def align_forecast_to_target(
     # TODO: provide passthrough for other methods
     method: str = "nearest",
 ) -> tuple[xr.Dataset, xr.Dataset]:
-    # Find spatial dimensions that exist in both datasets
+    """Put forecast and target on a shared sample geometry.
+
+    Two grids: remap forecast onto the target grid. If either side is
+    points, sample the field at those (lat, lon) pairs instead of
+    expanding onto a unique-lat x unique-lon mesh.
+    """
+    fc_layout = utils.infer_spatial_layout(forecast_data)
+    tg_layout = utils.infer_spatial_layout(target_data)
+
+    if fc_layout == "grid" and tg_layout == "grid":
+        return _align_grid_to_grid(forecast_data, target_data, method)
+
+    if tg_layout == "points":
+        target_pts = utils.as_point_dataset(target_data)
+        if fc_layout == "grid":
+            forecast_pts = utils.sample_field_at_points(
+                forecast_data,
+                target_pts["latitude"],
+                target_pts["longitude"],
+                method=method,
+            )
+        else:
+            forecast_pts = utils._colocate_points(
+                utils.as_point_dataset(forecast_data), target_pts
+            )
+        return _align_time_inner(forecast_pts, target_pts)
+
+    forecast_pts = utils.as_point_dataset(forecast_data)
+    target_pts = utils.sample_field_at_points(
+        target_data,
+        forecast_pts["latitude"],
+        forecast_pts["longitude"],
+        method=method,
+    )
+    return _align_time_inner(forecast_pts, target_pts)
+
+
+def _align_grid_to_grid(
+    forecast_data: xr.Dataset,
+    target_data: xr.Dataset,
+    method: str,
+) -> tuple[xr.Dataset, xr.Dataset]:
+    """Remap a gridded forecast onto a gridded target."""
     intersection_dims = [
         dim
         for dim in forecast_data.dims
         if dim in target_data.dims
         and dim not in ["time", "valid_time", "lead_time", "init_time"]
     ]
-
     spatial_dims = {str(dim): target_data[dim] for dim in intersection_dims}
-
-    # Align time dimensions if they exist in both datasets
     time_aligned_target, time_aligned_forecast = xr.align(
         target_data,
         forecast_data,
         join="inner",
         exclude=spatial_dims.keys(),
     )
-    # Squeeze the data to remove any single-value dimensions
-    target_data = target_data.squeeze()
-    forecast_data = forecast_data.squeeze()
-    # Regrid forecast to target grid using nearest neighbor interpolation
-    # extrapolate in the case of targets slightly outside the forecast domain
     if spatial_dims:
         same_grid = all(
             time_aligned_forecast[dim].equals(time_aligned_target[dim])
             for dim in spatial_dims
         )
         if same_grid:
-            time_space_aligned_forecast = time_aligned_forecast
-        else:
-            interp_method: Literal["nearest", "linear"] = (
-                "nearest" if method == "nearest" else "linear"
-            )
+            return time_aligned_forecast, time_aligned_target
+        interp_method: Literal["nearest", "linear"] = (
+            "nearest" if method == "nearest" else "linear"
+        )
+        interp_kwargs = cast(
+            dict[str, Any],
+            {"method": interp_method, "kwargs": {"fill_value": "extrapolate"}},
+        )
+        interp_kwargs.update(spatial_dims)
+        return time_aligned_forecast.interp(**interp_kwargs), time_aligned_target
+    return time_aligned_forecast, time_aligned_target
 
-            interp_kwargs = cast(
-                dict[str, Any],
-                {"method": interp_method, "kwargs": {"fill_value": "extrapolate"}},
-            )
-            interp_kwargs.update(spatial_dims)
 
-            time_space_aligned_forecast = time_aligned_forecast.interp(**interp_kwargs)
-    else:
-        time_space_aligned_forecast = time_aligned_forecast
-
-    return time_space_aligned_forecast, time_aligned_target
+def _align_time_inner(
+    forecast_data: xr.Dataset,
+    target_data: xr.Dataset,
+) -> tuple[xr.Dataset, xr.Dataset]:
+    """Inner-join time dims, leaving location/lat/lon unaligned."""
+    exclude = {
+        name
+        for name in (
+            "latitude",
+            "longitude",
+            "lat",
+            "lon",
+            "location",
+            "station",
+            "sample",
+            "stacked",
+        )
+        if name in forecast_data.dims or name in target_data.dims
+    }
+    time_aligned_target, time_aligned_forecast = xr.align(
+        target_data,
+        forecast_data,
+        join="inner",
+        exclude=exclude,
+    )
+    return time_aligned_forecast, time_aligned_target
 
 
 def maybe_subset_variables(

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -842,6 +842,221 @@ def convert_day_yearofday_to_time(
     )
 
 
+_TIME_DIM_NAMES = frozenset({"time", "valid_time", "lead_time", "init_time"})
+_LAT_NAMES = ("latitude", "lat")
+_LON_NAMES = ("longitude", "lon")
+_POINT_DIM_NAMES = ("location", "station", "sample", "stacked")
+
+
+def _lat_lon_names(
+    obj: xr.Dataset | xr.DataArray,
+) -> tuple[str | None, str | None]:
+    """Return latitude and longitude coordinate names if present."""
+    names = list(obj.dims) + list(obj.coords)
+    lat = next((n for n in _LAT_NAMES if n in names), None)
+    lon = next((n for n in _LON_NAMES if n in names), None)
+    return lat, lon
+
+
+def infer_spatial_layout(
+    obj: xr.Dataset | xr.DataArray,
+) -> Literal["grid", "points"]:
+    """Classify a Dataset or DataArray as a spatial grid or point samples.
+
+    Points are paired (lat, lon) samples: a shared non-time dimension, or a
+    sparse lat x lon cube of occupied stations. Independent lat and lon
+    dimensions with dense data are a grid.
+    """
+    lat_name, lon_name = _lat_lon_names(obj)
+    if lat_name is None or lon_name is None:
+        return "grid"
+
+    arrays: list[xr.DataArray]
+    if isinstance(obj, xr.DataArray):
+        arrays = [obj]
+    else:
+        arrays = [obj[v] for v in obj.data_vars]
+
+    for da in arrays:
+        if (
+            isinstance(da.data, sparse.COO)
+            and lat_name in da.dims
+            and lon_name in da.dims
+        ):
+            return "points"
+
+    for dim in _POINT_DIM_NAMES:
+        if dim not in obj.dims:
+            continue
+        if dim in obj[lat_name].dims and dim in obj[lon_name].dims:
+            return "points"
+
+    lat_dims = set(obj[lat_name].dims) - _TIME_DIM_NAMES
+    lon_dims = set(obj[lon_name].dims) - _TIME_DIM_NAMES
+    if lat_dims and lat_dims == lon_dims and lat_name not in obj.dims:
+        return "points"
+
+    return "grid"
+
+
+def _point_dim_name(obj: xr.Dataset | xr.DataArray) -> str | None:
+    """Name of the sample dimension for point-like data, if any."""
+    for dim in _POINT_DIM_NAMES:
+        if dim in obj.dims:
+            return dim
+    lat_name, lon_name = _lat_lon_names(obj)
+    if lat_name is None:
+        return None
+    skip = _TIME_DIM_NAMES | {lat_name, lon_name}
+    spatial = set(obj[lat_name].dims) - skip
+    if len(spatial) == 1:
+        return str(next(iter(spatial)))
+    return None
+
+
+def point_frame_to_dataset(
+    df: pd.DataFrame,
+    *,
+    time_col: str = "valid_time",
+    lat_col: str = "latitude",
+    lon_col: str = "longitude",
+    location_dim: str = "location",
+) -> xr.Dataset:
+    """Convert point rows to (time, location) with lat/lon as coords.
+
+    Does not build a unique-lat x unique-lon Cartesian product.
+    """
+    frame = df.copy()
+    key_cols = [time_col, lat_col, lon_col]
+    frame = frame.drop_duplicates(subset=key_cols, keep="first")
+    stations = frame[[lat_col, lon_col]].drop_duplicates().reset_index(drop=True)
+    stations[location_dim] = np.arange(len(stations))
+    frame = frame.merge(stations, on=[lat_col, lon_col], how="left")
+    skip = {time_col, lat_col, lon_col, location_dim}
+    value_cols = [c for c in frame.columns if c not in skip]
+    indexed = frame.set_index([time_col, location_dim])[value_cols]
+    ds = xr.Dataset.from_dataframe(indexed)
+    stations = stations.set_index(location_dim)
+    return ds.assign_coords(
+        latitude=(location_dim, stations[lat_col].to_numpy()),
+        longitude=(location_dim, stations[lon_col].to_numpy()),
+    )
+
+
+def sparse_cube_to_location(
+    ds: xr.Dataset, location_dim: str = "location"
+) -> xr.Dataset:
+    """Collapse a sparse lat x lon cube onto occupied station pairs."""
+    lat_name, lon_name = _lat_lon_names(ds)
+    if lat_name is None or lon_name is None:
+        return ds
+    da = next(iter(ds.data_vars.values()))
+    pairs: np.ndarray | None = None
+    if isinstance(da.data, sparse.COO):
+        dims = list(da.dims)
+        lat_i = da.data.coords[dims.index(lat_name)]
+        lon_i = da.data.coords[dims.index(lon_name)]
+        pairs = np.unique(np.column_stack([lat_i, lon_i]), axis=0)
+        ds = ds.map(
+            lambda v: (
+                v.copy(data=v.data.todense()) if isinstance(v.data, sparse.COO) else v
+            )
+        )
+    if pairs is None:
+        stacked = ds.stack({location_dim: (lat_name, lon_name)})
+        keep = (
+            stacked[da.name]
+            .notnull()
+            .any(dim=[d for d in stacked[da.name].dims if d != location_dim])
+        )
+        return stacked.isel({location_dim: keep})
+
+    loc = xr.DataArray(np.arange(len(pairs)), dims=location_dim)
+    out = ds.isel(
+        {
+            lat_name: xr.DataArray(pairs[:, 0], dims=location_dim),
+            lon_name: xr.DataArray(pairs[:, 1], dims=location_dim),
+        }
+    )
+    return out.assign_coords({location_dim: loc})
+
+
+def as_point_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """Return point data with a location dim and lat/lon coords."""
+    if _point_dim_name(ds) is not None and infer_spatial_layout(ds) == "points":
+        lat_name, lon_name = _lat_lon_names(ds)
+        point_dim = _point_dim_name(ds)
+        if point_dim != "location" and point_dim is not None:
+            ds = ds.rename({point_dim: "location"})
+        if lat_name and lat_name != "latitude":
+            ds = ds.rename({lat_name: "latitude"})
+        if lon_name and lon_name != "longitude":
+            ds = ds.rename({lon_name: "longitude"})
+        return ds
+    if infer_spatial_layout(ds) == "points":
+        return sparse_cube_to_location(ds)
+    return ds
+
+
+def sample_field_at_points(
+    field: xr.Dataset,
+    latitude: xr.DataArray,
+    longitude: xr.DataArray,
+    method: str = "nearest",
+) -> xr.Dataset:
+    """Sample a gridded field at paired latitude/longitude coordinates."""
+    lat_name, lon_name = _lat_lon_names(field)
+    if lat_name is None or lon_name is None:
+        return field
+    interp_method: Literal["nearest", "linear"] = (
+        "nearest" if method == "nearest" else "linear"
+    )
+    lat_da = latitude
+    lon_da = longitude
+    if "location" not in lat_da.dims:
+        loc = np.arange(lat_da.size)
+        lat_da = xr.DataArray(
+            np.asarray(lat_da),
+            dims="location",
+            coords={"location": loc},
+        )
+        lon_da = xr.DataArray(
+            np.asarray(lon_da),
+            dims="location",
+            coords={"location": loc},
+        )
+    return field.interp(
+        {lat_name: lat_da, lon_name: lon_da},
+        method=interp_method,
+        kwargs={"fill_value": None},
+    )
+
+
+def _colocate_points(forecast_pts: xr.Dataset, target_pts: xr.Dataset) -> xr.Dataset:
+    """Map forecast stations onto target stations by nearest lat/lon."""
+    fc_dim = _point_dim_name(forecast_pts) or "location"
+    tg_dim = _point_dim_name(target_pts) or "location"
+    fc_lat = np.asarray(forecast_pts["latitude"])
+    fc_lon = np.asarray(forecast_pts["longitude"])
+    tg_lat = np.asarray(target_pts["latitude"])
+    tg_lon = np.asarray(target_pts["longitude"])
+    dist = (fc_lat[:, None] - tg_lat[None, :]) ** 2 + (
+        fc_lon[:, None] - tg_lon[None, :]
+    ) ** 2
+    idx = dist.argmin(axis=0)
+    mapped = forecast_pts.isel({fc_dim: idx})
+    mapped = mapped.assign_coords(
+        {
+            tg_dim: target_pts[tg_dim].values,
+            "latitude": target_pts["latitude"],
+            "longitude": target_pts["longitude"],
+        }
+    )
+    if fc_dim != tg_dim:
+        mapped = mapped.rename({fc_dim: tg_dim})
+    return mapped
+
+
 def interp_climatology_to_target(
     target: xr.DataArray, climatology: xr.DataArray
 ) -> xr.DataArray:
@@ -856,6 +1071,14 @@ def interp_climatology_to_target(
         climatology is interpolated to the target coordinates. If the target is not
         sparse, the climatology is interpolated to the target coordinates.
     """
+    point_dim = _point_dim_name(target)
+    if point_dim is not None and "latitude" in target.coords:
+        return climatology.interp(
+            latitude=target["latitude"],
+            longitude=target["longitude"],
+            method="nearest",
+            kwargs={"fill_value": None},
+        )
     # If the target is sparse or has less than 3 dimensions, interpolate the
     # climatology using stacked dim
     if isinstance(target.data, sparse.COO) or target.ndim < 3:
@@ -917,7 +1140,23 @@ def reduce_dataarray(
     Returns:
         The reduced xarray dataarray.
     """
-    if isinstance(da.data, sparse.COO):
+    reduce_dims = list(reduce_dims)
+    present = [d for d in reduce_dims if d in da.dims]
+    if not present:
+        alt = _point_dim_name(da)
+        if alt is not None:
+            reduce_dims = [alt]
+        elif isinstance(da.data, sparse.COO):
+            da = stack_dataarray_from_dims(da, reduce_dims)
+            reduce_dims = ["stacked"]
+    else:
+        reduce_dims = present
+
+    if (
+        isinstance(da.data, sparse.COO)
+        and reduce_dims != ["stacked"]
+        and all(d in da.dims for d in reduce_dims)
+    ):
         da = stack_dataarray_from_dims(da, reduce_dims)
         reduce_dims = ["stacked"]
 

--- a/src/extremeweatherbench/utils.py
+++ b/src/extremeweatherbench/utils.py
@@ -863,9 +863,46 @@ def infer_spatial_layout(
 ) -> Literal["grid", "points"]:
     """Classify a Dataset or DataArray as a spatial grid or point samples.
 
-    Points are paired (lat, lon) samples: a shared non-time dimension, or a
-    sparse lat x lon cube of occupied stations. Independent lat and lon
-    dimensions with dense data are a grid.
+    Points are paired (lat, lon) samples: a shared non-time dimension such
+    as ``location``, or a sparse lat × lon cube of occupied stations.
+    Independent latitude and longitude dimensions with dense data are a
+    grid.
+
+    Args:
+        obj: Dataset or DataArray to classify.
+
+    Returns:
+        ``"points"`` if lat/lon are paired samples, otherwise ``"grid"``.
+        Objects with no lat/lon coordinates are treated as ``"grid"``.
+
+    Examples:
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> import xarray as xr
+        >>> from extremeweatherbench import utils
+        >>> times = pd.date_range("2021-01-01", periods=2, freq="6h")
+        >>> grid = xr.Dataset(
+        ...     {"t": (["valid_time", "latitude", "longitude"], np.zeros((2, 3, 4)))},
+        ...     coords={
+        ...         "valid_time": times,
+        ...         "latitude": [10.0, 11.0, 12.0],
+        ...         "longitude": [100.0, 101.0, 102.0, 103.0],
+        ...     },
+        ... )
+        >>> utils.infer_spatial_layout(grid)
+        'grid'
+        >>> pts = utils.point_frame_to_dataset(
+        ...     pd.DataFrame(
+        ...         {
+        ...             "valid_time": [times[0], times[0]],
+        ...             "latitude": [10.0, 12.0],
+        ...             "longitude": [100.0, 103.0],
+        ...             "t": [273.0, 275.0],
+        ...         }
+        ...     )
+        ... )
+        >>> utils.infer_spatial_layout(pts)
+        'points'
     """
     lat_name, lon_name = _lat_lon_names(obj)
     if lat_name is None or lon_name is None:
@@ -922,9 +959,41 @@ def point_frame_to_dataset(
     lon_col: str = "longitude",
     location_dim: str = "location",
 ) -> xr.Dataset:
-    """Convert point rows to (time, location) with lat/lon as coords.
+    """Convert station rows to (time, location) with lat/lon as coords.
 
-    Does not build a unique-lat x unique-lon Cartesian product.
+    Each unique (latitude, longitude) pair becomes one location. This does
+    not build a unique-lat × unique-lon Cartesian product, which would
+    fill empty grid crossings and can exhaust memory.
+
+    Args:
+        df: Point observations with time, latitude, longitude, and value
+            columns.
+        time_col: Name of the valid-time column.
+        lat_col: Name of the latitude column.
+        lon_col: Name of the longitude column.
+        location_dim: Name of the sample dimension to create.
+
+    Returns:
+        Dataset with dimensions ``(time_col, location_dim)``. Latitude
+        and longitude are non-dimension coordinates on ``location_dim``.
+        Duplicate (time, lat, lon) rows keep the first value.
+
+    Examples:
+        >>> import pandas as pd
+        >>> from extremeweatherbench import utils
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "valid_time": ["2021-02-01", "2021-02-01"],
+        ...         "latitude": [10.0, 30.0],
+        ...         "longitude": [20.0, 40.0],
+        ...         "surface_air_temperature": [273.1, 268.4],
+        ...     }
+        ... )
+        >>> ds = utils.point_frame_to_dataset(df)
+        >>> list(ds.dims)
+        ['valid_time', 'location']
+        >>> ds.sizes["location"]
+        2
     """
     frame = df.copy()
     key_cols = [time_col, lat_col, lon_col]
@@ -946,7 +1015,23 @@ def point_frame_to_dataset(
 def sparse_cube_to_location(
     ds: xr.Dataset, location_dim: str = "location"
 ) -> xr.Dataset:
-    """Collapse a sparse lat x lon cube onto occupied station pairs."""
+    """Collapse a sparse lat × lon cube onto occupied station pairs.
+
+    Use this when point data was stored as a unique-lat × unique-lon
+    product with values only at real stations. The result has a sample
+    dimension instead of separate latitude and longitude dimensions.
+
+    Args:
+        ds: Dataset with latitude and longitude dimensions. Sparse COO
+            variables are densified after occupied pairs are collected.
+        location_dim: Name of the sample dimension to create. Defaults
+            to ``"location"``.
+
+    Returns:
+        Dataset indexed by occupied (lat, lon) pairs along
+        ``location_dim``, with latitude and longitude as coordinates.
+        If lat/lon names are missing, ``ds`` is returned unchanged.
+    """
     lat_name, lon_name = _lat_lon_names(ds)
     if lat_name is None or lon_name is None:
         return ds
@@ -982,7 +1067,19 @@ def sparse_cube_to_location(
 
 
 def as_point_dataset(ds: xr.Dataset) -> xr.Dataset:
-    """Return point data with a location dim and lat/lon coords."""
+    """Return point data with a ``location`` dim and lat/lon coords.
+
+    Accepts already-point Datasets (``location``, ``station``,
+    ``sample``, or ``stacked``) or a sparse lat × lon cube of occupied
+    stations. Grid Datasets are returned unchanged.
+
+    Args:
+        ds: Point or gridded Dataset.
+
+    Returns:
+        Point Dataset with a ``location`` dimension and ``latitude`` /
+        ``longitude`` coordinates, or ``ds`` if it is a spatial grid.
+    """
     if _point_dim_name(ds) is not None and infer_spatial_layout(ds) == "points":
         lat_name, lon_name = _lat_lon_names(ds)
         point_dim = _point_dim_name(ds)
@@ -1004,7 +1101,43 @@ def sample_field_at_points(
     longitude: xr.DataArray,
     method: str = "nearest",
 ) -> xr.Dataset:
-    """Sample a gridded field at paired latitude/longitude coordinates."""
+    """Sample a gridded field at paired latitude/longitude coordinates.
+
+    Interpolating onto 1D lat and lon *dimension* coords builds a full
+    lat × lon mesh. This instead evaluates the field at each (lat, lon)
+    pair, so the output has a ``location`` dimension.
+
+    Args:
+        field: Gridded Dataset with latitude and longitude dimensions.
+        latitude: Sample latitudes. Should share a ``location`` dim with
+            ``longitude`` when already a DataArray.
+        longitude: Sample longitudes paired with ``latitude``.
+        method: Interpolation method passed to ``Dataset.interp``.
+            ``"nearest"`` or ``"linear"``. Defaults to ``"nearest"``.
+
+    Returns:
+        ``field`` interpolated at the given pairs, with a ``location``
+        dimension. If ``field`` has no lat/lon coordinates, it is
+        returned unchanged.
+
+    Examples:
+        >>> import numpy as np
+        >>> import xarray as xr
+        >>> from extremeweatherbench import utils
+        >>> t2m = np.arange(6.0).reshape(2, 3)
+        >>> forecast = xr.Dataset(
+        ...     {"t2m": (("latitude", "longitude"), t2m)},
+        ...     coords={
+        ...         "latitude": [10.0, 20.0],
+        ...         "longitude": [1.0, 2.0, 3.0],
+        ...     },
+        ... )
+        >>> lat = xr.DataArray([10.0, 20.0], dims="location")
+        >>> lon = xr.DataArray([1.0, 3.0], dims="location")
+        >>> sampled = utils.sample_field_at_points(forecast, lat, lon)
+        >>> list(sampled.dims)
+        ['location']
+    """
     lat_name, lon_name = _lat_lon_names(field)
     if lat_name is None or lon_name is None:
         return field

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -11,6 +11,7 @@ import warnings
 from typing import ClassVar
 from unittest import mock
 
+import joblib
 import numpy as np
 import pandas as pd
 import pytest
@@ -1202,7 +1203,7 @@ class TestRunParallel:
         mock_manager.assert_called_once()
         _, renderer_kwargs = mock_renderer_class.call_args
         n_slots = renderer_kwargs["n_slots"]
-        assert 0 < n_slots <= 64
+        assert n_slots == joblib.effective_n_jobs(-1)
 
     @mock.patch("extremeweatherbench.evaluate.multiprocessing.Manager")
     @mock.patch("extremeweatherbench.evaluate.progress_module.LogQueueListener")

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1253,6 +1253,218 @@ class TestERA5:
         assert len(aligned_forecast.valid_time) > 0
 
 
+def _gridded_forecast(times, lats, lons, *, leads=None, value=1.0) -> xr.Dataset:
+    """Build a dense gridded forecast on (valid_time, lat, lon)."""
+    if leads is None:
+        data = np.full((len(times), len(lats), len(lons)), value)
+        dims = ["valid_time", "latitude", "longitude"]
+        coords = {"valid_time": times, "latitude": lats, "longitude": lons}
+    else:
+        data = np.full((len(leads), len(times), len(lats), len(lons)), value)
+        dims = ["lead_time", "valid_time", "latitude", "longitude"]
+        coords = {
+            "lead_time": leads,
+            "valid_time": times,
+            "latitude": lats,
+            "longitude": lons,
+        }
+    return xr.Dataset(
+        {"surface_air_temperature": (dims, data)},
+        coords=coords,
+    )
+
+
+def _point_dataset_location_dim(times, lats, lons, values) -> xr.Dataset:
+    """Point obs as (valid_time, location) with lat/lon coords."""
+    n_loc = len(lats)
+    data = np.broadcast_to(np.asarray(values), (len(times), n_loc)).copy()
+    return xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["valid_time", "location"],
+                data,
+            )
+        },
+        coords={
+            "valid_time": times,
+            "location": np.arange(n_loc),
+            "latitude": ("location", np.asarray(lats)),
+            "longitude": ("location", np.asarray(lons)),
+        },
+    )
+
+
+def _sparse_station_cube(times, lats, lons, values) -> xr.Dataset:
+    """GHCN-style sparse cube: unique lat x lon, one station per pair."""
+    n_t, n_s = len(times), len(lats)
+    coords = np.array(
+        [
+            np.repeat(np.arange(n_t), n_s),
+            np.tile(np.arange(n_s), n_t),
+            np.tile(np.arange(n_s), n_t),
+        ]
+    )
+    data = np.broadcast_to(np.asarray(values), (n_t * n_s,)).copy()
+    sparse_arr = sparse.COO(coords, data, shape=(n_t, n_s, n_s))
+    return xr.Dataset(
+        {
+            "surface_air_temperature": (
+                ["valid_time", "latitude", "longitude"],
+                sparse_arr,
+            )
+        },
+        coords={
+            "valid_time": times,
+            "latitude": np.asarray(lats),
+            "longitude": np.asarray(lons),
+        },
+    )
+
+
+class TestAgnosticSpatialAlign:
+    """Grid/point alignment must sample pairs, not a lat x lon mesh."""
+
+    def test_infer_grid_layout(self):
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        ds = _gridded_forecast(times, [10.0, 20.0], [100.0, 110.0])
+        assert utils.infer_spatial_layout(ds) == "grid"
+
+    def test_infer_location_dim_as_points(self):
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        ds = _point_dataset_location_dim(
+            times, [10.0, 11.0, 12.0], [100.0, 101.0, 102.0], 273.0
+        )
+        assert utils.infer_spatial_layout(ds) == "points"
+
+    def test_infer_sparse_cube_as_points(self):
+        times = pd.date_range("2021-01-01", periods=2, freq="6h")
+        ds = _sparse_station_cube(
+            times, [10.0, 20.0, 30.0], [100.0, 110.0, 120.0], 273.0
+        )
+        assert utils.infer_spatial_layout(ds) == "points"
+
+    def test_grid_to_location_points_is_o_stations_not_mesh(self):
+        """Sampling a field at stations must not allocate n_lat * n_lon."""
+        times = pd.date_range("2021-01-01", periods=4, freq="6h")
+        leads = pd.to_timedelta([0, 6, 12, 18, 24], unit="h")
+        grid_lat = np.linspace(10, 20, 8)
+        grid_lon = np.linspace(100, 110, 8)
+        forecast = _gridded_forecast(
+            times, grid_lat, grid_lon, leads=leads, value=280.0
+        )
+        n_stations = 40
+        st_lats = np.linspace(10.5, 19.5, n_stations)
+        st_lons = np.linspace(100.5, 109.5, n_stations)
+        target = _point_dataset_location_dim(times, st_lats, st_lons, 273.0)
+        aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        assert "location" in aligned_fc.dims
+        assert aligned_fc.sizes["location"] == n_stations
+        fc_spatial = aligned_fc.surface_air_temperature.isel(lead_time=0, valid_time=0)
+        assert fc_spatial.size == n_stations
+        assert "latitude" not in aligned_fc.dims
+        assert "longitude" not in aligned_fc.dims
+        np.testing.assert_allclose(
+            aligned_fc.latitude.values, aligned_tg.latitude.values
+        )
+        np.testing.assert_allclose(
+            aligned_fc.longitude.values, aligned_tg.longitude.values
+        )
+
+    def test_grid_to_sparse_cube_does_not_fill_lat_lon_product(self):
+        """A sparse station cube must align at occupied pairs only."""
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        n_stations = 25
+        st_lats = np.linspace(10.0, 20.0, n_stations)
+        st_lons = np.linspace(100.0, 110.0, n_stations)
+        forecast = _gridded_forecast(
+            times,
+            np.linspace(9.0, 21.0, 10),
+            np.linspace(99.0, 111.0, 10),
+            value=280.0,
+        )
+        target = _sparse_station_cube(times, st_lats, st_lons, 273.0)
+        aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        fc_slice = aligned_fc.surface_air_temperature.isel(valid_time=0)
+        # Occupied stations, not the n_stations x n_stations mesh.
+        assert fc_slice.size == n_stations
+        assert aligned_tg.surface_air_temperature.isel(valid_time=0).size == n_stations
+
+    def test_point_forecast_samples_gridded_target(self):
+        """Point forecasts sample the target field at forecast stations."""
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        st_lats = np.array([10.0, 15.0, 20.0])
+        st_lons = np.array([100.0, 105.0, 110.0])
+        forecast = _point_dataset_location_dim(times, st_lats, st_lons, 280.0)
+        target = _gridded_forecast(
+            times,
+            np.linspace(10.0, 20.0, 5),
+            np.linspace(100.0, 110.0, 5),
+            value=270.0,
+        )
+        aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        assert "location" in aligned_tg.dims
+        assert aligned_tg.sizes["location"] == 3
+        assert "latitude" not in aligned_tg.dims
+        np.testing.assert_allclose(
+            aligned_fc.latitude.values, aligned_tg.latitude.values
+        )
+
+    def test_grid_to_grid_still_remaps_forecast_to_target(self):
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        target = _gridded_forecast(
+            times, np.linspace(10, 20, 5), np.linspace(100, 110, 6)
+        )
+        forecast = _gridded_forecast(
+            times, np.linspace(10, 20, 4), np.linspace(100, 110, 5)
+        )
+        aligned_fc, aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        np.testing.assert_array_equal(
+            aligned_fc.latitude.values, aligned_tg.latitude.values
+        )
+        np.testing.assert_array_equal(
+            aligned_fc.longitude.values, aligned_tg.longitude.values
+        )
+        assert "latitude" in aligned_fc.dims
+        assert "longitude" in aligned_fc.dims
+
+    def test_grid_align_keeps_size_one_lead_time(self):
+        """A single lead must stay a dimension so metrics can preserve it."""
+        times = pd.date_range("2021-01-01", periods=3, freq="6h")
+        leads = pd.to_timedelta([6], unit="h")
+        forecast = _gridded_forecast(
+            times,
+            np.linspace(10, 20, 4),
+            np.linspace(100, 110, 5),
+            leads=leads,
+        )
+        target = _gridded_forecast(
+            times, np.linspace(10, 20, 5), np.linspace(100, 110, 6)
+        )
+        aligned_fc, _aligned_tg = inputs.align_forecast_to_target(forecast, target)
+        assert "lead_time" in aligned_fc.dims
+        assert aligned_fc.sizes["lead_time"] == 1
+
+    def test_point_frame_to_dataset_is_not_a_lat_lon_product(self):
+        times = pd.date_range("2021-01-01", periods=2, freq="6h")
+        rows = []
+        for t in times:
+            for lat, lon in [(10.0, 100.0), (11.0, 101.0), (12.0, 102.0)]:
+                rows.append(
+                    {
+                        "valid_time": t,
+                        "latitude": lat,
+                        "longitude": lon,
+                        "surface_air_temperature": 273.0,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        ds = utils.point_frame_to_dataset(df)
+        assert "location" in ds.dims
+        assert "latitude" not in ds.dims
+        assert ds.sizes["location"] == 3
+        assert ds.surface_air_temperature.size == 2 * 3
+
+
 class TestGHCN:
     """Test the GHCN target class."""
 
@@ -1361,8 +1573,9 @@ class TestGHCN:
 
         assert isinstance(result, xr.Dataset)
         assert "valid_time" in result.dims
-        assert "latitude" in result.dims
-        assert "longitude" in result.dims
+        assert "location" in result.dims
+        assert "latitude" in result.coords
+        assert "longitude" in result.coords
 
     def test_ghcn_custom_convert_to_dataset_invalid_input(self):
         """Test GHCN custom conversion with invalid input."""
@@ -1394,8 +1607,9 @@ class TestGHCN:
 
         assert isinstance(result, xr.Dataset)
         assert "valid_time" in result.dims
-        assert "latitude" in result.dims
-        assert "longitude" in result.dims
+        assert "location" in result.dims
+        assert "latitude" in result.coords
+        assert "longitude" in result.coords
         assert "surface_air_temperature" in result.data_vars
 
         # Should have no NaN values if no duplicates were dropped


### PR DESCRIPTION
## Summary
- Station targets (GHCN, LSR) now use a `location` dimension instead of a unique-lat × unique-lon cube.
- Alignment samples the forecast at those stations. That stops freeze cases from running out of memory, and spatial-mean metrics average real stations only.
- Grid-to-grid alignment is unchanged. The BYOT recipe shows `point_frame_to_dataset` so the old cube pattern is not copied back in.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` on changed Python files
- [x] `uv run pytest` (1297 passed)
- [x] CI on 3.12 / 3.13 / 3.14

Made with [Cursor](https://cursor.com)