### PR TITLE
Centralize physical constants

### DIFF
--- a/src/extremeweatherbench/__init__.py
+++ b/src/extremeweatherbench/__init__.py
@@ -20,6 +20,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
     submodules=[
         "calc",
         "cases",
+        "constants",
         "defaults",
         "derived",
         "evaluate",

--- a/src/extremeweatherbench/_cape.py
+++ b/src/extremeweatherbench/_cape.py
@@ -19,58 +19,32 @@ import numpy as np
 import numpy.typing as npt
 from numba import njit, prange
 
-# ============================================================================
-# Physical Constants
-# ============================================================================
-
-# Thermodynamic constants
-KAPPA = 2.0 / 7.0  # Poisson constant R/Cp for dry air (dimensionless)
-GRAVITY = 9.80665  # Gravitational acceleration (m/s^2)
-Rd = 287.058  # Gas constant for dry air (J/kg/K)
-Cp = 1005.7  # Specific heat at constant pressure for dry air (J/kg/K)
-
-# Water vapor constants.
-# EPSILON is the single definition of this ratio for the whole package. It
-# lives here because this module imports nothing else from the package, so
-# any module can take it without risking an import cycle, and because numba
-# freezes it into the jitted kernels below as a plain module global.
-EPSILON = 0.6219569100577033  # Ratio of molecular weights (H2O/dry air)
-VIRTUAL_TEMP_COEFF = (
-    0.61  # Coefficient for virtual temperature calculation (dimensionless)
+from extremeweatherbench.constants import (
+    A_BOLTON,
+    B_BOLTON,
+    E0_BOLTON,
+    EPSILON,
+    GRAVITY,
+    KAPPA,
+    KELVIN_TO_CELSIUS,
+    LCL_DENOM,
+    LCL_OFFSET,
+    L_V_0,
+    L_V_TEMP_COEFF,
+    MAX_VAPOR_PRESSURE_FRACTION,
+    MIN_TV,
+    MOIST_ASCENT_STEPS,
+    MOIST_ASCENT_SUBSTEPS,
+    P_REF,
+    VIRTUAL_TEMP_COEFF,
+    Cp,
+    Rd,
 )
 
-# Latent heat constants
-L_V_0 = 2.501e6  # Latent heat of vaporization at 0°C (J/kg)
-L_V_TEMP_COEFF = 2370.0  # Temperature dependence of latent heat (J/kg/K)
-
-# Reference values
-P_REF = 1000.0  # Reference pressure for potential temperature (hPa)
-KELVIN_TO_CELSIUS = 273.15  # Conversion factor from Kelvin to Celsius (K)
-
-# Bolton (1980) formula constants for saturation vapor pressure
-# e_s = E0 * exp(A * T_c / (T_c + B))
-# where T_c is temperature in Celsius
-E0_BOLTON = 6.112  # Reference vapor pressure (hPa)
-A_BOLTON = 17.67  # Empirical constant (dimensionless)
-B_BOLTON = 243.5  # Empirical constant (°C)
-
-# Bolton (1980) LCL formula constants
-LCL_OFFSET = 56.0  # Empirical constant for LCL calculation (K)
-LCL_DENOM = 800.0  # Empirical constant for LCL calculation (K)
-
-# Numerical integration parameters
-MOIST_ASCENT_STEPS = 50  # Number of steps for moist adiabat integration
-# Steps used per level gap when marching the adiabat up a profile. Marching
-# never re-integrates the part of the column it has already covered, so fewer
-# steps per gap reach a smaller truncation error than restarting from the LCL
-# with MOIST_ASCENT_STEPS does. Measured against a converged integration of
-# the same ODE over 100 ERA5 profiles, 16 substeps lands at 31 J/kg mean
-# absolute error where the restarting scheme sits at 53 J/kg; 8 substeps was
-# worse than restarting, so this is the floor rather than a tuning knob.
-MOIST_ASCENT_SUBSTEPS = 16
-
-# Data processing parameters
-RADIUS_DEG = 2.0  # Default radius for sample data extraction (degrees)
+# Re-export package constants as this module's globals. Numba nopython
+# kernels bind those names at compile time; they cannot follow
+# ``constants.EPSILON`` attribute lookups. constants.py is a leaf so
+# this import cannot cycle.
 
 
 # ============================================================================
@@ -109,9 +83,8 @@ def mixing_ratio_inline(pressure: float, vapor_pressure: float) -> float:
     Returns:
         The mixing ratio in kg/kg.
     """
-    # Prevent supersaturation: cap vapor pressure at 0.9999 * pressure
-    # This handles both real supersaturation in data and numerical precision issues
-    max_vapor_pressure = 0.9999 * pressure
+    # Cap vapor pressure so the mixing-ratio denominator stays positive.
+    max_vapor_pressure = MAX_VAPOR_PRESSURE_FRACTION * pressure
     vapor_pressure = min(vapor_pressure, max_vapor_pressure)
     return EPSILON * vapor_pressure / (pressure - vapor_pressure)
 
@@ -175,10 +148,6 @@ def compute_buoyancy_energy_inline(
     Returns:
         The buoyancy energy in J/kg.
     """
-    # Minimum reasonable virtual temperature (in K) to avoid division issues
-    # ~100 K is well below any realistic atmospheric temperature
-    MIN_TV = 100.0
-
     if env_tv_avg < MIN_TV or not np.isfinite(env_tv_avg):
         return 0.0
 
@@ -204,7 +173,9 @@ def lcl(pressure: float, temperature: float, dewpoint: float) -> tuple[float, fl
     """
     # LCL temperature (Bolton 1980, eq. 15)
     t_lcl = (
-        1.0 / (1.0 / (dewpoint - 56.0) + np.log(temperature / dewpoint) / 800.0) + 56.0
+        1.0
+        / (1.0 / (dewpoint - LCL_OFFSET) + np.log(temperature / dewpoint) / LCL_DENOM)
+        + LCL_OFFSET
     )
 
     # LCL pressure (Bolton 1980, eq. 22)

--- a/src/extremeweatherbench/calc.py
+++ b/src/extremeweatherbench/calc.py
@@ -10,12 +10,21 @@ from numba import float64, guvectorize, njit
 from scipy import ndimage
 
 from extremeweatherbench import utils
-from extremeweatherbench._cape import EPSILON
+from extremeweatherbench.constants import (
+    A_BOLTON,
+    B_BOLTON,
+    E0_BOLTON,
+    EARTH_RADIUS_KM,
+    EPSILON,
+    GRAVITY,
+    KELVIN_TO_CELSIUS,
+    NS_PER_HOUR,
+)
 
 epsilon: float = EPSILON  # Ratio of molecular weights (H2O/dry air)
-sat_press_0c: float = 6.112  # Saturation vapor pressure at 0°C (hPa)
-g0: float = 9.80665  # Standard gravity (m/s^2)
-_ns_per_hour = 3_600_000_000_000
+sat_press_0c: float = E0_BOLTON  # Saturation vapor pressure at 0°C (hPa)
+g0: float = GRAVITY  # Standard gravity (m/s^2)
+_ns_per_hour = NS_PER_HOUR
 logger = logging.getLogger("extremeweatherbench.calc")
 logger.setLevel(logging.INFO)
 
@@ -49,7 +58,7 @@ def mixing_ratio(
     r"""Calculate the mixing ratio of water vapor in air.
 
     Uses the formula: $w = (\epsilon * e) / (p - e)$ where $\epsilon \approx
-    0.622$; the code uses the unrounded ratio in `_cape.EPSILON`.
+    0.622$; the code uses the unrounded ratio in ``constants.EPSILON``.
 
     Args:
         partial_pressure: Water vapor partial pressure in hPa.
@@ -92,7 +101,7 @@ def saturation_vapor_pressure(
     """
     # Suppress overflow warnings for this calculation
     with np.errstate(over="ignore", invalid="ignore"):
-        return sat_press_0c * np.exp(17.67 * temperature / (temperature + 243.5))
+        return sat_press_0c * np.exp(A_BOLTON * temperature / (temperature + B_BOLTON))
 
 
 def saturation_mixing_ratio(
@@ -139,7 +148,7 @@ def haversine_distance(
     a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
     c = 2 * np.arcsin(np.sqrt(a))
     if units == "km" or units == "kilometers":
-        return 6371 * c
+        return EARTH_RADIUS_KM * c
     elif units == "deg" or units == "degrees":
         return np.degrees(c)  # Convert back to degrees
     else:
@@ -355,7 +364,9 @@ def specific_humidity_from_relative_humidity(
         A DataArray of specific humidity in kg/kg.
     """
     # Compute saturation mixing ratio; air temperature must be in Kelvin
-    sat_mixing_ratio = saturation_mixing_ratio(levels, air_temperature - 273.15)
+    sat_mixing_ratio = saturation_mixing_ratio(
+        levels, air_temperature - KELVIN_TO_CELSIUS
+    )
 
     # Calculate specific humidity using saturation mixing ratio, epsilon,
     # and relative humidity
@@ -416,8 +427,8 @@ def dewpoint_from_specific_humidity(pressure: float, specific_humidity: float) -
     # remaining physical constraints.
     w = specific_humidity / (1.0 - specific_humidity)
     e = pressure * w / (w + epsilon)
-    T_d = 243.5 * np.log(e / sat_press_0c) / (17.67 - np.log(e / sat_press_0c))
-    return T_d + 273.15
+    T_d = B_BOLTON * np.log(e / sat_press_0c) / (A_BOLTON - np.log(e / sat_press_0c))
+    return T_d + KELVIN_TO_CELSIUS
 
 
 def find_landfalls(
@@ -982,7 +993,7 @@ def _deduplicate_landfalls(
         dlat = lat2 - lat1
         dlon = lon2 - lon1
         a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
-        dist_km = 2 * 6371.0 * np.arcsin(np.sqrt(a))
+        dist_km = 2 * EARTH_RADIUS_KM * np.arcsin(np.sqrt(a))
         if dist_km < min_distance_km:
             keep[i] = False
         else:

--- a/src/extremeweatherbench/constants.py
+++ b/src/extremeweatherbench/constants.py
@@ -1,0 +1,61 @@
+"""Numeric constants for ExtremeWeatherBench.
+
+This module is a leaf: it must not import other package modules so that
+Numba kernels in ``_cape`` can bind these names as local globals via
+``from extremeweatherbench.constants import ...``.
+"""
+
+# Thermodynamic constants
+KAPPA = 2.0 / 7.0  # Poisson constant R/Cp for dry air (dimensionless)
+GRAVITY = 9.80665  # Gravitational acceleration (m/s^2)
+# Rounded g historically used to convert geopotential thickness to meters.
+GRAVITY_ROUNDED = 9.81
+Rd = 287.058  # Gas constant for dry air (J/kg/K)
+Cp = 1005.7  # Specific heat at constant pressure for dry air (J/kg/K)
+
+# Water vapor constants.
+# EPSILON is the unrounded Mw(H2O)/Mw(dry air) ratio for the package.
+EPSILON = 0.6219569100577033
+VIRTUAL_TEMP_COEFF = 0.61  # Virtual temperature mixing-ratio coefficient
+
+# Latent heat constants
+L_V_0 = 2.501e6  # Latent heat of vaporization at 0°C (J/kg)
+L_V_TEMP_COEFF = 2370.0  # Temperature dependence of latent heat (J/kg/K)
+
+# Reference values
+P_REF = 1000.0  # Reference pressure for potential temperature (hPa)
+KELVIN_TO_CELSIUS = 273.15  # Kelvin minus Celsius offset (K)
+EARTH_RADIUS_KM = 6371.0  # Mean Earth radius used in haversine (km)
+
+# Bolton (1980) formula constants for saturation vapor pressure
+# e_s = E0 * exp(A * T_c / (T_c + B)) with T_c in Celsius
+E0_BOLTON = 6.112  # Reference vapor pressure (hPa)
+A_BOLTON = 17.67  # Empirical constant (dimensionless)
+B_BOLTON = 243.5  # Empirical constant (°C)
+
+# Bolton (1980) LCL formula constants
+LCL_OFFSET = 56.0  # Empirical constant for LCL calculation (K)
+LCL_DENOM = 800.0  # Empirical constant for LCL calculation (K)
+
+# Numerical integration parameters
+MOIST_ASCENT_STEPS = 50  # Steps for moist adiabat integration from the LCL
+# Steps per level gap when marching the adiabat up a profile. Marching
+# never re-integrates the column already covered, so fewer steps per gap
+# reach a smaller truncation error than restarting from the LCL with
+# MOIST_ASCENT_STEPS. Against a converged integration of the same ODE
+# over 100 ERA5 profiles, 16 substeps is 31 J/kg MAE vs 53 J/kg for
+# restarting; 8 substeps was worse than restarting.
+MOIST_ASCENT_SUBSTEPS = 16
+
+# Mixing-ratio guard: cap vapor pressure at this fraction of total pressure.
+MAX_VAPOR_PRESSURE_FRACTION = 0.9999
+
+# Minimum environment virtual temperature (K) to avoid divide-by-zero
+# in buoyancy; well below any realistic atmospheric temperature.
+MIN_TV = 100.0
+
+# Default radius for sample data extraction (degrees)
+RADIUS_DEG = 2.0
+
+# Nanoseconds in one hour, for datetime64[ns] gaps.
+NS_PER_HOUR = 3_600_000_000_000

--- a/src/extremeweatherbench/events/severe_convection.py
+++ b/src/extremeweatherbench/events/severe_convection.py
@@ -26,13 +26,13 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from extremeweatherbench._cape import EPSILON
 from extremeweatherbench._cape import (
     _compute_batch_parallel as compute_ml_cape_cin_parallel,
 )
 from extremeweatherbench._cape import (
     _compute_batch_serial as compute_ml_cape_cin_serial,
 )
+from extremeweatherbench.constants import EPSILON
 
 # Atmospheric Physics Constants
 # All constants follow standard atmospheric physics values from CODATA and WMO

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,27 @@
+"""Tests for shared numeric constants."""
+
+from extremeweatherbench import _cape, calc, constants
+
+
+def test_cape_reexports_match_constants():
+    """Numba kernels bind the same floats defined in constants.py."""
+    assert _cape.EPSILON is constants.EPSILON
+    assert _cape.GRAVITY is constants.GRAVITY
+    assert _cape.KAPPA is constants.KAPPA
+    assert _cape.KELVIN_TO_CELSIUS is constants.KELVIN_TO_CELSIUS
+    assert _cape.Rd is constants.Rd
+    assert _cape.E0_BOLTON is constants.E0_BOLTON
+    assert _cape.MIN_TV is constants.MIN_TV
+
+
+def test_calc_aliases_match_constants():
+    """Public calc aliases stay equal to the canonical constants."""
+    assert calc.epsilon is constants.EPSILON
+    assert calc.g0 is constants.GRAVITY
+    assert calc.sat_press_0c is constants.E0_BOLTON
+    assert calc._ns_per_hour is constants.NS_PER_HOUR
+
+
+def test_epsilon_value():
+    """EPSILON is the unrounded Mw(H2O)/Mw(dry air) ratio."""
+    assert constants.EPSILON == 0.6219569100577033


### PR DESCRIPTION
## Summary
- Move duplicated CAPE/calc scalars into `constants.py` so there is one definition.
- `_cape` imports those names as module globals so Numba nopython kernels can still bind them at compile time.
- `calc.epsilon` / `g0` / `sat_press_0c` are the same objects as the canonical constants.
- Centralize all other constants into `constants.py` and unify definitions based on it elsewhere in the library (e.g. `calc.py`)
## Test plan
- [x] `pytest tests/test_constants.py tests/test_cape.py tests/test_calc.py tests/test_severe_convection.py`
- [x] CI on 3.12 / 3.13 / 3.14


Made with [Cursor](https://cursor.com) and checked myself + text tweaked to better clarify PR