### PR TITLE
Map tabular preprocess to EWB names after variable mapping

### DIFF
--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1253,8 +1253,7 @@ def run_pipeline(
         data = input_data._open_data_from_source()
     is_gridded = isinstance(data, (xr.Dataset, xr.DataArray))
     preprocess_before_map = (
-        not is_gridded
-        and input_data.preprocess_before_variable_mapping is True
+        not is_gridded and input_data.preprocess_before_variable_mapping is True
     )
     if preprocess_before_map:
         data = input_data.preprocess(data)

--- a/src/extremeweatherbench/evaluate.py
+++ b/src/extremeweatherbench/evaluate.py
@@ -1243,17 +1243,24 @@ def run_pipeline(
     Returns:
         The processed input data as an xarray dataset.
     """
-    # Gridded: map names, subset case, preprocess, then subset variables so
-    # preprocess can add fields such as geopotential thickness. Tabular
-    # sources such as IBTrACS need original column names inside preprocess.
+    # Map to EWB names before preprocess. IBTrACS (and similar) set
+    # preprocess_before_variable_mapping to merge/coerce source columns first.
+    # Gridded preprocess still runs after case subset so it can add fields
+    # such as geopotential thickness before variable subset.
     if isinstance(input_data, inputs.LSR):
         data = input_data._open_data_from_source(case_metadata=case_metadata)
     else:
         data = input_data._open_data_from_source()
     is_gridded = isinstance(data, (xr.Dataset, xr.DataArray))
-    if not is_gridded:
+    preprocess_before_map = (
+        not is_gridded
+        and input_data.preprocess_before_variable_mapping is True
+    )
+    if preprocess_before_map:
         data = input_data.preprocess(data)
     data = input_data.maybe_map_variable_names(data)
+    if not is_gridded and not preprocess_before_map:
+        data = input_data.preprocess(data)
 
     # Get the appropriate source module for the data type
     source_module = sources.get_backend_module(type(data))

--- a/src/extremeweatherbench/inputs.py
+++ b/src/extremeweatherbench/inputs.py
@@ -191,6 +191,9 @@ class InputBase(abc.ABC):
         variable_mapping: A dictionary of variable names to map to the data.
         storage_options: Storage/access options for the data.
         preprocess: A function to preprocess the data.
+        preprocess_before_variable_mapping: If True, run preprocess on the
+            source variable names before mapping to EWB names. Reserved for
+            inputs such as IBTrACS that must merge and coerce source columns.
 
     Public methods:
         open_and_maybe_preprocess_data_from_source: Open and preprocess data
@@ -211,6 +214,7 @@ class InputBase(abc.ABC):
     variable_mapping: dict = dataclasses.field(default_factory=dict)
     storage_options: dict | None = None
     preprocess: Callable = _default_preprocess
+    preprocess_before_variable_mapping: bool = False
 
     def open_and_maybe_preprocess_data_from_source(
         self,
@@ -859,8 +863,9 @@ class PPH(TargetBase):
 def _ibtracs_preprocess(data: IncomingDataInput) -> IncomingDataInput:
     """Preprocess IBTrACS data.
 
-    Preprocessing is done before any variable mapping is applied, thus using the
-    original variable names is required."""
+    IBTrACS sets preprocess_before_variable_mapping so this runs on source
+    column names (USA_WIND, WMO_PRES, and similar) before EWB mapping.
+    """
 
     schema = data.collect_schema()
     # Convert pressure and surface wind columns to float, replacing " " with null
@@ -955,6 +960,7 @@ class IBTrACS(TargetBase):
 
     name: str = "IBTrACS"
     preprocess: Callable = _ibtracs_preprocess
+    preprocess_before_variable_mapping: bool = True
     variable_mapping: dict = dataclasses.field(
         default_factory=lambda: IBTrACS_metadata_variable_mapping.copy()
     )

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -2295,9 +2295,7 @@ class TestPipelineFunctions:
         assert "t2" not in seen_columns[0]
         assert "surface_air_temperature" in seen_columns[0]
 
-    def test_run_pipeline_tabular_source_names_keyerror(
-        self, sample_individual_case
-    ):
+    def test_run_pipeline_tabular_source_names_keyerror(self, sample_individual_case):
         """Source-name lookup in a tabular preprocess must KeyError."""
         raw = pd.DataFrame(
             {

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -2242,6 +2242,140 @@ class TestPipelineFunctions:
             "preprocess"
         )
 
+    def test_run_pipeline_tabular_preprocess_after_mapping(
+        self, sample_individual_case
+    ):
+        """Tabular preprocess sees EWB names, not source names."""
+        raw = pd.DataFrame(
+            {
+                "t2": [280.0],
+                "valid_time": [pd.Timestamp("2021-06-20")],
+                "latitude": [45.0],
+                "longitude": [-120.0],
+            }
+        )
+        mapped = raw.rename(columns={"t2": "surface_air_temperature"})
+        seen_columns = []
+
+        def preprocess(data):
+            seen_columns.append(list(data.columns))
+            return data
+
+        target = mock.Mock(spec=inputs.TargetBase)
+        target.name = "GHCN"
+        target.variables = ["surface_air_temperature"]
+        target.preprocess_before_variable_mapping = False
+        target._open_data_from_source.return_value = raw
+        target.maybe_map_variable_names.return_value = mapped
+        target.preprocess.side_effect = preprocess
+        target.subset_data_to_case.return_value = mapped
+        target.maybe_convert_to_dataset.return_value = xr.Dataset()
+        target.add_source_to_dataset_attrs.return_value = xr.Dataset()
+
+        with (
+            mock.patch(
+                "extremeweatherbench.evaluate.inputs.check_for_missing_data",
+                return_value=True,
+            ),
+            mock.patch(
+                "extremeweatherbench.evaluate.inputs.maybe_subset_variables",
+                side_effect=lambda data, **kwargs: data,
+            ),
+            mock.patch(
+                "extremeweatherbench.derived.maybe_derive_variables",
+                return_value=xr.Dataset(),
+            ),
+        ):
+            evaluate.run_pipeline(sample_individual_case, target)
+
+        method_names = [name for name, *_ in target.method_calls]
+        assert method_names.index("maybe_map_variable_names") < method_names.index(
+            "preprocess"
+        )
+        assert "t2" not in seen_columns[0]
+        assert "surface_air_temperature" in seen_columns[0]
+
+    def test_run_pipeline_tabular_source_names_keyerror(
+        self, sample_individual_case
+    ):
+        """Source-name lookup in a tabular preprocess must KeyError."""
+        raw = pd.DataFrame(
+            {
+                "t2": [280.0],
+                "valid_time": [pd.Timestamp("2021-06-20")],
+                "latitude": [45.0],
+                "longitude": [-120.0],
+            }
+        )
+
+        def preprocess(data):
+            _ = data["t2"]
+            return data
+
+        target = mock.Mock(spec=inputs.TargetBase)
+        target.name = "GHCN"
+        target.variables = ["surface_air_temperature"]
+        target.preprocess_before_variable_mapping = False
+        target._open_data_from_source.return_value = raw
+        target.maybe_map_variable_names.return_value = raw.rename(
+            columns={"t2": "surface_air_temperature"}
+        )
+        target.preprocess.side_effect = preprocess
+
+        with pytest.raises(KeyError, match="t2"):
+            evaluate.run_pipeline(sample_individual_case, target)
+
+    def test_run_pipeline_ibtracs_preprocess_before_mapping(
+        self, sample_individual_case
+    ):
+        """IBTrACS preprocess still runs on source column names."""
+        raw = pd.DataFrame(
+            {
+                "USA_WIND": [50.0],
+                "valid_time": [pd.Timestamp("2021-06-20")],
+            }
+        )
+        seen_columns = []
+
+        def preprocess(data):
+            seen_columns.append(list(data.columns))
+            return data
+
+        target = mock.Mock(spec=inputs.IBTrACS)
+        target.name = "IBTrACS"
+        target.variables = ["surface_wind_speed"]
+        target.preprocess_before_variable_mapping = True
+        target._open_data_from_source.return_value = raw
+        target.maybe_map_variable_names.return_value = raw.rename(
+            columns={"USA_WIND": "usa_surface_wind_speed"}
+        )
+        target.preprocess.side_effect = preprocess
+        target.subset_data_to_case.return_value = raw
+        target.maybe_convert_to_dataset.return_value = xr.Dataset()
+        target.add_source_to_dataset_attrs.return_value = xr.Dataset()
+
+        with (
+            mock.patch(
+                "extremeweatherbench.evaluate.inputs.check_for_missing_data",
+                return_value=True,
+            ),
+            mock.patch(
+                "extremeweatherbench.evaluate.inputs.maybe_subset_variables",
+                side_effect=lambda data, **kwargs: data,
+            ),
+            mock.patch(
+                "extremeweatherbench.derived.maybe_derive_variables",
+                return_value=xr.Dataset(),
+            ),
+        ):
+            evaluate.run_pipeline(sample_individual_case, target)
+
+        method_names = [name for name, *_ in target.method_calls]
+        assert method_names.index("preprocess") < method_names.index(
+            "maybe_map_variable_names"
+        )
+        assert "USA_WIND" in seen_columns[0]
+
     def test_run_pipeline_invalid_source(self, sample_case_operator):
         """Test run_pipeline function with invalid input source."""
         with pytest.raises(AttributeError, match="'str' object has no attribute"):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -2338,6 +2338,15 @@ class TestConstants:
         assert mapping["LAT"] == "latitude"
         assert mapping["LON"] == "longitude"
 
+    def test_ibtracs_preprocess_before_variable_mapping(self):
+        """IBTrACS is the exception that preprocesses source columns."""
+        ibtracs = inputs.IBTrACS(source="test.csv")
+        ghcn = inputs.GHCN(source="test.parquet")
+        lsr = inputs.LSR(source="test.parquet")
+        assert ibtracs.preprocess_before_variable_mapping is True
+        assert ghcn.preprocess_before_variable_mapping is False
+        assert lsr.preprocess_before_variable_mapping is False
+
 
 @pytest.mark.integration
 class TestInputsIntegration:


### PR DESCRIPTION
## Summary

- IBTrACS: unchanged — still preprocesses on raw USA_WIND/WMO_* source columns before mapping, so wind/pressure coalescing keeps working. (test_run_pipeline_ibtracs_preprocess_before_mapping)
- GHCN/LSR and all other tabular targets: preprocess now runs after mapping. A preprocess function that still reaches for a source column name (e.g. data["t2"]) now correctly KeyErrors instead of silently operating on stale/wrong column names. (test_run_pipeline_tabular_source_names_keyerror)
- Gridded sources are untouched by this change — their order (map → subset case → preprocess) was already correct and isn't affected by the new flag.

## Test plan
- [x] `pytest tests/test_evaluate.py::TestPipelineFunctions tests/test_inputs.py::TestConstants`
- [x] Confirm IBTrACS evaluation still coalesces USA/WMO wind and pressure columns
- [x] Confirm a GHCN/LSR-style preprocess that uses source column names fails as expected


Made with [Cursor](https://cursor.com) and me, tested in Claude Code as well